### PR TITLE
Warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,9 +63,16 @@ add_library(internal INTERFACE)
 target_include_directories(common INTERFACE include)
 target_include_directories(internal INTERFACE include/quic)
 
-if(WARNINGS_AS_ERRORS)
-    target_compile_options(internal INTERFACE -Werror)
+option(WARNINGS_AS_ERRORS "treat all warnings as errors. turn off for development, on for release" OFF)
+
+set(warning_flags -Wall -Wextra -Wno-unknown-pragmas -Wno-unused-function -Werror=vla -Wdeprecated-declarations)
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    list(APPEND warning_flags -Wno-unknown-warning-option)
 endif()
+if (WARNINGS_AS_ERRORS)
+    list(APPEND warning_flags -Werror)
+endif()
+target_compile_options(common INTERFACE "$<$<OR:$<COMPILE_LANGUAGE:CXX>,$<COMPILE_LANGUAGE:C>>:${warning_flags}>")
 
 add_subdirectory(external)
 add_subdirectory(src)

--- a/include/quic/connection.hpp
+++ b/include/quic/connection.hpp
@@ -36,6 +36,8 @@ namespace oxen::quic
                 stream_data_callback_t data_cb = nullptr, stream_close_callback_t close_cb = nullptr) = 0;
 
         virtual const ConnectionID& scid() const = 0;
+
+        virtual ~connection_interface() = default;
     };
 
     class Connection : public connection_interface, public std::enable_shared_from_this<Connection>
@@ -156,8 +158,6 @@ namespace oxen::quic
         // holds queue of pending streams not yet ready to broadcast
         // streams are added to the back and popped from the front (FIFO)
         std::deque<std::shared_ptr<Stream>> pending_streams;
-
-        ngtcp2_ccerr last_error;
 
       public:
         // Buffer used to store non-stream connection data

--- a/include/quic/connection.hpp
+++ b/include/quic/connection.hpp
@@ -93,8 +93,6 @@ namespace oxen::quic
         const ConnectionID _source_cid;
         ConnectionID _dest_cid;
         Path _path;
-        const Address _local;
-        const Address _remote;
         std::function<void(Connection&)> on_closing;  // clear immediately after use
 
         // private Constructor (publicly construct via `make_conn` instead, so that we can properly

--- a/include/quic/connection.hpp
+++ b/include/quic/connection.hpp
@@ -41,6 +41,12 @@ namespace oxen::quic
     class Connection : public connection_interface, public std::enable_shared_from_this<Connection>
     {
       public:
+          // Non-movable/non-copyable; you must always hold a Connection in a shared_ptr
+          Connection(const Connection&) = delete;
+          Connection& operator=(const Connection&) = delete;
+          Connection(Connection&&) = delete;
+          Connection& operator=(Connection&&) = delete;
+
         // Construct and initialize a new inbound/outbound connection to/from a remote
         //      ep: owning endpoints
         //      scid: local ("primary") CID used for this connection (random for outgoing)

--- a/include/quic/connection.hpp
+++ b/include/quic/connection.hpp
@@ -162,8 +162,7 @@ namespace oxen::quic
         int stream_ack(int64_t id, size_t size);
         int stream_receive(int64_t id, bstring_view data, bool fin);
         void stream_closed(int64_t id, uint64_t app_code);
-        void check_pending_streams(
-                int available, stream_data_callback_t data_cb = nullptr, stream_close_callback_t close_cb = nullptr);
+        void check_pending_streams(int available);
 
         // Implicit conversion of Connection to the underlying ngtcp2_conn* (so that you can pass a
         // Connection directly to ngtcp2 functions taking a ngtcp2_conn* argument).

--- a/include/quic/crypto.hpp
+++ b/include/quic/crypto.hpp
@@ -17,6 +17,7 @@ namespace oxen::quic
     {
       public:
         virtual std::unique_ptr<TLSSession> make_session(const ngtcp2_crypto_conn_ref& conn_ref, bool is_client) = 0;
+        virtual ~TLSCreds() = default;
     };
 
     class TLSSession

--- a/include/quic/endpoint.hpp
+++ b/include/quic/endpoint.hpp
@@ -204,7 +204,7 @@ namespace oxen::quic
 
         void check_timeouts();
 
-        Connection* accept_initial_connection(const Packet& pkt, const ConnectionID& dcid);
+        Connection* accept_initial_connection(const Packet& pkt);
     };
 
 }  // namespace oxen::quic

