### PR TITLE
Thread safety

### DIFF
--- a/include/quic/handler.hpp
+++ b/include/quic/handler.hpp
@@ -109,7 +109,7 @@ namespace oxen::quic
         using Job = std::pair<std::function<void()>, source_location>;
 
         std::thread::id loop_thread_id;
-        std::shared_ptr<uvw::AsyncHandle> job_waker;
+        std::shared_ptr<uvw::async_handle> job_waker;
         std::queue<Job> job_queue;
         std::mutex job_queue_mutex;
     };

--- a/include/quic/handler.hpp
+++ b/include/quic/handler.hpp
@@ -11,12 +11,12 @@ extern "C"
 #include <cstdint>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <queue>
+#include <thread>
 #include <unordered_set>
 #include <uvw.hpp>
 #include <vector>
-#include <mutex>
-#include <thread>
 
 #include "crypto.hpp"
 #include "utils.hpp"

--- a/include/quic/handler.hpp
+++ b/include/quic/handler.hpp
@@ -26,18 +26,18 @@ using oxen::log::slns::source_location;
 namespace oxen::quic
 {
     template <typename... T>
-    void loop_trace_log(const log::logger_ptr& cat_logger,
-          [[maybe_unused]] const source_location& location,
-          [[maybe_unused]] fmt::format_string<T...> fmt,
-          [[maybe_unused]] T&&... args)
+    void loop_trace_log(
+            const log::logger_ptr& cat_logger,
+            [[maybe_unused]] const source_location& location,
+            [[maybe_unused]] fmt::format_string<T...> fmt,
+            [[maybe_unused]] T&&... args)
     {
 #if defined(NDEBUG) && !defined(OXEN_LOGGING_RELEASE_TRACE)
         // Using [[maybe_unused]] on the *first* ctor argument breaks gcc 8/9
         (void)cat_logger;
 #else
         if (cat_logger)
-            cat_logger->log(
-                    log::detail::spdlog_sloc(location), log::Level::trace, fmt, std::forward<T>(args)...);
+            cat_logger->log(log::detail::spdlog_sloc(location), log::Level::trace, fmt, std::forward<T>(args)...);
 #endif
     }
 

--- a/include/quic/handler.hpp
+++ b/include/quic/handler.hpp
@@ -21,8 +21,26 @@ extern "C"
 #include "crypto.hpp"
 #include "utils.hpp"
 
+using oxen::log::slns::source_location;
+
 namespace oxen::quic
 {
+    template <typename... T>
+    void loop_trace_log(const log::logger_ptr& cat_logger,
+          [[maybe_unused]] const source_location& location,
+          [[maybe_unused]] fmt::format_string<T...> fmt,
+          [[maybe_unused]] T&&... args)
+    {
+#if defined(NDEBUG) && !defined(OXEN_LOGGING_RELEASE_TRACE)
+        // Using [[maybe_unused]] on the *first* ctor argument breaks gcc 8/9
+        (void)cat_logger;
+#else
+        if (cat_logger)
+            cat_logger->log(
+                    log::detail::spdlog_sloc(location), log::Level::trace, fmt, std::forward<T>(args)...);
+#endif
+    }
+
     // class Client;
     class Stream;
     class Client;
@@ -52,15 +70,20 @@ namespace oxen::quic
 
         void client_call_async(async_callback_t async_cb);
 
-        void call_soon(std::function<void(void)> f);
+        void call_soon(std::function<void(void)> f, source_location src = source_location::current());
 
         template <typename Callable>
-        void call(Callable&& f)
+        void call(Callable&& f, source_location src = source_location::current())
         {
             if (in_event_loop())
+            {
+                loop_trace_log(log_cat, src, "Event loop calling `{}`", src.function_name());
                 f();
+            }
             else
-                call_soon(std::forward<Callable>(f));
+            {
+                call_soon(std::forward<Callable>(f), std::move(src));
+            }
         }
 
         void process_job_queue();
@@ -83,9 +106,11 @@ namespace oxen::quic
         ///	keep ev loop open for cleanup
         std::shared_ptr<int> keep_alive = std::make_shared<int>(0);
 
+        using Job = std::pair<std::function<void()>, source_location>;
+
         std::thread::id loop_thread_id;
         std::shared_ptr<uvw::AsyncHandle> job_waker;
-        std::queue<std::function<void()>> job_queue;
+        std::queue<Job> job_queue;
         std::mutex job_queue_mutex;
     };
 }  // namespace oxen::quic

