### PR TITLE
Test suite cleanups

### DIFF
--- a/tests/002-send-receive.cpp
+++ b/tests/002-send-receive.cpp
@@ -6,18 +6,8 @@ namespace oxen::quic::test
 {
     using namespace std::literals;
 
-    bool run{true};
-    bool good{false};
-
-    void signal_handler(int)
+    TEST_CASE("002: Simple client to server transmission", "[002][simple]")
     {
-        run = false;
-    }
-
-    TEST_CASE("Simple client to server transmission")
-    {
-        signal(SIGINT, signal_handler);
-        signal(SIGTERM, signal_handler);
         logger_config();
 
         log::debug(log_cat, "Beginning test of client to server transmission...");
@@ -25,20 +15,16 @@ namespace oxen::quic::test
         Network test_net{};
         auto msg = "hello from the other siiiii-iiiiide"_bsv;
 
+        std::atomic<bool> good{false};
+
         server_data_callback_t server_data_cb = [&](const uvw::UDPDataEvent& event, uvw::UDPHandle& udp) {
             log::debug(log_cat, "Calling server data callback... data received...");
             good = true;
         };
 
-        opt::server_tls server_tls{
-                "/home/dan/oxen/libquicinet/tests/certs/serverkey.pem"s,
-                "/home/dan/oxen/libquicinet/tests/certs/servercert.pem"s,
-                "/home/dan/oxen/libquicinet/tests/certs/clientcert.pem"s};
+        opt::server_tls server_tls{"./serverkey.pem"s, "./servercert.pem"s, "./clientcert.pem"s};
 
-        opt::client_tls client_tls{
-                "/home/dan/oxen/libquicinet/tests/certs/clientkey.pem"s,
-                "/home/dan/oxen/libquicinet/tests/certs/clientcert.pem"s,
-                "/home/dan/oxen/libquicinet/tests/certs/servercert.pem"s};
+        opt::client_tls client_tls{"./clientkey.pem"s, "./clientcert.pem"s, "./servercert.pem"s};
 
         opt::local_addr server_local{"127.0.0.1"s, static_cast<uint16_t>(5500)};
         opt::local_addr client_local{"127.0.0.1"s, static_cast<uint16_t>(4400)};
@@ -60,14 +46,11 @@ namespace oxen::quic::test
             std::this_thread::sleep_for(std::chrono::milliseconds(1000));
         });
 
-        std::thread check_thread([&]() {
-            REQUIRE(good == true);
-            test_net.close();
-        });
+        REQUIRE(good == true);
+        test_net.close();
 
         test_net.ev_loop->close();
         stream_thread.join();
-        check_thread.join();
         ev_thread.detach();
     };
 }  // namespace oxen::quic::test

--- a/tests/004-stream-pending.cpp
+++ b/tests/004-stream-pending.cpp
@@ -7,18 +7,8 @@ namespace oxen::quic::test
 {
     using namespace std::literals;
 
-    bool run{true};
-    bool good{false};
-
-    void signal_handler(int)
+    TEST_CASE("004: Multiple pending streams", "[004][streams]")
     {
-        run = false;
-    }
-
-    TEST_CASE("Simple client to server transmission")
-    {
-        signal(SIGINT, signal_handler);
-        signal(SIGTERM, signal_handler);
         logger_config();
 
         log::debug(log_cat, "Beginning test of client to server transmission...");
@@ -26,20 +16,16 @@ namespace oxen::quic::test
         Network test_net{};
         auto msg = "hello from the other siiiii-iiiiide"_bsv;
 
+        std::atomic<bool> good{false};
+
         server_data_callback_t server_data_cb = [&](const uvw::UDPDataEvent& event, uvw::UDPHandle& udp) {
             log::debug(log_cat, "Calling server data callback... data received...");
             good = true;
         };
 
-        opt::server_tls server_tls{
-                "/home/dan/oxen/libquicinet/tests/certs/serverkey.pem"s,
-                "/home/dan/oxen/libquicinet/tests/certs/servercert.pem"s,
-                "/home/dan/oxen/libquicinet/tests/certs/clientcert.pem"s};
+        opt::server_tls server_tls{"./serverkey.pem"s, "./servercert.pem"s, "./clientcert.pem"s};
 
-        opt::client_tls client_tls{
-                "/home/dan/oxen/libquicinet/tests/certs/clientkey.pem"s,
-                "/home/dan/oxen/libquicinet/tests/certs/clientcert.pem"s,
-                "/home/dan/oxen/libquicinet/tests/certs/servercert.pem"s};
+        opt::client_tls client_tls{"./clientkey.pem"s, "./clientcert.pem"s, "./servercert.pem"s};
 
         opt::local_addr server_local{"127.0.0.1"s, static_cast<uint16_t>(5500)};
         opt::local_addr client_local{"127.0.0.1"s, static_cast<uint16_t>(4400)};
@@ -80,15 +66,12 @@ namespace oxen::quic::test
         streams[0] = client->open_stream();
         streams[1] = client->open_stream();
 
-        std::thread check_thread([&]() {
-            REQUIRE(good == true);
-            auto conn = client->get_conn(client->context->conn_id);
-            REQUIRE(conn->pending_streams.size() == 1);
-            test_net.close();
-        });
+        REQUIRE(good == true);
+        auto conn = client->get_conn(client->context->conn_id);
+        REQUIRE(conn->pending_streams.size() == 1);
+        test_net.close();
 
         test_net.ev_loop->close();
-        check_thread.join();
         ev_thread.detach();
     };
 }  // namespace oxen::quic::test

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,24 +1,13 @@
 add_subdirectory(Catch2)
 
-add_executable(
-    001
-    001-handshake.cpp)
-target_link_libraries(001 PUBLIC quic Catch2::Catch2WithMain)
-
-add_executable(
-    002
-    002-send-receive.cpp)
-target_link_libraries(002 PUBLIC quic Catch2::Catch2WithMain)
-
-add_executable(
-    003
-    003-multiclient.cpp)
-target_link_libraries(003 PUBLIC quic Catch2::Catch2WithMain)
-
-add_executable(
-    004
-    004-stream-pending.cpp)
-target_link_libraries(004 PUBLIC quic Catch2::Catch2WithMain)
+add_executable(test_all
+    001-handshake.cpp
+    002-send-receive.cpp
+    003-multiclient.cpp
+    004-stream-pending.cpp
+)
+target_link_libraries(test_all PUBLIC quic Catch2::Catch2WithMain)
+set_target_properties(test_all PROPERTIES OUTPUT_NAME all)
 
 add_executable(
     test_client


### PR DESCRIPTION
- Combine catch2 test executables into a single `./tests/all` binary
- Add test tags to tests so that you can run `./testAll [001]` to run a single test
- Give tests more descriptive names
- Avoid global variables (`good`, `run`)
- Remove unused/unwanted signal handler from tests
- Remove unneeded threaded cleanup call
- Change `bool` -> `atomic<bool>` for thread safety
- Change cert path to ./ instead of hard-coded /home/dan/whatever path. (This requires creating some certs in the `build` dir for now.  This is temporary: we've discussed fixing the tests to dynamically generate certs as needed -- perhaps using a catch2 fixture?)