--- a/include/quic/endpoint.hpp
+++ b/include/quic/endpoint.hpp
@@ -36,7 +36,6 @@ namespace oxen::quic
         friend class Connection;
         friend class Stream;
 
-      private:
         const Address local;
         event_ptr expiry_timer;
         std::unique_ptr<UDPSocket> socket;
@@ -44,6 +43,12 @@ namespace oxen::quic
         Network& net;
 
       public:
+        // Non-movable/non-copyable; you must always hold a Endpoint in a shared_ptr
+        Endpoint(const Endpoint&) = delete;
+        Endpoint& operator=(const Endpoint&) = delete;
+        Endpoint(Endpoint&&) = delete;
+        Endpoint& operator=(Endpoint&&) = delete;
+
         explicit Endpoint(Network& n, const Address& listen_addr);
 
         template <typename... Opt>

--- a/include/quic/gnutls_crypto.hpp
+++ b/include/quic/gnutls_crypto.hpp
@@ -53,15 +53,18 @@ namespace oxen::quic
                 from_mem = true;
             }
         }
-        datum(datum const& other)
+        datum(const datum& other)
         {
-            if (!other.path.empty())
-                path = other.path;
-            memcpy(mem.data, other.mem.data, other.mem.size);
+            *this = other;
+        }
+        datum& operator=(const datum& other)
+        {
+            path = other.path;
+            std::memcpy(mem.data, other.mem.data, other.mem.size);
             mem.size = other.mem.size;
-            if (ext)
-                ext = other.ext;
+            ext = other.ext;
             from_mem = other.from_mem;
+            return *this;
         }
 
         // returns truew if path is not empty OR mem has a value set

--- a/include/quic/network.hpp
+++ b/include/quic/network.hpp
@@ -70,7 +70,6 @@ namespace oxen::quic
         std::queue<Job> job_queue;
         std::mutex job_queue_mutex;
 
-      protected:
         friend class Endpoint;
         friend class Connection;
         friend class Stream;

--- a/include/quic/stream.hpp
+++ b/include/quic/stream.hpp
@@ -35,6 +35,12 @@ namespace oxen::quic
         Stream(Connection& conn, Endpoint& ep, int64_t stream_id) : Stream{conn, ep, nullptr, nullptr, stream_id} {}
         ~Stream();
 
+        // non-copyable, non-moveable (you must always hold a stream in a shared_ptr)
+        Stream(const Stream&) = delete;
+        Stream& operator=(const Stream&) = delete;
+        Stream(Stream&&) = delete;
+        Stream& operator=(Stream&&) = delete;
+
         stream_data_callback_t data_callback;
         stream_close_callback_t close_callback;
         Connection& conn;

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -754,8 +754,6 @@ namespace oxen::quic
             _source_cid{scid},
             _dest_cid{dcid},
             _path{path},
-            _local{ep.local},
-            _remote{path.remote},
             context{std::move(ctx)},
             tls_creds{context->tls_creds},
             user_config{context->config},

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -33,7 +33,7 @@ namespace oxen::quic
             return *static_cast<Connection*>(conn_ref->user_data);
         }
 
-        void log_printer(void* user_data, const char* fmt, ...)
+        void log_printer(void* /*user_data*/, const char* fmt, ...)
         {
             std::array<char, 2048> buf{};
             va_list ap;
@@ -58,14 +58,14 @@ namespace oxen::quic
     }
 
     int recv_stream_data(
-            ngtcp2_conn* conn,
+            ngtcp2_conn* /*conn*/,
             uint32_t flags,
             int64_t stream_id,
-            uint64_t offset,
+            uint64_t /*offset*/,
             const uint8_t* data,
             size_t datalen,
             void* user_data,
-            void* stream_user_data)
+            void* /*stream_user_data*/)
     {
         log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
         return static_cast<Connection*>(user_data)->stream_receive(
@@ -73,31 +73,31 @@ namespace oxen::quic
     }
 
     int acked_stream_data_offset(
-            ngtcp2_conn* conn_,
+            ngtcp2_conn* /*conn_*/,
             int64_t stream_id,
             uint64_t offset,
             uint64_t datalen,
             void* user_data,
-            void* stream_user_data)
+            void* /*stream_user_data*/)
     {
         log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
         log::trace(log_cat, "Ack [{},{}]", offset, offset + datalen);
         return static_cast<Connection*>(user_data)->stream_ack(stream_id, datalen);
     }
 
