### PR TITLE
Refactored stream creation

### DIFF
--- a/include/quic/client.hpp
+++ b/include/quic/client.hpp
@@ -32,7 +32,7 @@ namespace oxen::quic
 
         ~Client();
 
-        const std::shared_ptr<Stream>& open_stream(
+        std::shared_ptr<Stream> open_stream(
                 stream_data_callback_t data_cb = nullptr, stream_close_callback_t close_cb = nullptr);
 
         std::shared_ptr<uvw::UDPHandle> get_handle(Address& addr) override;

--- a/include/quic/crypto.hpp
+++ b/include/quic/crypto.hpp
@@ -163,6 +163,7 @@ namespace oxen::quic
 
         void client_callback_init();
         void server_callback_init();
+
       private:
         int _client_session_init();
         int _server_session_init();

--- a/include/quic/stream.hpp
+++ b/include/quic/stream.hpp
@@ -97,21 +97,24 @@ namespace oxen::quic
 
         void send(bstring_view data, std::any keep_alive);
 
-        inline void send(bstring_view data) { return send(data, std::move(data)); }
+        inline void send(bstring_view data) { send(data, std::move(data)); }
 
         template <
                 typename CharType,
                 std::enable_if_t<sizeof(CharType) == 1 && !std::is_same_v<CharType, std::byte>, int> = 0>
         void send(std::basic_string_view<CharType> data, std::any keep_alive)
         {
-            return send(convert_sv<std::byte>(data), std::move(keep_alive));
+            send(convert_sv<std::byte>(data), std::move(keep_alive));
         }
 
         template <typename Char, std::enable_if_t<sizeof(Char) == 1, int> = 0>
         void send(std::vector<Char>&& buf)
         {
-            return send(std::basic_string_view<Char>{buf.data(), buf.size()}, std::move(buf));
+            send(std::basic_string_view<Char>{buf.data(), buf.size()}, std::move(buf));
         }
+
+        inline void set_ready() { ready = true; };
+        inline void set_not_ready() { ready = false; };
 
       private:
         // Callback(s) to invoke once we have the requested amount of space available in the buffer.
@@ -127,6 +130,7 @@ namespace oxen::quic
         bool is_closing{false};
         bool is_shutdown{false};
         bool sent_fin{false};
+        bool ready{false};
 
         // Async trigger for batch scheduling callbacks
         std::shared_ptr<uvw::AsyncHandle> avail_trigger;

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -260,7 +260,7 @@ namespace oxen::quic
         return 0;
     }
 
-    // Note: set_hook_function is purposely not wrapped in a conditional checking 'if (client_tls_cb)' inside 
+    // Note: set_hook_function is purposely not wrapped in a conditional checking 'if (client_tls_cb)' inside
     // _{client, server}_session_init(). If the server/client tls callbacks are passed to client_connect or
     // server_listen prior to the tls information, it will set a nullptr for the callback function. This is no
     // good. By separating the callback emplacement, we ensure that it is called when the tls callback is processed

--- a/src/opt.cpp
+++ b/src/opt.cpp
@@ -19,7 +19,11 @@ namespace oxen::quic
         }
 
         client_tls::client_tls(
-                std::string client_key, std::string client_cert, std::string server_cert, std::string server_ca, client_tls_callback_t client_cb)
+                std::string client_key,
+                std::string client_cert,
+                std::string server_cert,
+                std::string server_ca,
+                client_tls_callback_t client_cb)
         {
             log::trace(log_cat, "client_tls constructor");
             private_key = datum{client_key};

--- a/tests/003-multiclient.cpp
+++ b/tests/003-multiclient.cpp
@@ -26,7 +26,7 @@ namespace oxen::quic::test
         Network test_net{};
         auto msg = "hello from the other siiiii-iiiiide"_bsv;
 
-        server_data_callback_t server_data_cb = [&](const uvw::UDPDataEvent& event, uvw::UDPHandle& udp){
+        server_data_callback_t server_data_cb = [&](const uvw::UDPDataEvent& event, uvw::UDPHandle& udp) {
             log::debug(log_cat, "Calling server data callback... data received...");
             good = true;
         };
@@ -39,9 +39,9 @@ namespace oxen::quic::test
         opt::local_addr server_local{"127.0.0.1"s, static_cast<uint16_t>(5500)};
 
         opt::client_tls client_tls{
-            "/home/dan/oxen/libquicinet/tests/certs/clientkey.pem"s,
-            "/home/dan/oxen/libquicinet/tests/certs/clientcert.pem"s,
-            "/home/dan/oxen/libquicinet/tests/certs/servercert.pem"s};
+                "/home/dan/oxen/libquicinet/tests/certs/clientkey.pem"s,
+                "/home/dan/oxen/libquicinet/tests/certs/clientcert.pem"s,
+                "/home/dan/oxen/libquicinet/tests/certs/servercert.pem"s};
 
         opt::local_addr client_a_local{"127.0.0.1"s, static_cast<uint16_t>(4400)};
         opt::local_addr client_b_local{"127.0.0.1"s, static_cast<uint16_t>(4422)};
@@ -93,7 +93,7 @@ namespace oxen::quic::test
 
         std::this_thread::sleep_for(std::chrono::milliseconds(2000));
 
-        std::thread check_thread ([&]() {
+        std::thread check_thread([&]() {
             REQUIRE(good == true);
             test_net.close();
         });

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,11 @@ add_executable(
 target_link_libraries(003 PUBLIC quic Catch2::Catch2WithMain)
 
 add_executable(
+    004
+    004-stream-pending.cpp)
+target_link_libraries(004 PUBLIC quic Catch2::Catch2WithMain)
+
+add_executable(
     test_client
     test_client.cpp)
 target_link_libraries(test_client PUBLIC quic)


### PR DESCRIPTION
- Stream is not created when the first call to extend_max_streams_bidi is made at client-side handshake completion
- Streams can be created and data can be pushed down whether the connection is ready or not
- When ready, streams are moved from pending_streams to ready map, and broadcast as usual
- Unit test 004 testing the above