### PR TITLE
Fix setting ECN on IPv6-bound sockets

### DIFF
--- a/include/quic/udp.hpp
+++ b/include/quic/udp.hpp
@@ -96,7 +96,7 @@ namespace oxen::quic
 
         socket_t sock_;
         Address bound_;
-        uint8_t ecn_{0};
+        unsigned int ecn_{0};
         void set_ecn();
 
         event_base* ev_ = nullptr;


### PR DESCRIPTION
IPV6_TCLASS doesn't like being given a uint8_t, so switch the ecn value to an unsigned int instead, which it is happy with.