-    int on_stream_open(ngtcp2_conn* conn, int64_t stream_id, void* user_data)
+    int on_stream_open(ngtcp2_conn* /*conn*/, int64_t stream_id, void* user_data)
     {
         log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
         return static_cast<Connection*>(user_data)->stream_opened(stream_id);
     }
 
     int on_stream_close(
-            ngtcp2_conn* conn,
-            uint32_t flags,
+            ngtcp2_conn* /*conn*/,
+            uint32_t /*flags*/,
             int64_t stream_id,
             uint64_t app_error_code,
             void* user_data,
-            void* stream_user_data)
+            void* /*stream_user_data*/)
     {
         log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
         static_cast<Connection*>(user_data)->stream_closed(stream_id, app_error_code);
@@ -105,12 +105,12 @@ namespace oxen::quic
     }
 
     int on_stream_reset(
-            ngtcp2_conn* conn,
+            ngtcp2_conn* /*conn*/,
             int64_t stream_id,
-            uint64_t final_size,
+            uint64_t /*final_size*/,
             uint64_t app_error_code,
             void* user_data,
-            void* stream_user_data)
+            void* /*stream_user_data*/)
     {
         log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
         static_cast<Connection*>(user_data)->stream_closed(stream_id, app_error_code);
@@ -140,19 +140,19 @@ namespace oxen::quic
         return 0;
     }
 
-    int recv_rx_key(ngtcp2_conn* conn, ngtcp2_encryption_level level, void* user_data)
+    int recv_rx_key(ngtcp2_conn* /*conn*/, ngtcp2_encryption_level /*level*/, void* /*user_data*/)
     {
         // fix this
         return 0;
     }
 
-    int recv_tx_key(ngtcp2_conn* conn, ngtcp2_encryption_level level, void* user_data)
+    int recv_tx_key(ngtcp2_conn* /*conn*/, ngtcp2_encryption_level /*level*/, void* /*user_data*/)
     {
         // same
         return 0;
     }
 
-    int extend_max_local_streams_bidi(ngtcp2_conn* _conn, uint64_t max_streams, void* user_data)
+    int extend_max_local_streams_bidi(ngtcp2_conn* /*_conn*/, uint64_t /*max_streams*/, void* user_data)
     {
         log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
 
@@ -175,7 +175,7 @@ namespace oxen::quic
     // so, we move them to the streams map, where they will get picked up by flush_streams and dump
     // their buffers. If none are ready, we keep chugging along and make another stream as usual. Though
     // if none of the pending streams are ready, the new stream really shouldn't be ready, but here we are
-    void Connection::check_pending_streams(int available, stream_data_callback_t data_cb, stream_close_callback_t close_cb)
+    void Connection::check_pending_streams(int available)
     {
         log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
         int popped = 0;
@@ -552,7 +552,7 @@ namespace oxen::quic
             return 0;
         }
 
-        auto [it, ins] = streams.emplace(id, std::move(stream));
+        [[maybe_unused]] auto [it, ins] = streams.emplace(id, std::move(stream));
         assert(ins);
         log::info(log_cat, "Created new incoming stream {}", id);
         return 0;
@@ -750,14 +750,14 @@ namespace oxen::quic
             Direction dir,
             ngtcp2_pkt_hd* hdr) :
 
+            context{std::move(ctx)},
+            user_config{context->config},
+            dir{dir},
             _endpoint{ep},
             _source_cid{scid},
             _dest_cid{dcid},
             _path{path},
