### PR TITLE
add oxen-encoding submodule and fixup format script

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "external/CLI11"]
 	path = tests/CLI11
 	url = https://github.com/CLIUtils/CLI11
+[submodule "external/oxen-encoding"]
+	path = external/oxen-encoding
+	url = https://github.com/oxen-io/oxen-encoding.git

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -25,6 +25,7 @@ if(GIT_FOUND)
     check_submodule(libuv)
     check_submodule(uvw)
     check_submodule(oxen-logging fmt spdlog)
+    check_submodule(oxen-encoding)
 endif()
 
 find_package(PkgConfig REQUIRED)
@@ -54,6 +55,8 @@ system_or_submodule(LIBUV uv_a libuv>=1.45.0 libuv)
 # oxen-logging
 set(OXEN_LOGGING_SOURCE_ROOT "${PROJECT_SOURCE_DIR}" CACHE INTERNAL "")
 add_subdirectory(oxen-logging)
+
+system_or_submodule(OXENC oxenc liboxenc>=1.0.4 oxen-encoding)
 
 # uvw
 add_library(uvw INTERFACE)

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -72,7 +72,7 @@ namespace oxen::quic
                     // uvw's udp_handle_t is completely broken when you turn RECVMMSG on) get mashed
                     // and dereferenced into the wrong pointer type in this call:
                     //
-                    //ev_loop->walk([](auto&& h) { h.close(); });
+                    // ev_loop->walk([](auto&& h) { h.close(); });
                     ev_loop->stop();
                 }
                 p.set_value();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,5 +39,5 @@ endif()
 
 foreach(x speedtest-client speedtest-server)
     add_executable(${x} ${x}.cpp)
-    target_link_libraries(${x} PRIVATE quic CLI11::CLI11 sodium)
+    target_link_libraries(${x} PRIVATE quic CLI11::CLI11 sodium oxenc)
 endforeach()

--- a/utils/format.sh
+++ b/utils/format.sh
@@ -20,7 +20,7 @@ if [ $? -ne 0 ]; then
 fi
 
 cd "$(dirname $0)/../"
-readarray -t sources < <(find include src tests | grep -E '\.([hc](pp)?)$' | grep -v '\#' | grep -v Catch2)
+readarray -t sources < <(find include src tests | grep -E '\.([hc](pp)?)$' | grep -v '\#' | grep -v Catch2 | grep -v CLI11)
 if [ "$1" = "verify" ] ; then
     if [ $($binary --output-replacements-xml "${sources[@]}"  | grep '</replacement>' | wc -l) -ne 0 ] ; then
         exit 2


### PR DESCRIPTION
Adds oxen-encoding submodule as target 'oxenc' and updates the tests using it to depend on it.

utils/format.sh will not try to format tests/CLI11 now.

also format.sh wanted to pedant a comment's formatting so I let it.