### PR TITLE
Add chunked send interface

### DIFF
--- a/include/quic/stream.hpp
+++ b/include/quic/stream.hpp
@@ -118,6 +118,96 @@ namespace oxen::quic
             send(std::basic_string_view<Char>{buf.data(), buf.size()}, std::make_shared<std::vector<Char>>(std::move(buf)));
         }
 
+      private:
+        // Implementations classes for send_chunks()
+
+        // chunk_sender: When sending chunks we construct *one* of these, then share its ownership
+        // across all the chunks in flight.  When each individual chunk gets destroyed, it called
+        // back into this to queue the next chunk, which this class then sends into the stream.
+        template <typename Container>
+        struct chunk_sender : std::enable_shared_from_this<chunk_sender<Container>>
+        {
+            using chunk_callback_t = std::function<Container()>;
+            using done_callback_t = std::function<void()>;
+
+            template <typename... Args>
+            static void make(int initial_queue, Args&&... args)
+            {
+                std::shared_ptr<chunk_sender<Container>> cs{new chunk_sender<Container>(std::forward<Args>(args)...)};
+                for (int i = 0; i < initial_queue; i++)
+                    cs->queue_next_chunk();
+            }
+
+          private:
+            // This is instantiated for each chunk, contains the chunk data itself, and is what we
+            // put into the keep_alive; during destruction, we queue the next chunk.
+            struct single_chunk
+            {
+                std::shared_ptr<chunk_sender> chunks;
+                Container data;
+
+                single_chunk(chunk_sender& cs, Container&& d) : chunks{cs.shared_from_this()}, data{std::move(d)} {}
+                ~single_chunk() { chunks->queue_next_chunk(); }
+            };
+
+            chunk_sender(Stream& s, chunk_callback_t next, done_callback_t done) :
+                    str{s}, next_chunk{std::move(next)}, done{std::move(done)}
+            {
+                assert(next_chunk);
+            }
+
+            Stream& str;
+            std::shared_ptr<Container> data;
+            chunk_callback_t next_chunk;
+            done_callback_t done;
+
+          public:
+            void queue_next_chunk()
+            {
+                if (!next_chunk)
+                    // We already finished (i.e. via a previous chunk destructor)
+                    return;
+
+                auto data = next_chunk();
+                if (data.empty())
+                {
+                    log::trace(log_cat, "send_chunks finished");
+                    // We're finishing
+                    next_chunk = nullptr;
+                    if (done)
+                        done();
+                    return;
+                }
+
+                auto next = std::make_shared<single_chunk>(*this, std::move(data));
+                log::trace(log_cat, "got chunk to send of size {}", next->data.size());
+                bstring_view bsv{reinterpret_cast<const std::byte*>(next->data.data()), next->data.size()};
+                str.send(bsv, std::move(next));
+            }
+        };
+
+      public:
+        /// Sends data in chunks: `next_chunk()` will be called to obtain the next chunk of data
+        /// until it returns an empty container, at which point `done()` will be called.  Chunks are
+        /// called when a previous chunk has been completely send and acknolwedged by the other end
+        /// of the stream.
+        ///
+        /// Note that done() is called once all chunks are queued, *not* once all chunks are
+        /// acknoledged; this allows you to use the `done` callback to know when it is safe to
+        /// append data to followed the chunked data.
+        ///
+        /// simultaneous controls how many initial chunks to queue up (and thus also how many chunks
+        /// will be in-flight at a given time), and must be at least 1.
+        template <typename T = std::string>
+        void send_chunks(std::function<T()> next_chunk, std::function<void()> done = nullptr, int simultaneous = 2)
+        {
+            assert(next_chunk);
+            if (simultaneous < 1)
+                throw std::logic_error{"Stream::send_chunks simultaneous must be >= 1"};
+
+            chunk_sender<T>::make(simultaneous, *this, std::move(next_chunk), std::move(done));
+        }
+
         inline void set_ready() { ready = true; };
         inline void set_not_ready() { ready = false; };
 

--- a/include/quic/stream.hpp
+++ b/include/quic/stream.hpp
@@ -104,6 +104,14 @@ namespace oxen::quic
             send(convert_sv<std::byte>(data), std::move(keep_alive));
         }
 