--- a/include/quic/network.hpp
+++ b/include/quic/network.hpp
@@ -5,11 +5,11 @@ extern "C"
 #include <gnutls/gnutls.h>
 }
 
-#include <cstdint>
-#include <memory>
 #include <atomic>
-#include <thread>
+#include <cstdint>
 #include <future>
+#include <memory>
+#include <thread>
 #include <uvw.hpp>
 
 #include "client.hpp"
@@ -62,8 +62,9 @@ namespace oxen::quic
         {
             std::promise<std::shared_ptr<Client>> p;
             auto f = p.get_future();
-            quic_manager->call([&opts...,&p,this]() mutable {
-                try {
+            quic_manager->call([&opts..., &p, this]() mutable {
+                try
+                {
                     // initialize client context and client tls context simultaneously
                     std::shared_ptr<ClientContext> client_ctx =
                             std::make_shared<ClientContext>(quic_manager, std::forward<Opt>(opts)...);
@@ -84,8 +85,8 @@ namespace oxen::quic
 
                     // create client and then copy assign it to the client context so we can return
                     // the shared ptr from this function
-                    auto client_ptr =
-                            std::make_shared<Client>(quic_manager, client_ctx, (*client_ctx).conn_id, client_ctx->udp_handle);
+                    auto client_ptr = std::make_shared<Client>(
+                            quic_manager, client_ctx, (*client_ctx).conn_id, client_ctx->udp_handle);
                     client_ctx->client = client_ptr;
 
                     quic_manager->clients.emplace_back(std::move(client_ctx));
@@ -93,7 +94,8 @@ namespace oxen::quic
 
                     p.set_value(client_ptr);
                 }
-                catch (...) {
+                catch (...)
+                {
                     p.set_exception(std::current_exception());
                 }
             });
@@ -131,8 +133,9 @@ namespace oxen::quic
         {
             std::promise<std::shared_ptr<Server>> p;
             auto f = p.get_future();
-            quic_manager->call([&opts...,&p,this]() mutable {
-                try {
+            quic_manager->call([&opts..., &p, this]() mutable {
+                try
+                {
                     // initialize server context and server tls context simultaneously
                     std::shared_ptr<ServerContext> server_ctx =
                             std::make_shared<ServerContext>(quic_manager, std::forward<Opt>(opts)...);
@@ -159,7 +162,8 @@ namespace oxen::quic
                     log::trace(log_cat, "Server context emplaced");
                     p.set_value(server_ptr);
                 }
-                catch (...) {
+                catch (...)
+                {
                     p.set_exception(std::current_exception());
                 }
             });

--- a/include/quic/network.hpp
+++ b/include/quic/network.hpp
@@ -7,6 +7,7 @@ extern "C"
 
 #include <cstdint>
 #include <memory>
+#include <atomic>
 #include <thread>
 #include <future>
 #include <uvw.hpp>
@@ -169,6 +170,8 @@ namespace oxen::quic
         void close();
 
       private:
+        std::atomic<bool> running{false};
+
         std::shared_ptr<Handler> quic_manager;
         std::unordered_map<Address, std::shared_ptr<uvw::udp_handle>> mapped_client_addrs;
         std::unordered_map<Address, std::shared_ptr<uvw::udp_handle>> mapped_server_addrs;

--- a/include/quic/network.hpp
+++ b/include/quic/network.hpp
@@ -7,6 +7,7 @@ extern "C"
 
 #include <cstdint>
 #include <memory>
+#include <thread>
 #include <uvw.hpp>
 
 #include "client.hpp"
@@ -23,14 +24,14 @@ namespace oxen::quic
         friend class Handler;
 
       public:
-        Network(std::shared_ptr<uvw::loop> loop_ptr = nullptr);
+        Network(std::shared_ptr<uvw::loop> loop_ptr, std::thread::id loop_thread_id);
+        Network();
         ~Network();
 
         std::shared_ptr<uvw::loop> ev_loop;
+        std::unique_ptr<std::thread> loop_thread;
 
         Handler* get_quic();
-
-        void run();
 
         // Main client endpoint creation function. If a local address is passed, then a dedicated
         // UDPHandle is bound to that address. If not, the universal UDPHandle is used for I/O. To

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -9,6 +9,7 @@ extern "C"
 #include <cstdio>
 #include <cstring>
 #include <stdexcept>
+#include <future>
 
 #include "connection.hpp"
 #include "context.hpp"
@@ -59,11 +60,25 @@ namespace oxen::quic
     std::shared_ptr<Stream> Client::open_stream(stream_data_callback_t data_cb, stream_close_callback_t close_cb)
     {
         log::trace(log_cat, "Opening client stream...");
-        auto ctx = reinterpret_cast<ClientContext*>(context.get());
 
-        auto conn = get_conn(ctx->conn_id);
+        std::promise<std::shared_ptr<Stream>> p;
+        auto f = p.get_future();
+        handler->call([&data_cb, &close_cb, &p, this](){
+            try
+            {
+                auto ctx = reinterpret_cast<ClientContext*>(context.get());
 
-        return conn->get_new_stream(std::move(data_cb), std::move(close_cb));
+                auto conn = get_conn(ctx->conn_id);
+
+                p.set_value(conn->get_new_stream(std::move(data_cb), std::move(close_cb)));
+            }
+            catch (...)
+            {
+                p.set_exception(std::current_exception());
+            }
+        });
+
+        return f.get();
     }
 
     std::shared_ptr<uvw::udp_handle> Client::get_handle(Address& addr)

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -66,9 +66,7 @@ namespace oxen::quic
         handler->call([&data_cb, &close_cb, &p, this]() {
             try
             {
-                auto ctx = reinterpret_cast<ClientContext*>(context.get());
-
-                auto conn = get_conn(ctx->conn_id);
+                auto conn = get_conn(context->conn_id);
 
                 p.set_value(conn->get_new_stream(std::move(data_cb), std::move(close_cb)));
             }

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -8,8 +8,8 @@ extern "C"
 
 #include <cstdio>
 #include <cstring>
-#include <stdexcept>
 #include <future>
+#include <stdexcept>
 
 #include "connection.hpp"
 #include "context.hpp"
@@ -63,7 +63,7 @@ namespace oxen::quic
 
         std::promise<std::shared_ptr<Stream>> p;
         auto f = p.get_future();
-        handler->call([&data_cb, &close_cb, &p, this](){
+        handler->call([&data_cb, &close_cb, &p, this]() {
             try
             {
                 auto ctx = reinterpret_cast<ClientContext*>(context.get());

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -602,6 +602,7 @@ namespace oxen::quic
 
     int Connection::stream_receive(int64_t id, bstring_view data, bool fin)
     {
+        log::trace(log_cat, "Stream (ID: {}) received data: {}", id, buffer_printer{data});
         auto str = get_stream(id);
 
         if (!str->data_callback)

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -120,8 +120,7 @@ namespace oxen::quic
         }
 
         ngtcp2_ccerr err;
-        ngtcp2_ccerr_set_liberr(
-                &err, code, reinterpret_cast<uint8_t*>(const_cast<char*>(msg.data())), msg.size());
+        ngtcp2_ccerr_set_liberr(&err, code, reinterpret_cast<uint8_t*>(const_cast<char*>(msg.data())), msg.size());
 
         conn.conn_buffer.resize(max_pkt_size_v4);
         Path path;

--- a/src/handler.cpp
+++ b/src/handler.cpp
@@ -38,10 +38,10 @@ namespace oxen::quic
         universal_handle->bind(default_local);
         net.mapped_client_addrs.emplace(Address{default_local}, universal_handle);
 
-        if (job_waker = ev_loop->resource<uvw::AsyncHandle>(); !job_waker)
+        if (job_waker = ev_loop->resource<uvw::async_handle>(); !job_waker)
             throw std::runtime_error{"Failed to create job queue uvw async handle"};
 
-        job_waker->on<uvw::AsyncEvent>([this](const auto&, auto&) { process_job_queue(); });
+        job_waker->on<uvw::async_event>([this](const auto&, const auto&) { process_job_queue(); });
 
         log::info(log_cat, "{}", (ev_loop) ? "Event loop successfully created" : "Error: event loop creation failed");
     }
@@ -85,11 +85,13 @@ namespace oxen::quic
         loop_trace_log(log_cat, src, "Event loop queueing `{}`", src.function_name());
         std::lock_guard<std::mutex> lock{job_queue_mutex};
         job_queue.emplace(std::move(f), std::move(src));
+        log::trace(log_cat, "Event loop now has {} jobs queued", job_queue.size());
         job_waker->send();
     }
 
     void Handler::process_job_queue()
     {
+        log::trace(log_cat, "Event loop processing job queue");
         assert(in_event_loop());
 
         decltype(job_queue) swapped_queue;

--- a/src/handler.cpp
+++ b/src/handler.cpp
@@ -29,7 +29,8 @@ extern "C"
 
 namespace oxen::quic
 {
-    Handler::Handler(std::shared_ptr<uvw::loop> loop_ptr, std::thread::id loop_thread_id, Network& net) : net{net}, loop_thread_id{loop_thread_id}
+    Handler::Handler(std::shared_ptr<uvw::loop> loop_ptr, std::thread::id loop_thread_id, Network& net) :
+            net{net}, loop_thread_id{loop_thread_id}
     {
         ev_loop = loop_ptr;
         universal_handle = ev_loop->resource<uvw::udp_handle>();
@@ -121,7 +122,7 @@ namespace oxen::quic
 
     void Handler::close_all()
     {
-        call([this](){
+        call([this]() {
             if (!clients.empty())
             {
                 for (const auto& ctx : clients)

--- a/src/handler.cpp
+++ b/src/handler.cpp
@@ -80,6 +80,7 @@ namespace oxen::quic
 
     void Handler::call_soon(std::function<void(void)> f)
     {
+        log::trace(log_cat, "{}", __PRETTY_FUNCTION__);
         std::lock_guard<std::mutex> lock{job_queue_mutex};
         job_queue.push(std::move(f));
         job_waker->send();

--- a/src/handler.cpp
+++ b/src/handler.cpp
@@ -79,6 +79,7 @@ namespace oxen::quic
         return std::this_thread::get_id() == loop_thread_id;
     }
 
+    // TODO: when closing, when to stop accepting new jobs and stop/close async handle?
     void Handler::call_soon(std::function<void(void)> f, source_location src)
     {
         loop_trace_log(log_cat, src, "Event loop queueing `{}`", src.function_name());
@@ -122,6 +123,7 @@ namespace oxen::quic
         {}
     }
 
+    // TODO: for graceful shutdown, how best to wait until clients and servers have properly disconnected
     void Handler::close_all()
     {
         call([this]() {

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -90,6 +90,7 @@ namespace oxen::quic
                     log::debug(log_cat, "closing server UDPHandle bound to {}:{}", s.ip, s.port);
                     handle->close();
                 }
+
                 if (loop_thread)
                 {
                     // this does not reset the ev_loop shared_ptr, but rather "reset"s the underlying

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -27,9 +27,9 @@ namespace oxen::quic
         log::trace(log_cat, __PRETTY_FUNCTION__);
         ev_loop = uvw::Loop::create();
 
-        signal_config(); // TODO: probably remove this, as the library user should handle signals
+        signal_config();  // TODO: probably remove this, as the library user should handle signals
 
-        loop_thread = std::make_unique<std::thread>([this](){ ev_loop->run(); });
+        loop_thread = std::make_unique<std::thread>([this]() { ev_loop->run(); });
         running.store(true);
         quic_manager = std::make_shared<Handler>(ev_loop, loop_thread->get_id(), *this);
     }
@@ -73,8 +73,9 @@ namespace oxen::quic
 
         std::promise<void> p;
         auto f = p.get_future();
-        quic_manager->call([this, &p](){
-            try {
+        quic_manager->call([this, &p]() {
+            try
+            {
                 quic_manager->close_all();
 
                 for (auto& [addr, handle] : mapped_client_addrs)
@@ -95,11 +96,11 @@ namespace oxen::quic
                     // uvw::loop parent class uvw::emitter (unregisters all event listeners)
                     ev_loop->clear();
                     ev_loop->stop();
-
                 }
                 p.set_value();
             }
-            catch (...) {
+            catch (...)
+            {
                 p.set_exception(std::current_exception());
             }
         });

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -29,7 +29,12 @@ namespace oxen::quic
 
         signal_config();  // TODO: probably remove this, as the library user should handle signals
 
-        loop_thread = std::make_unique<std::thread>([this]() { while (not running) {}; ev_loop->run(); log::debug(log_cat, "Event Loop `run` returned, thread finished"); });
+        loop_thread = std::make_unique<std::thread>([this]() {
+            while (not running)
+            {};
+            ev_loop->run();
+            log::debug(log_cat, "Event Loop `run` returned, thread finished");
+        });
         quic_manager = std::make_shared<Handler>(ev_loop, loop_thread->get_id(), *this);
 
         running.store(true);
@@ -110,7 +115,7 @@ namespace oxen::quic
 
         if (loop_thread)
         {
-            quic_manager->call([this](){
+            quic_manager->call([this]() {
                 ev_loop->walk([](auto&& h) { h.close(); });
                 ev_loop->stop();
             });

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -78,15 +78,15 @@ namespace oxen::quic
             {
                 quic_manager->close_all();
 
-                for (auto& [addr, handle] : mapped_client_addrs)
+                for (const auto& [addr, handle] : mapped_client_addrs)
                 {
-                    auto s = handle->sock();
+                    const auto& s = handle->sock();
                     log::debug(log_cat, "closing client UDPHandle bound to {}:{}", s.ip, s.port);
                     handle->close();
                 }
-                for (auto& [addr, handle] : mapped_server_addrs)
+                for (const auto& [addr, handle] : mapped_server_addrs)
                 {
-                    auto s = handle->sock();
+                    const auto& s = handle->sock();
                     log::debug(log_cat, "closing server UDPHandle bound to {}:{}", s.ip, s.port);
                     handle->close();
                 }

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -187,9 +187,4 @@ namespace oxen::quic
 
         return q->second;
     }
-
-    Handler* Network::get_quic()
-    {
-        return (quic_manager) ? quic_manager.get() : nullptr;
-    }
 }  // namespace oxen::quic

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -14,27 +14,28 @@
 
 namespace oxen::quic
 {
-    Network::Network(std::shared_ptr<uvw::loop> loop_ptr)
+    Network::Network(std::shared_ptr<uvw::loop> loop_ptr, std::thread::id loop_thread_id) : ev_loop{loop_ptr}
     {
+        assert(ev_loop);
         log::trace(log_cat, "Beginning context creation");
-        ev_loop = (loop_ptr) ? loop_ptr : uvw::loop::create();
-        signal_config();
 
-        quic_manager = std::make_shared<Handler>(ev_loop, *this);
+        quic_manager = std::make_shared<Handler>(ev_loop, loop_thread_id, *this);
+    }
+
+    Network::Network()
+    {
+        log::trace(log_cat, __PRETTY_FUNCTION__);
+        ev_loop = uvw::Loop::create();
+
+        signal_config(); // TODO: probably remove this, as the library user should handle signals
+
+        loop_thread = std::make_unique<std::thread>([this](){ ev_loop->run(); });
+        quic_manager = std::make_shared<Handler>(ev_loop, loop_thread->get_id(), *this);
     }
 
     Network::~Network()
     {
-        log::info(log_cat, "Shutting down context...");
-
-        if (ev_loop)
-        {
-            ev_loop->walk(uvw::overloaded{[](uvw::udp_handle&& h) { h.close(); }, [](auto&&) {}});
-            ev_loop->reset();
-            ev_loop->stop();
-            ev_loop->close();
-            log::debug(log_cat, "Event loop shut down...");
-        }
+        close();
     }
 
     void Network::signal_config()
@@ -64,13 +65,23 @@ namespace oxen::quic
 
     void Network::close()
     {
+        log::info(log_cat, "Shutting down context...");
         quic_manager->close_all();
-        std::this_thread::sleep_for(std::chrono::milliseconds(2500));
-    }
 
-    void Network::run()
-    {
-        ev_loop->run();
+        if (loop_thread)
+        {
+            quic_manager->call([this](){
+                ev_loop->walk(uvw::Overloaded{[](uvw::UDPHandle&& h) { h.close(); }, [](auto&&) {}});
+                // this does not reset the ev_loop shared_ptr, but rather "reset"s the underlying
+                // uvw::loop parent class uvw::emitter (unregisters all event listeners)
+                ev_loop->reset();
+                ev_loop->stop();
+            });
+            loop_thread->join();
+            loop_thread.reset();
+            ev_loop->close();
+            log::debug(log_cat, "Event loop shut down...");
+        }
     }
 
     void Network::configure_client_handle(std::shared_ptr<uvw::udp_handle> handle)

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -69,7 +69,7 @@ namespace oxen::quic
 
     void Stream::close(uint64_t error_code)
     {
-        conn.quic_manager->call([this, error_code](){
+        conn.quic_manager->call([this, error_code]() {
             log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
 
             if (is_shutdown)
@@ -124,7 +124,7 @@ namespace oxen::quic
 
     void Stream::when_available(unblocked_callback_t unblocked_cb)
     {
-        conn.quic_manager->call([this, unblocked_cb](){
+        conn.quic_manager->call([this, unblocked_cb]() {
             log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
             unblocked_callbacks.push(std::move(unblocked_cb));
         });
@@ -206,7 +206,7 @@ namespace oxen::quic
 
     void Stream::send(bstring_view data, std::shared_ptr<void> keep_alive)
     {
-        conn.quic_manager->call([this, data, keep_alive](){
+        conn.quic_manager->call([this, data, keep_alive]() {
             log::trace(log_cat, "Stream (ID: {}) sending message: {}", stream_id, buffer_printer{data});
             append_buffer(data, keep_alive);
         });
@@ -214,8 +214,6 @@ namespace oxen::quic
 
     void Stream::set_user_data(std::shared_ptr<void> data)
     {
-        conn.quic_manager->call([this, data](){
-            user_data = std::move(data);
-        });
+        conn.quic_manager->call([this, data]() { user_data = std::move(data); });
     }
 }  // namespace oxen::quic

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -69,22 +69,24 @@ namespace oxen::quic
 
     void Stream::close(uint64_t error_code)
     {
-        log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
+        conn.quic_manager->call([this, error_code](){
+            log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
 
-        if (is_shutdown)
-            log::info(log_cat, "Stream is already shutting down");
-        else if (is_closing)
-            log::debug(log_cat, "Stream is already closing");
-        else
-        {
-            is_closing = is_shutdown = true;
-            log::info(log_cat, "Closing stream (ID: {}) with error code {}", stream_id, ngtcp2_strerror(error_code));
-            ngtcp2_conn_shutdown_stream(conn, 0, stream_id, error_code);
-        }
-        if (is_shutdown)
-            data_callback = {};
+            if (is_shutdown)
+                log::info(log_cat, "Stream is already shutting down");
+            else if (is_closing)
+                log::debug(log_cat, "Stream is already closing");
+            else
+            {
+                is_closing = is_shutdown = true;
+                log::info(log_cat, "Closing stream (ID: {}) with error code {}", stream_id, ngtcp2_strerror(error_code));
+                ngtcp2_conn_shutdown_stream(conn, 0, stream_id, error_code);
+            }
+            if (is_shutdown)
+                data_callback = {};
 
-        conn.io_ready();
+            conn.io_ready();
+        });
     }
 
     void Stream::append_buffer(bstring_view buffer, std::shared_ptr<void> keep_alive)
@@ -122,8 +124,10 @@ namespace oxen::quic
 
     void Stream::when_available(unblocked_callback_t unblocked_cb)
     {
-        log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
-        unblocked_callbacks.push(std::move(unblocked_cb));
+        conn.quic_manager->call([this, unblocked_cb](){
+            log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
+            unblocked_callbacks.push(std::move(unblocked_cb));
+        });
     }
 
     void Stream::handle_unblocked()
@@ -202,12 +206,16 @@ namespace oxen::quic
 
     void Stream::send(bstring_view data, std::shared_ptr<void> keep_alive)
     {
-        log::trace(log_cat, "Stream (ID: {}) sending message: {}", stream_id, buffer_printer{data});
-        append_buffer(data, keep_alive);
+        conn.quic_manager->call([this, data, keep_alive](){
+            log::trace(log_cat, "Stream (ID: {}) sending message: {}", stream_id, buffer_printer{data});
+            append_buffer(data, keep_alive);
+        });
     }
 
     void Stream::set_user_data(std::shared_ptr<void> data)
     {
-        user_data = std::move(data);
+        conn.quic_manager->call([this, data](){
+            user_data = std::move(data);
+        });
     }
 }  // namespace oxen::quic

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -83,7 +83,7 @@ namespace oxen::quic
                 ngtcp2_conn_shutdown_stream(conn, 0, stream_id, error_code);
             }
             if (is_shutdown)
-                data_callback = {};
+                data_callback = nullptr;
 
             conn.io_ready();
         });
@@ -124,7 +124,7 @@ namespace oxen::quic
 
     void Stream::when_available(unblocked_callback_t unblocked_cb)
     {
-        conn.quic_manager->call([this, unblocked_cb]() {
+        conn.quic_manager->call([this, unblocked_cb = std::move(unblocked_cb)]() mutable {
             log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
             unblocked_callbacks.push(std::move(unblocked_cb));
         });

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,5 +1,7 @@
 #include "utils.hpp"
 
+#include <atomic>
+
 extern "C"
 {
 #include <netinet/in.h>
@@ -13,8 +15,13 @@ namespace oxen::quic
 {
     void logger_config(std::string out, log::Type type, log::Level reset)
     {
-        oxen::log::add_sink(type, out);
-        oxen::log::reset_level(reset);
+        static std::atomic<bool> run_once{false};
+
+        if (not run_once.exchange(true))
+        {
+            oxen::log::add_sink(type, out);
+            oxen::log::reset_level(reset);
+        }
     }
 
     uint64_t get_timestamp()

--- a/tests/001-handshake.cpp
+++ b/tests/001-handshake.cpp
@@ -46,14 +46,9 @@ namespace oxen::quic::test
         log::debug(log_cat, "Calling 'client_connect'...");
         auto client = test_net.client_connect(client_local, client_remote, client_tls, client_tls_cb);
 
-        std::thread ev_thread{[&]() { test_net.run(); }};
-
         std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 
         REQUIRE(good);
         test_net.close();
-
-        test_net.ev_loop->close();
-        ev_thread.detach();
     };
 }  // namespace oxen::quic::test

--- a/tests/002-send-receive.cpp
+++ b/tests/002-send-receive.cpp
@@ -44,9 +44,9 @@ namespace oxen::quic::test
             std::this_thread::sleep_for(std::chrono::milliseconds(1000));
         });
 
+        stream_thread.join();
+
         REQUIRE(good == true);
         test_net.close();
-
-        stream_thread.join();
     };
 }  // namespace oxen::quic::test

--- a/tests/002-send-receive.cpp
+++ b/tests/002-send-receive.cpp
@@ -36,8 +36,6 @@ namespace oxen::quic::test
         log::debug(log_cat, "Calling 'client_connect'...");
         auto client = test_net.client_connect(client_local, client_remote, client_tls);
 
-        std::thread ev_thread{[&]() { test_net.run(); }};
-
         std::this_thread::sleep_for(std::chrono::milliseconds(2000));
 
         std::thread stream_thread([&]() {
@@ -49,8 +47,6 @@ namespace oxen::quic::test
         REQUIRE(good == true);
         test_net.close();
 
-        test_net.ev_loop->close();
         stream_thread.join();
-        ev_thread.detach();
     };
 }  // namespace oxen::quic::test

--- a/tests/003-multiclient.cpp
+++ b/tests/003-multiclient.cpp
@@ -44,8 +44,6 @@ namespace oxen::quic::test
         auto client_a = test_net.client_connect(client_a_local, client_a_remote, client_tls);
         auto client_b = test_net.client_connect(client_b_local, client_b_remote, client_tls);
 
-        std::thread ev_thread{[&]() { test_net.run(); }};
-
         std::this_thread::sleep_for(std::chrono::milliseconds(2000));
 
         std::thread async_thread_a{[&]() {
@@ -83,9 +81,7 @@ namespace oxen::quic::test
 
         std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 
-        test_net.ev_loop->close();
         async_thread_a.join();
         async_thread_b.join();
-        ev_thread.detach();
     };
 }  // namespace oxen::quic::test

--- a/tests/003-multiclient.cpp
+++ b/tests/003-multiclient.cpp
@@ -76,12 +76,10 @@ namespace oxen::quic::test
 
         std::this_thread::sleep_for(std::chrono::milliseconds(2000));
 
-        REQUIRE(good);
-        test_net.close();
-
-        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-
         async_thread_a.join();
         async_thread_b.join();
+
+        REQUIRE(good);
+        test_net.close();
     };
 }  // namespace oxen::quic::test

--- a/tests/004-stream-pending.cpp
+++ b/tests/004-stream-pending.cpp
@@ -68,6 +68,5 @@ namespace oxen::quic::test
         auto conn = client->get_conn(client->context->conn_id);
         REQUIRE(conn->pending_streams.size() == 1);
         test_net.close();
-
     };
 }  // namespace oxen::quic::test

--- a/tests/004-stream-pending.cpp
+++ b/tests/004-stream-pending.cpp
@@ -45,8 +45,6 @@ namespace oxen::quic::test
         for (auto& s : streams)
             s->send(msg);
 
-        std::thread ev_thread{[&]() { test_net.run(); }};
-
         std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 
         streams[0]->close();
@@ -71,7 +69,5 @@ namespace oxen::quic::test
         REQUIRE(conn->pending_streams.size() == 1);
         test_net.close();
 
-        test_net.ev_loop->close();
-        ev_thread.detach();
     };
 }  // namespace oxen::quic::test

--- a/tests/005-chunked-sender.cpp
+++ b/tests/005-chunked-sender.cpp
@@ -34,8 +34,6 @@ namespace oxen::quic::test
         log::debug(log_cat, "Calling 'client_connect'...");
         auto client = test_net.client_connect(client_local, client_remote, client_tls);
 
-        std::thread ev_thread{[&]() { test_net.run(); }};
-
         auto stream = client->open_stream();
         stream->send("HELLO!"s);
 
@@ -98,7 +96,6 @@ namespace oxen::quic::test
                   "Goodbye.");
         }
 
-        test_net.ev_loop->stop();
-        ev_thread.join();
+        test_net.close();
     };
 }  // namespace oxen::quic::test

--- a/tests/test_client.cpp
+++ b/tests/test_client.cpp
@@ -36,8 +36,6 @@ int main(int argc, char* argv[])
     log::debug(log_cat, "Calling 'client_connect'...");
     auto client = client_net.client_connect(client_local, client_remote, client_tls);
 
-    std::thread ev_thread{[&]() { client_net.run(); }};
-
     log::debug(log_cat, "Main thread call");
     std::this_thread::sleep_for(std::chrono::milliseconds(2000));
 
@@ -62,7 +60,6 @@ int main(int argc, char* argv[])
     } while (run);
 
     async_thread.join();
-    ev_thread.join();
 
     return 0;
 }

--- a/tests/test_multiclient.cpp
+++ b/tests/test_multiclient.cpp
@@ -42,8 +42,6 @@ int main(int argc, char* argv[])
     auto client_a = client_net.client_connect(client_a_local, client_a_remote, client_tls);
     auto client_b = client_net.client_connect(client_b_local, client_b_remote, client_tls);
 
-    std::thread ev_thread{[&]() { client_net.run(); }};
-
     log::debug(log_cat, "Main thread call");
     std::this_thread::sleep_for(std::chrono::milliseconds(2000));
 
@@ -88,7 +86,6 @@ int main(int argc, char* argv[])
 
     async_thread_a.join();
     async_thread_b.join();
-    ev_thread.join();
 
     return 0;
 }

--- a/tests/test_server.cpp
+++ b/tests/test_server.cpp
@@ -38,9 +38,6 @@ int main(int argc, char* argv[])
     log::debug(log_cat, "Calling 'server_listen'...");
     auto server = server_net.server_listen(server_local, server_tls, stream_cb);
 
-    log::debug(log_cat, "Starting event loop...");
-    server_net.ev_loop->run();
-
     size_t counter = 0;
     do
     {


### PR DESCRIPTION
Adds an event loop "caller" concept to the code, such that things which must run on the event loop thread call that and run either now (if already on that thread) or are queued to run on the next event loop tick.