### PR TITLE
README updates for dependencies, cmake flags, etc.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
-build/
-certs/
-.gdb_history
+/build*
 .cache/
 .vscode/
 .DS_Store
@@ -12,3 +10,4 @@ certs/
 rebuild.sh
 full_rebuild.sh
 notes.txt
+/compile_commands.json

--- a/readme.md
+++ b/readme.md
@@ -4,34 +4,54 @@ C++ library for multi-stream QUIC implementations.
 
 ## Overview
 
-"Bleeding-edge" is tracked in the dev branch, while the stable branch is intermittently updated as new features and capabilities are added.
+"Bleeding-edge" is tracked in the `dev` branch, while the `stable` branch is intermittently updated
+as new features and capabilities are added that are suitable for production use.
 
 ## Building
 
 ### Requirements:
 
-- Cmake
-- C++ 17 compiler (Clang, GCC, etc)
-- NGTCP2
-- GNUTLS
+- CMake 3.13+
+- C++17 compiler (such as clang >= 8 or GCC >= 8)
+- gnutls (>= 3.7.2)
+- libevent (>= 2.1)
+
 
 ### Building from Source
 
-Clone the repository as usual, and run the following commands from the project source directory:
+Clone the repository as usual, including submodules (either by passing `--recurse-submodules` to
+`git clone`, or else running `git submodule update --init --recursive` the top-level project
+directory).
+
+To compile the library run the following commands from the project source directory:
 
 ```
 mkdir -p build
 cd build
-cmake .. -GNinja \
-    -DCMAKE_C_COMPILER="clang" \
-    -DCMAKE_CXX_COMPILER="clang++" \
-    -DCMAKE_BUILD_TYPE=Debug \
-    -DCMAKE_EXPORT_COMPILE_COMMANDS=1 \
-    -DCMAKE_POLICY_DEFAULT_CMP0069=NEW
+cmake ..
+make -j8  # Tweak as needed for the desired build parallelism
 ```
 
-Building using clang/clang++ as the C/C++ compiler is not required; simply change to your compiler of choice. The same applies when compiling a release build, rather than a debug build.
+Various options can be added to the `cmake ..` line; some common options are:
+- `-DCMAKE_BUILD_TYPE=Release` to make a release build
+- `-DBUILD_STATIC_DEPS=ON` to build and bundle static versions of dependencies.
+- `-DWITH_LTO=OFF` to disable link-time optimizations.
+- `-DWARNINGS_AS_ERRORS=ON` to turn compiler warnings into fatal errors.
+- `-DBUILD_TESTS=OFF` to disable building the test suite.
+- `-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++` to use a specific compiler
+- `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON` to generate a `build/compile_commands.json` (used by various
+  IDEs for detecting compilation settings and flags).
+- `-GNinja` to use `ninja` for the build instead of `make`; this also requires changing the `make
+  -j8` line to `ninja`.
 
-### Unit Testing
+## Testing
 
-All tests use [Catch2](https://github.com/catchorg/Catch2) as a formal unit-test framework. Tests are built by default as part of the standard Cmake build logic. The compiled and built test binaries can be found in `/build/tests/*`, named identically to their `*.cpp` source files (ex: `001-handshake.cpp` produces the binary `/build/tests/001`).
+Unit tests use [Catch2](https://github.com/catchorg/Catch2) as a formal unit-test framework. Unit
+tests are built by default as part of the standard CMake build logic (unless being built as a
+subdirectory of another CMake project) and can be invoked through the `build/tests/alltests` binary.
+
+Tests require tls certificates to run; suitable certificates can be created by running the
+`../utils/gen-certs.sh` script from the `build` directory.
+
+Building the tests also build `./tests/speedtest-client` and `./tests/speedtest-server` which can be
+used to test network performance of libquic streams.


### PR DESCRIPTION
- clean up `.gitignore` a bit
- various wording tweaks.
- add required versions to Requirements section
- remove ngtcp2 from requirements: we always build our own bundled version and so it isn't a requirement.
- add libevent to requirements
- add note about needing to clone submodules in addition to the main repo
- remove unneeded options from cmake invocation
- add `make` line (the current build instructions only configured the build, but didn't actually build it).
- add list of various cmake options someone might want to use after the basic version.
- add note about needing to generate certificates for test suite
- add note about speedtest-server/-client test binaries