+        template <typename CharType>
+        void send(std::basic_string<CharType>&& data)
+        {
+            auto keep_alive = std::make_shared<std::basic_string<CharType>>(std::move(data));
+            std::basic_string_view<CharType> view{*keep_alive};
+            send(view, std::move(keep_alive));
+        }
+
         template <typename Char, std::enable_if_t<sizeof(Char) == 1, int> = 0>
         void send(std::vector<Char>&& buf)
         {

--- a/include/quic/stream.hpp
+++ b/include/quic/stream.hpp
@@ -124,11 +124,19 @@ namespace oxen::quic
         // chunk_sender: When sending chunks we construct *one* of these, then share its ownership
         // across all the chunks in flight.  When each individual chunk gets destroyed, it called
         // back into this to queue the next chunk, which this class then sends into the stream.
+        //
+        // Container -- can be a value or a pointer, but not a reference.
         template <typename Container>
         struct chunk_sender : std::enable_shared_from_this<chunk_sender<Container>>
         {
-            using chunk_callback_t = std::function<Container()>;
-            using done_callback_t = std::function<void()>;
+            static_assert(!std::is_reference_v<Container>, "chunk_sender requires a value or pointer, not a reference");
+
+            static constexpr bool is_pointer = std::is_pointer_v<Container> ||
+                                               is_instantiation<std::unique_ptr, Container> ||
+                                               is_instantiation<std::shared_ptr, Container>;
+
+            using chunk_callback_t = std::function<Container(const Stream&)>;
+            using done_callback_t = std::function<void(Stream&)>;
 
             template <typename... Args>
             static void make(int initial_queue, Args&&... args)
@@ -143,11 +151,27 @@ namespace oxen::quic
             // put into the keep_alive; during destruction, we queue the next chunk.
             struct single_chunk
             {
-                std::shared_ptr<chunk_sender> chunks;
-                Container data;
+              private:
+                std::shared_ptr<chunk_sender> _chunks;
+                Container _data;
 
-                single_chunk(chunk_sender& cs, Container&& d) : chunks{cs.shared_from_this()}, data{std::move(d)} {}
-                ~single_chunk() { chunks->queue_next_chunk(); }
+              public:
+                single_chunk(chunk_sender& cs, Container&& d) : _chunks{cs.shared_from_this()}, _data{std::move(d)} {}
+                ~single_chunk() { _chunks->queue_next_chunk(); }
+
+                bstring_view view() const
+                {
+                    if constexpr (is_pointer)
+                    {
+                        static_assert(sizeof(*_data->data()) == 1, "chunk_sender requires bytes data");
+                        return {reinterpret_cast<const std::byte*>(_data->data()), _data->size()};
+                    }
+                    else
+                    {
+                        static_assert(sizeof(*_data.data()) == 1, "chunk_sender requires bytes data");
+                        return {reinterpret_cast<const std::byte*>(_data.data()), _data.size()};
+                    }
+                }
             };
 
             chunk_sender(Stream& s, chunk_callback_t next, done_callback_t done) :
@@ -157,7 +181,6 @@ namespace oxen::quic
             }
 
             Stream& str;
-            std::shared_ptr<Container> data;
             chunk_callback_t next_chunk;
             done_callback_t done;
 
@@ -168,43 +191,61 @@ namespace oxen::quic
                     // We already finished (i.e. via a previous chunk destructor)
                     return;
 
-                auto data = next_chunk();
-                if (data.empty())
+                auto data = next_chunk(const_cast<const Stream&>(str));
+                bool no_data = false;
+                if constexpr (is_pointer)
+                    no_data = !data || data->size() == 0;
+                else
+                    no_data = data.size() == 0;
+
+                if (no_data)
                 {
                     log::trace(log_cat, "send_chunks finished");
                     // We're finishing
                     next_chunk = nullptr;
                     if (done)
-                        done();
+                        done(str);
                     return;
                 }
 
                 auto next = std::make_shared<single_chunk>(*this, std::move(data));
-                log::trace(log_cat, "got chunk to send of size {}", next->data.size());
-                bstring_view bsv{reinterpret_cast<const std::byte*>(next->data.data()), next->data.size()};
+                auto bsv = next->view();
+                log::trace(log_cat, "got chunk to send of size {}", bsv.size());
                 str.send(bsv, std::move(next));
             }
         };
 
       public:
-        /// Sends data in chunks: `next_chunk()` will be called to obtain the next chunk of data
-        /// until it returns an empty container, at which point `done()` will be called.  Chunks are
-        /// called when a previous chunk has been completely send and acknolwedged by the other end
-        /// of the stream.
+        /// Sends data in chunks: `next_chunk` is some callable (e.g. lambda) that will be called
+        /// with a const reference to the stream instance as needed to obtain the next chunk of data
+        /// until it returns an empty container, at which point `done(stream)` will be called.
+        /// Chunks are called when a previous chunk has been completely send and acknolwedged by the
+        /// other end of the stream.
+        ///
+        /// next_chunk() can return any contiguous container with `.data()` and `.size()` member
+        /// functions as long as `.data()` returns a pointer to a single-byte type (e.g.
+        /// std::string, std::vector of bytes, etc. are acceptable), or a
+        /// pointer/unique_ptr/shared_ptr to such a container.  If returned by value the container
+        /// or smart pointer will be moved and kept until no longer needed; if returned by raw
+        /// pointer then it must remain valid until the stream chunk is complete.  When returning a
+        /// pointer either an empty container or a nullptr can be returned to signal the end of the
+        /// data.
         ///
         /// Note that done() is called once all chunks are queued, *not* once all chunks are
         /// acknoledged; this allows you to use the `done` callback to know when it is safe to
         /// append data to followed the chunked data.
         ///
         /// simultaneous controls how many initial chunks to queue up (and thus also how many chunks
-        /// will be in-flight at a given time), and must be at least 1.
-        template <typename T = std::string>
-        void send_chunks(std::function<T()> next_chunk, std::function<void()> done = nullptr, int simultaneous = 2)
+        /// will be in-flight at a given time), and must be at least 1.  You can rely on no more
+        /// than simultaneous being active at a time (and so, for example, can safely return
+        /// pointers to a circular buffer of `simultaneous` Containers).
+        template <typename NextChunk>
+        void send_chunks(NextChunk next_chunk, std::function<void(Stream&)> done = nullptr, int simultaneous = 2)
         {
-            assert(next_chunk);
             if (simultaneous < 1)
                 throw std::logic_error{"Stream::send_chunks simultaneous must be >= 1"};
 
+            using T = decltype(next_chunk(const_cast<const Stream&>(*this)));
             chunk_sender<T>::make(simultaneous, *this, std::move(next_chunk), std::move(done));
         }
 

--- a/include/quic/utils.hpp
+++ b/include/quic/utils.hpp
@@ -83,6 +83,13 @@ namespace oxen::quic
     static constexpr size_t dgram_size = 1200;
     static constexpr size_t ev_loop_queue_size = 1024;
 
+    // Check if T is an instantiation of templated class `Class`; for example,
+    // `is_instantiation<std::basic_string, std::string>` is true.
+    template <template <typename...> class Class, typename T>
+    inline constexpr bool is_instantiation = false;
+    template <template <typename...> class Class, typename... Us>
+    inline constexpr bool is_instantiation<Class, Class<Us...>> = true;
+
     // Max theoretical size of a UDP packet is 2^16-1 minus IP/UDP header overhead
     static constexpr size_t max_bufsize = 64 * 1024;
     // Max size of a UDP packet that we'll send

--- a/include/quic/utils.hpp
+++ b/include/quic/utils.hpp
@@ -329,7 +329,7 @@ namespace oxen::quic
 
     // Stringview conversion function to interoperate between bstring_views and any other potential
     // user supplied type
-    template <typename CharOut, typename CharIn, std::enable_if_t<sizeof(CharOut) == 1 && sizeof(CharIn) == 1>>
+    template <typename CharOut, typename CharIn, typename = std::enable_if_t<sizeof(CharOut) == 1 && sizeof(CharIn) == 1>>
     std::basic_string_view<CharOut> convert_sv(std::basic_string_view<CharIn> in)
     {
         return {reinterpret_cast<const CharOut*>(in.data()), in.size()};

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -87,10 +87,10 @@ namespace oxen::quic
         conn.io_ready();
     }
 
-    void Stream::append_buffer(bstring_view buffer, std::any keep_alive)
+    void Stream::append_buffer(bstring_view buffer, std::shared_ptr<void> keep_alive)
     {
         log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
-        user_buffers.emplace_back(buffer, keep_alive);
+        user_buffers.emplace_back(buffer, std::move(keep_alive));
         if (ready)
             conn.io_ready();
         else
@@ -159,7 +159,7 @@ namespace oxen::quic
         unacked_size += bytes;
     }
 
