### PR TITLE
Add `KEY_TYPES` env param to gen-certs.sh

### DIFF
--- a/utils/gen-certs.sh
+++ b/utils/gen-certs.sh
@@ -17,6 +17,6 @@ if ! type -p $bin && [ -x ./static-deps/bin/certtool ]; then
 fi
 
 for f in server client; do
-    $bin -p --key-type ed448 --outfile ${f}key.pem --no-text
+    $bin -p --key-type ${KEY_TYPE:-ed448} --outfile ${f}key.pem --no-text
     $bin -s --load-privkey ${f}key.pem --no-text --template <(echo 'expiration_days=-1') --outfile=${f}cert.pem
 done


### PR DESCRIPTION
Allows you to generate some key type other than ed448, e.g.

    KEY_TYPE=ed25519 ../utils/gen-certs.sh