-            context{std::move(ctx)},
-            tls_creds{context->tls_creds},
-            user_config{context->config},
-            dir{dir}
+            tls_creds{context->tls_creds}
     {
         const auto outbound = (dir == Direction::OUTBOUND);
         const auto d_str = outbound ? "outbound"s : "inbound"s;

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -19,7 +19,7 @@ extern "C"
 
 namespace oxen::quic
 {
-    Endpoint::Endpoint(Network& n, const Address& listen_addr) : net{n}, local{listen_addr}
+    Endpoint::Endpoint(Network& n, const Address& listen_addr) : local{listen_addr}, net{n}
     {
         log::debug(log_cat, "Starting new UDP socket on {}", local);
         socket = std::make_unique<UDPSocket>(get_loop().get(), local, [this](const auto& packet) { handle_packet(packet); });
@@ -101,7 +101,7 @@ namespace oxen::quic
         {
             if (accepting_inbound)
             {
-                cptr = accept_initial_connection(pkt, dcid);
+                cptr = accept_initial_connection(pkt);
 
                 if (!cptr)
                 {
@@ -224,7 +224,7 @@ namespace oxen::quic
         return std::make_optional<ConnectionID>(vid.dcid, vid.dcidlen);
     }
 
-    Connection* Endpoint::accept_initial_connection(const Packet& pkt, const ConnectionID& dcid)
+    Connection* Endpoint::accept_initial_connection(const Packet& pkt)
     {
         log::info(log_cat, "Accepting new connection...");
 

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -126,7 +126,7 @@ namespace oxen::quic
         }
         else
         {
-            it->second = std::move(std::make_shared<Endpoint>(*this, local_addr));
+            it->second = std::make_shared<Endpoint>(*this, local_addr);
             return it->second;
         }
     }

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -21,13 +21,14 @@ namespace oxen::quic
             stream_data_callback_t data_cb,
             stream_close_callback_t close_cb,
             int64_t stream_id) :
-            conn{conn}, endpoint{_ep}, stream_id{stream_id}, data_callback{data_cb}
+            data_callback{data_cb}, close_callback{std::move(close_cb)}, conn{conn}, stream_id{stream_id}, endpoint{_ep}
     {
         log::trace(log_cat, "Creating Stream object...");
 
-        close_callback = (close_cb) ? std::move(close_cb) : [](Stream& s, uint64_t error_code) {
-            log::warning(log_cat, "Stream close callback called (error code: {})", error_code);
-        };
+        if (!close_callback)
+            close_callback = [](Stream&, uint64_t error_code) {
+                log::info(log_cat, "Default stream close callback called (error code: {})", error_code);
+            };
 
         log::trace(log_cat, "Stream object created");
     }

--- a/src/udp.cpp
+++ b/src/udp.cpp
@@ -177,7 +177,7 @@ namespace oxen::quic
 
             count += nread;
 
-            if (nread < DATAGRAM_BATCH_SIZE)
+            if (nread < static_cast<int>(DATAGRAM_BATCH_SIZE))
                 // We didn't fill the recvmmsg array so must be done
                 return io_result{};
 
@@ -271,7 +271,7 @@ namespace oxen::quic
         std::array<uint16_t, MAX_BATCH> gso_counts{};  // Number of packets
 
         unsigned int msg_count = 0;
-        for (int i = 0; i < n_pkts; i++)
+        for (size_t i = 0; i < n_pkts; i++)
         {
             auto& gso_size = gso_sizes[msg_count];
             auto& gso_count = gso_counts[msg_count];
@@ -348,7 +348,7 @@ namespace oxen::quic
 #elif defined(OXEN_LIBQUIC_UDP_SENDMMSG)  // sendmmsg, but not GSO
 #define OXEN_LIBQUIC_SEND_TYPE "sendmmsg"
 
-        for (int i = 0; i < n_pkts; i++)
+        for (size_t i = 0; i < n_pkts; i++)
         {
             assert(bufsize[i] > 0);
 

--- a/tests/001-handshake.cpp
+++ b/tests/001-handshake.cpp
@@ -15,19 +15,15 @@ namespace oxen::quic::test
 
         Network test_net{};
         std::atomic<bool> good{false};
-        auto msg = "hello from the other siiiii-iiiiide"_bsv;
 
         std::shared_ptr<Stream> server_extracted;
 
-        gnutls_callback outbound_tls_cb = [&](gnutls_session_t session,
-                                              unsigned int htype,
-                                              unsigned int when,
-                                              unsigned int incoming,
-                                              const gnutls_datum_t* msg) {
+        gnutls_callback outbound_tls_cb = [&](gnutls_session_t /*session*/,
+                                              unsigned int /*htype*/,
+                                              unsigned int /*when*/,
+                                              unsigned int /*incoming*/,
+                                              const gnutls_datum_t* /*msg*/) {
             log::debug(log_cat, "Calling client TLS callback... handshake completed...");
-
-            const auto& conn_ref = static_cast<ngtcp2_crypto_conn_ref*>(gnutls_session_get_ptr(session));
-            const auto& ep = static_cast<Connection*>(conn_ref->user_data)->endpoint();
 
             good = true;
             return 0;

--- a/tests/002-send-receive.cpp
+++ b/tests/002-send-receive.cpp
@@ -19,7 +19,7 @@ namespace oxen::quic::test
 
         std::atomic<bool> good{false};
 
-        stream_data_callback_t server_data_cb = [&](Stream& s, bstring_view dat) {
+        stream_data_callback_t server_data_cb = [&](Stream&, bstring_view dat) {
             log::debug(log_cat, "Calling server stream data callback... data received...");
             capture = dat;
             good.store(true);

--- a/tests/003-multiclient.cpp
+++ b/tests/003-multiclient.cpp
@@ -18,7 +18,7 @@ namespace oxen::quic::test
 
         std::atomic<int> data_check{0};
 
-        stream_data_callback_t server_data_cb = [&](Stream s, bstring_view dat) {
+        stream_data_callback_t server_data_cb = [&](Stream& s, bstring_view dat) {
             log::debug(log_cat, "Calling server stream data callback... data received...");
             data_check += 1;
         };

--- a/tests/003-multiclient.cpp
+++ b/tests/003-multiclient.cpp
@@ -18,7 +18,7 @@ namespace oxen::quic::test
 
         std::atomic<int> data_check{0};
 
-        stream_data_callback_t server_data_cb = [&](Stream& s, bstring_view dat) {
+        stream_data_callback_t server_data_cb = [&](Stream&, bstring_view) {
             log::debug(log_cat, "Calling server stream data callback... data received...");
             data_check += 1;
         };

--- a/tests/004-streams.cpp
+++ b/tests/004-streams.cpp
@@ -16,12 +16,11 @@ namespace oxen::quic::test
         Network test_net{};
         auto msg = "hello from the other siiiii-iiiiide"_bsv;
 
-        std::atomic<bool> good{false};
         std::atomic<int> data_check{0};
 
         opt::max_streams max_streams{8};
 
-        stream_data_callback_t server_stream_data_cb = [&](Stream& s, bstring_view dat) {
+        stream_data_callback_t server_stream_data_cb = [&](Stream& /*s*/, bstring_view /*dat*/) {
             log::debug(log_cat, "Calling server stream data callback... data received... incrementing counter...");
             data_check += 1;
         };
@@ -34,7 +33,7 @@ namespace oxen::quic::test
         opt::remote_addr client_remote{"127.0.0.1"s, 5500};
 
         auto server_endpoint = test_net.endpoint(server_local);
-        bool sinit = server_endpoint->listen(server_tls, max_streams, server_stream_data_cb);
+        server_endpoint->listen(server_tls, max_streams, server_stream_data_cb);
 
         auto client_endpoint = test_net.endpoint(client_local);
         auto conn_interface = client_endpoint->connect(client_remote, client_tls, max_streams);

--- a/tests/005-chunked-sender.cpp
+++ b/tests/005-chunked-sender.cpp
@@ -16,7 +16,7 @@ namespace oxen::quic::test
 
         std::mutex recv_mut;
         std::string received;
-        stream_data_callback_t stream_data_cb = [&](Stream& s, bstring_view data) {
+        stream_data_callback_t stream_data_cb = [&](Stream&, bstring_view data) {
             std::lock_guard lock{recv_mut};
             received.append(reinterpret_cast<const char*>(data.data()), data.size());
         };
@@ -29,7 +29,7 @@ namespace oxen::quic::test
         opt::remote_addr client_remote{"127.0.0.1"s, 5500};
 
         auto server_endpoint = test_net.endpoint(server_local);
-        bool sinit = server_endpoint->listen(server_tls, stream_data_cb);
+        server_endpoint->listen(server_tls, stream_data_cb);
 
         auto client_endpoint = test_net.endpoint(client_local);
         auto conn_interface = client_endpoint->connect(client_remote, client_tls);

--- a/tests/006-server-send.cpp
+++ b/tests/006-server-send.cpp
@@ -26,12 +26,12 @@ namespace oxen::quic::test
             return 0;
         };
 
-        stream_data_callback_t server_stream_data_cb = [&](Stream& s, bstring_view dat) {
+        stream_data_callback_t server_stream_data_cb = [&](Stream&, bstring_view) {
             log::debug(log_cat, "Calling server stream data callback... data received... incrementing counter...");
             data_check += 1;
         };
 
-        stream_data_callback_t client_stream_data_cb = [&](Stream& s, bstring_view dat) {
+        stream_data_callback_t client_stream_data_cb = [&](Stream&, bstring_view) {
             log::debug(log_cat, "Calling client stream data callback... data received... incrementing counter...");
             data_check += 1;
         };

--- a/tests/007-server-streams.cpp
+++ b/tests/007-server-streams.cpp
@@ -35,12 +35,12 @@ namespace oxen::quic::test
             return 0;
         };
 
-        stream_data_callback_t server_stream_data_cb = [&](Stream& s, bstring_view dat) {
+        stream_data_callback_t server_stream_data_cb = [&](Stream&, bstring_view) {
             log::debug(log_cat, "Calling server stream data callback... data received... incrementing counter...");
             data_check += 1;
         };
 
-        stream_data_callback_t client_stream_data_cb = [&](Stream& s, bstring_view dat) {
+        stream_data_callback_t client_stream_data_cb = [&](Stream&, bstring_view) {
             log::debug(log_cat, "Calling client stream data callback... data received... incrementing counter...");
             data_check += 1;
         };

--- a/tests/speedtest-client.cpp
+++ b/tests/speedtest-client.cpp
@@ -228,13 +228,12 @@ int main(int argc, char* argv[])
                             uint8_t& checksum) {
         assert(size > 0);
 
-        using RNG_val = RNG::result_type;
+        using rng_value = RNG::result_type;
 
         static_assert(
-                RNG::min() == 0 && std::is_unsigned_v<RNG::result_type> &&
-                RNG::max() == std::numeric_limits<RNG::result_type>::max());
+                RNG::min() == 0 && std::is_unsigned_v<rng_value> &&
+                RNG::max() == std::numeric_limits<rng_value>::max());
 
-        using rng_value = typename RNG::result_type;
         constexpr size_t rng_size = sizeof(rng_value);
         const size_t rng_chunks = (size + rng_size - 1) / rng_size;
         const size_t size_data = rng_chunks * rng_size;
@@ -269,7 +268,7 @@ int main(int argc, char* argv[])
         log::warning(test_cat, "Pregenerating data...");
     }
 
-    for (int i = 0; i < parallel; i++)
+    for (size_t i = 0; i < parallel; i++)
     {
         uint64_t my_data = per_stream + (i == 0 ? size % parallel : 0);
         auto& s = *streams.emplace_back(std::make_unique<stream_data>(
@@ -289,7 +288,7 @@ int main(int argc, char* argv[])
 
     auto started_at = std::chrono::steady_clock::now();
 
-    for (int i = 0; i < parallel; i++)
+    for (size_t i = 0; i < parallel; i++)
     {
         auto& s = *streams[i];
         s.stream = client_ci->get_new_stream();
@@ -334,7 +333,6 @@ int main(int argc, char* argv[])
         }
     }
 
-    auto last_print = std::chrono::steady_clock::now();
     for (;;)
     {
         bool all_done = true;

--- a/tests/speedtest-server.cpp
+++ b/tests/speedtest-server.cpp
@@ -160,7 +160,7 @@ int main(int argc, char* argv[])
 
     log::debug(test_cat, "Calling 'server_listen'...");
     auto _server = server_net.endpoint(server_local);
-    bool sinit = _server->listen(server_tls, stream_opened, stream_data);
+    _server->listen(server_tls, stream_opened, stream_data);
 
     for (;;)
         std::this_thread::sleep_for(10min);


### PR DESCRIPTION
- Enable additional compilation warnings to catch various common errors
- Add `-DWARNINGS_AS_ERRORS=ON` to make all warnings fatal errors
- Fix resulting compiler warnings in the library and test suite
- Fix a potential bug allowing copying/moving of Endpoint/Connection/Stream objects.  (We always hold these in shared_ptrs that we copy or move, but don't expect the instances themselves to copy or move).