-    static auto get_buffer_it(std::deque<std::pair<bstring_view, std::any>>& bufs, size_t offset)
+    static auto get_buffer_it(std::deque<std::pair<bstring_view, std::shared_ptr<void>>>& bufs, size_t offset)
     {
         log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
         auto it = bufs.begin();
@@ -200,7 +200,7 @@ namespace oxen::quic
         return nbufs;
     }
 
-    void Stream::send(bstring_view data, std::any keep_alive)
+    void Stream::send(bstring_view data, std::shared_ptr<void> keep_alive)
     {
         log::trace(log_cat, "Stream (ID: {}) sending message: {}", stream_id, buffer_printer{data});
         append_buffer(data, keep_alive);

--- a/tests/005-chunked-sender.cpp
+++ b/tests/005-chunked-sender.cpp
@@ -1,0 +1,66 @@
+#include <catch2/catch_test_macros.hpp>
+#include <thread>
+
+#include "quic.hpp"
+
+namespace oxen::quic::test
+{
+    using namespace std::literals;
+
+    TEST_CASE("005: Chunked stream sending", "[005][chunked]")
+    {
+        logger_config();
+
+        Network test_net{};
+
+        std::mutex recv_mut;
+        std::string received;
+        auto stream_callback = [&](Stream& s, bstring_view data) {
+            std::lock_guard lock{recv_mut};
+            received.append(reinterpret_cast<const char*>(data.data()), data.size());
+        };
+
+        opt::server_tls server_tls{"./serverkey.pem"s, "./servercert.pem"s, "./clientcert.pem"s};
+        opt::client_tls client_tls{"./clientkey.pem"s, "./clientcert.pem"s, "./servercert.pem"s};
+
+        opt::local_addr server_local{"127.0.0.1"s, static_cast<uint16_t>(5500)};
+        opt::local_addr client_local{"127.0.0.1"s, static_cast<uint16_t>(4400)};
+        opt::remote_addr client_remote{"127.0.0.1"s, static_cast<uint16_t>(5500)};
+
+        log::debug(log_cat, "Calling 'server_listen'...");
+        auto server = test_net.server_listen(server_local, server_tls, stream_callback);
+
+        log::debug(log_cat, "Calling 'client_connect'...");
+        auto client = test_net.client_connect(client_local, client_remote, client_tls);
+
+        std::thread ev_thread{[&]() { test_net.run(); }};
+
+        auto stream = client->open_stream();
+        stream->send("HELLO!"s);
+        int i = 0;
+        auto next_chunk = [&] {
+            log::critical(log_cat, "getting next chunk ({})", i);
+            if (i++ < 10)
+                return fmt::format("[CHUNK-{}]", i);
+            return ""s;
+        };
+        auto post_chunk = [&] {
+            log::critical(log_cat, "All chunks done!");
+            stream->send("Goodbye."s);
+        };
+
+        stream->send_chunks<std::string>(next_chunk, post_chunk);
+
+        std::this_thread::sleep_for(250ms);
+
+        {
+            std::lock_guard lock{recv_mut};
+            CHECK(received ==
+                  "HELLO![CHUNK-1][CHUNK-2][CHUNK-3][CHUNK-4][CHUNK-5][CHUNK-6][CHUNK-7][CHUNK-8][CHUNK-9][CHUNK-10]"
+                  "Goodbye.");
+        }
+
+        test_net.ev_loop->stop();
+        ev_thread.join();
+    };
+}  // namespace oxen::quic::test

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(test_all
     002-send-receive.cpp
     003-multiclient.cpp
     004-stream-pending.cpp
+    005-chunked-sender.cpp
 )
 target_link_libraries(test_all PUBLIC quic Catch2::Catch2WithMain)
 set_target_properties(test_all PROPERTIES OUTPUT_NAME all)


### PR DESCRIPTION
This allows you to queue up a callback to be invoked multiple times to be able to send chunks via callbacks that get automatically invoked as each chunk finishes being used by the stream buffer.

It also includes an (optional) final callback to invoke when the chunks are done so that you can know when it is safe to append post-chunk data to the stream.

See the added test code for an example of both.