### PR TITLE
Close Handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,6 @@ if (WARNINGS_AS_ERRORS)
 endif()
 target_compile_options(common INTERFACE "$<$<OR:$<COMPILE_LANGUAGE:CXX>,$<COMPILE_LANGUAGE:C>>:${warning_flags}>")
 
-
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     set(libquic_IS_TOPLEVEL_PROJECT TRUE)
 else()

--- a/include/quic/connection.hpp
+++ b/include/quic/connection.hpp
@@ -150,10 +150,12 @@ namespace oxen::quic
         bool is_inbound() const { return dir == Direction::INBOUND; }
         bool is_outbound() const { return dir == Direction::OUTBOUND; }
 
+        void halt_events();
         bool is_closing() const { return closing; }
-        void call_closing();
+        void set_closing() { closing = true; }
         bool is_draining() const { return draining; }
-        void drain() { draining = true; }
+        void set_draining() { draining = true; }
+        void call_close_cb();
 
         const ConnectionID& scid() const override { return _source_cid; }
         const ConnectionID& dcid() const { return _dest_cid; }

--- a/include/quic/datagram.hpp
+++ b/include/quic/datagram.hpp
@@ -67,7 +67,7 @@ namespace oxen::quic
         IOChannel(IOChannel&&) = delete;
         IOChannel& operator=(IOChannel&&) = delete;
 
-        virtual bool is_stream() = 0;
+        virtual bool is_stream() const = 0;
         virtual bool is_empty() const = 0;
         virtual std::shared_ptr<Stream> get_stream() = 0;
         virtual void send(bstring_view, std::shared_ptr<void> keep_alive = nullptr) = 0;
@@ -168,7 +168,7 @@ namespace oxen::quic
 
         prepared_datagram pending_datagram(bool r) override;
 
-        bool is_stream() override { return false; }
+        bool is_stream() const override { return false; }
 
         std::optional<bstring> to_buffer(bstring_view data, uint16_t dgid);
 

--- a/include/quic/network.hpp
+++ b/include/quic/network.hpp
@@ -58,12 +58,9 @@ namespace oxen::quic
         }
 
         /// Initiates shutdown the network, closing all endpoint connections and stopping the event
-        /// loop (if Network-managed).  If graceful is true (the default) this call initiates a
-        /// graceful shutdown (sending connection close packets, etc.).
-        ///
-        /// Returns a future that can be waited on to block until a graceful shutdown complete (for
-        /// ungraceful, the promise will be available immediately).
-        std::future<void> close(bool graceful = true);
+        /// loop (if Network-managed).If immediate is false (the default) this call initiates a
+        /// graceful shutdown (sending connection close packets, etc.)
+        void shutdown(bool immediate = false);
 
       private:
         std::atomic<bool> running{false};
@@ -126,6 +123,10 @@ namespace oxen::quic
         }
 
         void process_job_queue();
+
+        void close_gracefully();
+
+        void close_immediate();
 
         // Asynchronously begins closing (e.g. sending close packets) for all endpoints.  Triggers a
         // call to `close_ungraceful` when all connections have had their close packet written.  If

--- a/include/quic/network.hpp
+++ b/include/quic/network.hpp
@@ -57,13 +57,11 @@ namespace oxen::quic
             return *it;
         }
 
-        /// Initiates shutdown the network, closing all endpoint connections and stopping the event
-        /// loop (if Network-managed).If immediate is false (the default) this call initiates a
-        /// graceful shutdown (sending connection close packets, etc.)
-        void shutdown(bool immediate = false);
+        void set_shutdown_immediate(bool b = true) { shutdown_immediate = b; }
 
       private:
         std::atomic<bool> running{false};
+        std::atomic<bool> shutdown_immediate{false};
         std::shared_ptr<::event_base> ev_loop;
         std::optional<std::thread> loop_thread;
         std::thread::id loop_thread_id;
@@ -127,13 +125,5 @@ namespace oxen::quic
         void close_gracefully();
 
         void close_immediate();
-
-        // Asynchronously begins closing (e.g. sending close packets) for all endpoints.  Triggers a
-        // call to `close_ungraceful` when all connections have had their close packet written.  If
-        // the promise is given, it will be passed on to `close_final()` to be fulfilled once
-        // closing is complete.
-        void close_all(std::shared_ptr<std::promise<void>> done = nullptr);
-
-        void close_final(std::shared_ptr<std::promise<void>> done = nullptr);
     };
 }  // namespace oxen::quic

--- a/include/quic/stream.hpp
+++ b/include/quic/stream.hpp
@@ -47,7 +47,7 @@ namespace oxen::quic
         ~Stream();
 
         bool available() const { return !(_is_closing || is_shutdown || _sent_fin); }
-        bool is_stream() override { return true; }
+        bool is_stream() const override { return true; }
 
         int64_t stream_id() const override { return _stream_id; }
         const ConnectionID& conn_id() const;

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -233,8 +233,7 @@ namespace oxen::quic
             log::trace(log_cat, "Note: CID-{} in closing period; signaling endpoint to delete connection", scid());
 
             _endpoint.call([this]() {
-                log::debug(
-                        log_cat, "Error: connection (CID: {}) is in closing period; endpoint deleting connection", scid());
+                log::debug(log_cat, "Note: connection (CID: {}) is in closing period; endpoint deleting connection", scid());
                 _endpoint.delete_connection(scid());
             });
             return;
@@ -242,7 +241,7 @@ namespace oxen::quic
 
         if (is_draining())
         {
-            log::debug(log_cat, "Error: connection is already draining; dropping");
+            log::debug(log_cat, "Note: connection is already draining; dropping");
         }
 
         if (read_packet(pkt).success())

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -221,6 +221,14 @@ namespace oxen::quic
         return "{:02x}"_format(fmt::join(std::begin(data), std::begin(data) + datalen, ""));
     }
 
+    void Connection::halt_events()
+    {
+        log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
+        packet_io_trigger.reset();
+        packet_retransmit_timer.reset();
+        log::debug(log_cat, "Connection (CID: {}) io trigger/retransmit timer events halted");
+    }
+
     void Connection::packet_io_ready()
     {
         event_active(packet_io_trigger.get(), 0, 0);
@@ -374,7 +382,7 @@ namespace oxen::quic
         });
     }
 
-    void Connection::call_closing()
+    void Connection::call_close_cb()
     {
         if (!on_closing)
             return;

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -98,12 +98,18 @@ namespace oxen::quic
 
         setup_job_waker();
 
+        std::promise<void> p;
+
         loop_thread.emplace([this]() mutable {
             log::debug(log_cat, "Starting event loop run");
             event_base_loop(ev_loop.get(), EVLOOP_NO_EXIT_ON_EMPTY);
             log::debug(log_cat, "Event loop run returned, thread finished");
         });
+
+        call([&p]() { p.set_value(); });
+
         loop_thread_id = loop_thread->get_id();
+        p.get_future().get();
 
         running.store(true);
         log::info(log_cat, "Network is started");

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -112,9 +112,13 @@ namespace oxen::quic
     Network::~Network()
     {
         log::info(log_cat, "Shutting down network...");
-        close().get();
+
+        if (running.exchange(false))
+            shutdown(true);
+
         if (loop_thread)
             loop_thread->join();
+
         log::info(log_cat, "Network shutdown complete");
 
 #ifdef _WIN32
@@ -137,40 +141,57 @@ namespace oxen::quic
         assert(job_waker);
     }
 
-    std::future<void> Network::close(bool graceful)
+    void Network::shutdown(bool immediate)
     {
-        auto prom = std::make_shared<std::promise<void>>();
-        auto fut = prom->get_future();
-        if (not running.exchange(false))
+        log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
+
+        bool was_off = !running.exchange(false);
+
+        if (was_off)
+            log::warning(log_cat, "Network was not running prior to shutdown");
+
+        immediate = immediate or was_off;
+
+        if (!immediate)
         {
-            prom->set_value();
-            return fut;
+            log::info(log_cat, "Shutting network down gracefully");
+            close_gracefully();
         }
-
-        log::info(log_cat, "Shutting down Network...");
-
-        call([this, prom, &graceful]() mutable {
-            // If we have no endpoints we can just shut down immediately
-            if (endpoint_map.empty() || !graceful)
-                return close_final(std::move(prom));
-
-            // Otherwise we need to initiate closing
-            close_all(std::move(prom));
-        });
-
-        return fut;
+        else
+        {
+            log::warning(log_cat, "Shutting network down immediately");
+            close_immediate();
+        }
     }
 
-    void Network::close_final(std::shared_ptr<std::promise<void>> done)
+    void Network::close_immediate()
     {
+        log::debug(log_cat, "{} called", __PRETTY_FUNCTION__);
 
         endpoint_map.clear();
 
         if (loop_thread)
-            event_base_loopexit(ev_loop.get(), nullptr);
+            event_base_loopbreak(ev_loop.get());
+    }
 
-        if (done)
-            done->set_value();
+    void Network::close_gracefully()
+    {
+        log::info(log_cat, "{} called", __PRETTY_FUNCTION__);
+
+        std::promise<void> pr;
+        auto ft = pr.get_future();
+
+        call([&]() mutable {
+            for (const auto& ep : endpoint_map)
+                ep->close_conns();
+
+            pr.set_value();
+        });
+
+        ft.get();
+
+        if (loop_thread)
+            event_base_loopexit(ev_loop.get(), nullptr);
     }
 
     bool Network::in_event_loop() const
@@ -210,20 +231,6 @@ namespace oxen::quic
             loop_trace_log(log_cat, src, "Event loop calling `{}`", src.function_name());
             job.first();
         }
-    }
-
-    // TODO (Tom): for graceful shutdown, how best to wait until clients and servers have properly disconnected
-    void Network::close_all(std::shared_ptr<std::promise<void>> done)
-    {
-        call([this, done = std::move(done)]() mutable {
-            for (const auto& ep : endpoint_map)
-                ep->close_conns();
-            // FIXME TODO
-            log::critical(
-                    log_cat,
-                    "FIXME: need to properly get a call to close_final() to happen here *after* shutdown is complete");
-            close_final(done);
-        });
     }
 
 }  // namespace oxen::quic

--- a/tests/001-handshake.cpp
+++ b/tests/001-handshake.cpp
@@ -37,7 +37,7 @@ namespace oxen::quic::test
             auto ep = test_net.endpoint(default_addr);
             // Note: kernel chooses a random port after being passed default addr
             REQUIRE_FALSE(ep->local().to_string() == default_addr.to_string());
-            test_net.close();
+            test_net.shutdown();
         };
 
         SECTION("Endpoint::listen() - TLS credentials")
@@ -51,7 +51,7 @@ namespace oxen::quic::test
 
             REQUIRE_THROWS(ep_notls->listen());
             REQUIRE_NOTHROW(ep_tls->listen(local_tls));
-            test_net.close();
+            test_net.shutdown();
         };
 
         SECTION("Endpoint::listen() - Default addressing")
@@ -63,7 +63,7 @@ namespace oxen::quic::test
             auto ep = test_net.endpoint(default_addr);
 
             REQUIRE_NOTHROW(ep->listen(local_tls));
-            test_net.close();
+            test_net.shutdown();
         };
 
         SECTION("Endpoint::connect() - Default addressing")
@@ -82,7 +82,7 @@ namespace oxen::quic::test
 
             auto client_endpoint = test_net.endpoint(client_local);
             REQUIRE_NOTHROW(client_endpoint->connect(client_remote, client_tls));
-            test_net.close();
+            test_net.shutdown();
         };
 
         SECTION("Endpoint::connect() - Specific Addressing")
@@ -103,7 +103,7 @@ namespace oxen::quic::test
             // no client TLS passed
             REQUIRE_THROWS(client_endpoint->connect(client_remote));
             REQUIRE_NOTHROW(client_endpoint->connect(client_remote, client_tls));
-            test_net.close();
+            test_net.shutdown();
         };
     };
 
@@ -145,7 +145,7 @@ namespace oxen::quic::test
 
             REQUIRE(tls_future.get());
 
-            test_net.close();
+            test_net.shutdown();
         };
     };
 
@@ -182,7 +182,7 @@ namespace oxen::quic::test
             auto conn_interface = client_endpoint->connect(client_remote, client_tls);
 
             REQUIRE(tls_future.valid());
-            test_net.close();
+            test_net.shutdown();
         };
 
         SECTION("Successful TLS handshake")
@@ -216,7 +216,7 @@ namespace oxen::quic::test
             auto conn_interface = client_endpoint->connect(client_remote, client_tls);
 
             REQUIRE(tls_future.get());
-            test_net.close();
+            test_net.shutdown();
         };
     };
 }  // namespace oxen::quic::test

--- a/tests/002-send-receive.cpp
+++ b/tests/002-send-receive.cpp
@@ -43,6 +43,6 @@ namespace oxen::quic::test
         REQUIRE_THROWS(client_stream->send(bad_msg));
 
         REQUIRE(d_future.get());
-        test_net.close();
+        test_net.shutdown();
     };
 }  // namespace oxen::quic::test

--- a/tests/002-send-receive.cpp
+++ b/tests/002-send-receive.cpp
@@ -43,6 +43,5 @@ namespace oxen::quic::test
         REQUIRE_THROWS(client_stream->send(bad_msg));
 
         REQUIRE(d_future.get());
-        test_net.shutdown();
     };
 }  // namespace oxen::quic::test

--- a/tests/003-multiclient.cpp
+++ b/tests/003-multiclient.cpp
@@ -109,6 +109,5 @@ namespace oxen::quic::test
         async_thread_b.join();
         async_thread_a.join();
         REQUIRE(data_check == 4);
-        test_net.shutdown();
     };
 }  // namespace oxen::quic::test

--- a/tests/003-multiclient.cpp
+++ b/tests/003-multiclient.cpp
@@ -109,6 +109,6 @@ namespace oxen::quic::test
         async_thread_b.join();
         async_thread_a.join();
         REQUIRE(data_check == 4);
-        test_net.close();
+        test_net.shutdown();
     };
 }  // namespace oxen::quic::test

--- a/tests/004-streams.cpp
+++ b/tests/004-streams.cpp
@@ -40,8 +40,6 @@ namespace oxen::quic::test
 
         REQUIRE(tls_future.get());
         REQUIRE(conn_interface->get_max_streams() == max_streams.stream_count);
-
-        test_net.shutdown();
     };
 
     TEST_CASE("004 - Multiple pending streams: streams available", "[004][streams][pending][config]")
@@ -77,7 +75,6 @@ namespace oxen::quic::test
 
         REQUIRE(data_future.get());
         REQUIRE(conn_interface->get_streams_available() == max_streams.stream_count - 1);
-        test_net.shutdown();
     };
 
     TEST_CASE("004 - Multiple pending streams: different remote settings", "[004][streams][pending][config]")
@@ -140,7 +137,6 @@ namespace oxen::quic::test
         REQUIRE(server_ci->get_streams_available() == client_config.stream_count);
         REQUIRE(client_ci->get_streams_available() == server_config.stream_count - 1);
         REQUIRE(server_ci->get_max_streams() == server_config.stream_count);
-        test_net.shutdown();
     };
 
     TEST_CASE("004 - Multiple pending streams: Execution", "[004][streams][pending][execute]")
@@ -259,7 +255,5 @@ namespace oxen::quic::test
         REQUIRE(f.get());
 
         REQUIRE(data_check == n_recvs);
-
-        test_net.shutdown();
     };
 }  // namespace oxen::quic::test

--- a/tests/005-chunked-sender.cpp
+++ b/tests/005-chunked-sender.cpp
@@ -110,7 +110,5 @@ namespace oxen::quic::test
                     "HELLO![CHUNK-1][CHUNK-2][CHUNK-3][Chunk-4][Chunk-5][Chunk-6][chunk-7][chunk-8][chunk-9][chunk-10]"
                     "Goodbye.");
         }
-
-        test_net.shutdown();
     };
 }  // namespace oxen::quic::test

--- a/tests/005-chunked-sender.cpp
+++ b/tests/005-chunked-sender.cpp
@@ -111,6 +111,6 @@ namespace oxen::quic::test
                     "Goodbye.");
         }
 
-        test_net.close();
+        test_net.shutdown();
     };
 }  // namespace oxen::quic::test

--- a/tests/006-server-send.cpp
+++ b/tests/006-server-send.cpp
@@ -63,7 +63,6 @@ namespace oxen::quic::test
         REQUIRE(client_future.get());
         REQUIRE(server_future.get());
         REQUIRE(data_check == 2);
-        test_net.shutdown();
     };
 
     TEST_CASE("006 - Server streams: Remote initiation, server send", "[006][server][streams][send][execute]")
@@ -177,6 +176,5 @@ namespace oxen::quic::test
 
         REQUIRE(server_futures[2].get());
         REQUIRE(data_check == 4);
-        test_net.shutdown();
     };
 }  // namespace oxen::quic::test

--- a/tests/006-server-send.cpp
+++ b/tests/006-server-send.cpp
@@ -7,179 +7,176 @@ namespace oxen::quic::test
 {
     using namespace std::literals;
 
-    TEST_CASE("006: Server creating streams and sending stream data", "[006][server][streams][send][execute]")
+    TEST_CASE("006 - Server streams: Direct creation and transmission", "[006][server][streams][send][execute]")
     {
-        SECTION("Server direct stream creation and data transmission to remote")
-        {
-            Network test_net{};
-            auto msg = "hello from the other siiiii-iiiiide"_bsv;
+        Network test_net{};
+        auto msg = "hello from the other siiiii-iiiiide"_bsv;
 
-            std::atomic<int> data_check{0};
+        std::atomic<int> data_check{0};
 
-            std::shared_ptr<Stream> server_stream;
+        std::shared_ptr<Stream> server_stream;
 
-            std::promise<bool> server_promise, client_promise, stream_promise;
-            std::future<bool> server_future = server_promise.get_future(), client_future = client_promise.get_future(),
-                              stream_future = stream_promise.get_future();
+        std::promise<bool> server_promise, client_promise, stream_promise;
+        std::future<bool> server_future = server_promise.get_future(), client_future = client_promise.get_future(),
+                          stream_future = stream_promise.get_future();
 
-            stream_open_callback server_io_open_cb = [&](IOChannel& s) {
-                log::debug(log_cat, "Calling server stream open callback... stream opened...");
-                server_stream = s.get_stream();
-                stream_promise.set_value(true);
-                return 0;
-            };
-
-            stream_data_callback server_io_data_cb = [&](IOChannel&, bstring_view) {
-                log::debug(log_cat, "Calling server stream data callback... data received... incrementing counter...");
-                data_check += 1;
-                server_promise.set_value(true);
-            };
-
-            stream_data_callback client_io_data_cb = [&](IOChannel&, bstring_view) {
-                log::debug(log_cat, "Calling client stream data callback... data received... incrementing counter...");
-                data_check += 1;
-                client_promise.set_value(true);
-            };
-
-            auto server_tls = GNUTLSCreds::make("./serverkey.pem"s, "./servercert.pem"s, "./clientcert.pem"s);
-            auto client_tls = GNUTLSCreds::make("./clientkey.pem"s, "./clientcert.pem"s, "./servercert.pem"s);
-
-            opt::local_addr server_local{};
-            opt::local_addr client_local{};
-
-            auto server_endpoint = test_net.endpoint(server_local);
-            REQUIRE(server_endpoint->listen(server_tls, server_io_open_cb, server_io_data_cb));
-
-            opt::remote_addr client_remote{"127.0.0.1"s, server_endpoint->local().port()};
-
-            auto client_endpoint = test_net.endpoint(client_local);
-            auto conn_interface = client_endpoint->connect(client_remote, client_tls, client_io_data_cb);
-
-            auto client_stream = conn_interface->get_new_stream();
-            client_stream->send(msg);
-
-            REQUIRE(stream_future.get());
-
-            server_stream->send(msg);
-
-            REQUIRE(client_future.get());
-            REQUIRE(server_future.get());
-            REQUIRE(data_check == 2);
-            test_net.close();
+        stream_open_callback server_io_open_cb = [&](IOChannel& s) {
+            log::debug(log_cat, "Calling server stream open callback... stream opened...");
+            server_stream = s.get_stream();
+            stream_promise.set_value(true);
+            return 0;
         };
 
-        SECTION("Server extracts stream initiated by remote client and transmits data")
+        stream_data_callback server_io_data_cb = [&](IOChannel&, bstring_view) {
+            log::debug(log_cat, "Calling server stream data callback... data received... incrementing counter...");
+            data_check += 1;
+            server_promise.set_value(true);
+        };
+
+        stream_data_callback client_io_data_cb = [&](IOChannel&, bstring_view) {
+            log::debug(log_cat, "Calling client stream data callback... data received... incrementing counter...");
+            data_check += 1;
+            client_promise.set_value(true);
+        };
+
+        auto server_tls = GNUTLSCreds::make("./serverkey.pem"s, "./servercert.pem"s, "./clientcert.pem"s);
+        auto client_tls = GNUTLSCreds::make("./clientkey.pem"s, "./clientcert.pem"s, "./servercert.pem"s);
+
+        opt::local_addr server_local{};
+        opt::local_addr client_local{};
+
+        auto server_endpoint = test_net.endpoint(server_local);
+        REQUIRE(server_endpoint->listen(server_tls, server_io_open_cb, server_io_data_cb));
+
+        opt::remote_addr client_remote{"127.0.0.1"s, server_endpoint->local().port()};
+
+        auto client_endpoint = test_net.endpoint(client_local);
+        auto conn_interface = client_endpoint->connect(client_remote, client_tls, client_io_data_cb);
+
+        auto client_stream = conn_interface->get_new_stream();
+        client_stream->send(msg);
+
+        REQUIRE(stream_future.get());
+
+        server_stream->send(msg);
+
+        REQUIRE(client_future.get());
+        REQUIRE(server_future.get());
+        REQUIRE(data_check == 2);
+        test_net.shutdown();
+    };
+
+    TEST_CASE("006 - Server streams: Remote initiation, server send", "[006][server][streams][send][execute]")
+    {
+        Network test_net{};
+        auto msg = "hello from the other siiiii-iiiiide"_bsv;
+        auto response = "okay okay i get it already"_bsv;
+
+        std::atomic<int> ci{0}, si{0};
+        std::atomic<int> data_check{0};
+
+        std::shared_ptr<Stream> server_extracted_stream, client_extracted_stream;
+        std::shared_ptr<connection_interface> server_ci;
+
+        std::vector<std::promise<bool>> server_promises{3}, client_promises{3};
+        std::vector<std::future<bool>> server_futures{3}, client_futures{3};
+
+        for (int i = 0; i < 3; ++i)
         {
-            Network test_net{};
-            auto msg = "hello from the other siiiii-iiiiide"_bsv;
-            auto response = "okay okay i get it already"_bsv;
+            server_futures[i] = server_promises[i].get_future();
+            client_futures[i] = client_promises[i].get_future();
+        }
 
-            std::atomic<int> ci{0}, si{0};
-            std::atomic<int> data_check{0};
-
-            std::shared_ptr<Stream> server_extracted_stream, client_extracted_stream;
-            std::shared_ptr<connection_interface> server_ci;
-
-            std::vector<std::promise<bool>> server_promises{3}, client_promises{3};
-            std::vector<std::future<bool>> server_futures{3}, client_futures{3};
-
-            for (int i = 0; i < 3; ++i)
+        stream_open_callback server_io_open_cb = [&](Stream& s) {
+            log::debug(log_cat, "Calling server stream open callback... stream opened...");
+            server_extracted_stream = s.get_stream();
+            try
             {
-                server_futures[i] = server_promises[i].get_future();
-                client_futures[i] = client_promises[i].get_future();
+                server_promises.at(si).set_value(true);
+                ++si;
             }
-
-            stream_open_callback server_io_open_cb = [&](Stream& s) {
-                log::debug(log_cat, "Calling server stream open callback... stream opened...");
-                server_extracted_stream = s.get_stream();
-                try
-                {
-                    server_promises.at(si).set_value(true);
-                    ++si;
-                }
-                catch (std::exception& e)
-                {
-                    throw std::runtime_error(e.what());
-                }
-                return 0;
-            };
-
-            stream_open_callback client_io_open_cb = [&](Stream& s) {
-                log::debug(log_cat, "Calling client stream open callback... stream opened...");
-                client_extracted_stream = s.get_stream();
-                try
-                {
-                    client_promises.at(ci).set_value(true);
-                    ++ci;
-                }
-                catch (std::exception& e)
-                {
-                    throw std::runtime_error(e.what());
-                }
-                return 0;
-            };
-
-            stream_data_callback server_io_data_cb = [&](Stream&, bstring_view) {
-                log::debug(log_cat, "Calling server stream data callback... data received... incrementing counter...");
-                data_check += 1;
-                try
-                {
-                    server_promises.at(si).set_value(true);
-                    ++si;
-                }
-                catch (std::exception& e)
-                {
-                    throw std::runtime_error(e.what());
-                }
-            };
-
-            stream_data_callback client_io_data_cb = [&](Stream&, bstring_view) {
-                log::debug(log_cat, "Calling client stream data callback... data received... incrementing counter...");
-                data_check += 1;
-                try
-                {
-                    client_promises.at(ci).set_value(true);
-                    ++ci;
-                }
-                catch (std::exception& e)
-                {
-                    throw std::runtime_error(e.what());
-                }
-            };
-
-            auto server_tls = GNUTLSCreds::make("./serverkey.pem"s, "./servercert.pem"s, "./clientcert.pem"s);
-            auto client_tls = GNUTLSCreds::make("./clientkey.pem"s, "./clientcert.pem"s, "./servercert.pem"s);
-
-            opt::local_addr server_local{};
-            opt::local_addr client_local{};
-
-            auto server_endpoint = test_net.endpoint(server_local);
-            REQUIRE(server_endpoint->listen(server_tls, server_io_data_cb, server_io_open_cb));
-
-            opt::remote_addr client_remote{"127.0.0.1"s, server_endpoint->local().port()};
-
-            auto client_endpoint = test_net.endpoint(client_local);
-            auto client_ci = client_endpoint->connect(client_remote, client_tls, client_io_data_cb, client_io_open_cb);
-
-            auto client_stream = client_ci->get_new_stream();
-            client_stream->send(msg);
-
-            REQUIRE(server_futures[0].get());
-            REQUIRE(server_futures[1].get());
-
-            server_extracted_stream->send(response);
-            server_ci = server_endpoint->get_all_conns(Direction::INBOUND).front();
-            auto server_stream = server_ci->get_new_stream();
-            server_stream->send(msg);
-
-            for (auto& c : client_futures)
-                REQUIRE(c.get());
-
-            client_extracted_stream->send(response);
-
-            REQUIRE(server_futures[2].get());
-            REQUIRE(data_check == 4);
-            test_net.close();
+            catch (std::exception& e)
+            {
+                throw std::runtime_error(e.what());
+            }
+            return 0;
         };
+
+        stream_open_callback client_io_open_cb = [&](Stream& s) {
+            log::debug(log_cat, "Calling client stream open callback... stream opened...");
+            client_extracted_stream = s.get_stream();
+            try
+            {
+                client_promises.at(ci).set_value(true);
+                ++ci;
+            }
+            catch (std::exception& e)
+            {
+                throw std::runtime_error(e.what());
+            }
+            return 0;
+        };
+
+        stream_data_callback server_io_data_cb = [&](Stream&, bstring_view) {
+            log::debug(log_cat, "Calling server stream data callback... data received... incrementing counter...");
+            data_check += 1;
+            try
+            {
+                server_promises.at(si).set_value(true);
+                ++si;
+            }
+            catch (std::exception& e)
+            {
+                throw std::runtime_error(e.what());
+            }
+        };
+
+        stream_data_callback client_io_data_cb = [&](Stream&, bstring_view) {
+            log::debug(log_cat, "Calling client stream data callback... data received... incrementing counter...");
+            data_check += 1;
+            try
+            {
+                client_promises.at(ci).set_value(true);
+                ++ci;
+            }
+            catch (std::exception& e)
+            {
+                throw std::runtime_error(e.what());
+            }
+        };
+
+        auto server_tls = GNUTLSCreds::make("./serverkey.pem"s, "./servercert.pem"s, "./clientcert.pem"s);
+        auto client_tls = GNUTLSCreds::make("./clientkey.pem"s, "./clientcert.pem"s, "./servercert.pem"s);
+
+        opt::local_addr server_local{};
+        opt::local_addr client_local{};
+
+        auto server_endpoint = test_net.endpoint(server_local);
+        REQUIRE(server_endpoint->listen(server_tls, server_io_data_cb, server_io_open_cb));
+
+        opt::remote_addr client_remote{"127.0.0.1"s, server_endpoint->local().port()};
+
+        auto client_endpoint = test_net.endpoint(client_local);
+        auto client_ci = client_endpoint->connect(client_remote, client_tls, client_io_data_cb, client_io_open_cb);
+
+        auto client_stream = client_ci->get_new_stream();
+        client_stream->send(msg);
+
+        REQUIRE(server_futures[0].get());
+        REQUIRE(server_futures[1].get());
+
+        server_extracted_stream->send(response);
+        server_ci = server_endpoint->get_all_conns(Direction::INBOUND).front();
+        auto server_stream = server_ci->get_new_stream();
+        server_stream->send(msg);
+
+        for (auto& c : client_futures)
+            REQUIRE(c.get());
+
+        client_extracted_stream->send(response);
+
+        REQUIRE(server_futures[2].get());
+        REQUIRE(data_check == 4);
+        test_net.shutdown();
     };
 }  // namespace oxen::quic::test

--- a/tests/007-datagrams.cpp
+++ b/tests/007-datagrams.cpp
@@ -15,179 +15,176 @@ namespace oxen::quic::test
 {
     using namespace std::literals;
 
-    TEST_CASE("007 - Datagram support: Types", "[007][datagrams][types]")
+    TEST_CASE("007 - Datagram support: Default type construction", "[007][datagrams][types]")
     {
-        SECTION("opt::enable_datagrams default construction behaviors")
-        {
-            Network test_net{};
+        Network test_net{};
 
-            const int bsize = 256;
+        const int bsize = 256;
 
-            opt::enable_datagrams default_dgram{},          // packet_splitting = false
-                    split_dgram{Splitting::ACTIVE},         // packet_splitting = true, policy = ::ACTIVE
-                    bsize_dgram{Splitting::ACTIVE, bsize};  // bufsize = 256
-            opt::local_addr default_addr{};
+        opt::enable_datagrams default_dgram{},          // packet_splitting = false
+                split_dgram{Splitting::ACTIVE},         // packet_splitting = true, policy = ::ACTIVE
+                bsize_dgram{Splitting::ACTIVE, bsize};  // bufsize = 256
+        opt::local_addr default_addr{};
 
-            auto server_tls = GNUTLSCreds::make("./serverkey.pem"s, "./servercert.pem"s, "./clientcert.pem"s);
+        auto server_tls = GNUTLSCreds::make("./serverkey.pem"s, "./servercert.pem"s, "./clientcert.pem"s);
 
-            // datagrams = false, packet_splitting = false, splitting_policy = ::NONE
-            auto vanilla_ep = test_net.endpoint(default_addr);
-            REQUIRE_NOTHROW(vanilla_ep->listen(server_tls));
+        // datagrams = false, packet_splitting = false, splitting_policy = ::NONE
+        auto vanilla_ep = test_net.endpoint(default_addr);
+        REQUIRE_NOTHROW(vanilla_ep->listen(server_tls));
 
-            REQUIRE_FALSE(vanilla_ep->datagrams_enabled());
-            REQUIRE_FALSE(vanilla_ep->packet_splitting_enabled());
-            REQUIRE(vanilla_ep->splitting_policy() == Splitting::NONE);
+        REQUIRE_FALSE(vanilla_ep->datagrams_enabled());
+        REQUIRE_FALSE(vanilla_ep->packet_splitting_enabled());
+        REQUIRE(vanilla_ep->splitting_policy() == Splitting::NONE);
 
-            // datagrams = true, packet_splitting = false, splitting_policy = ::NONE
-            auto default_ep = test_net.endpoint(default_addr, default_dgram);
-            REQUIRE_NOTHROW(default_ep->listen(server_tls));
+        // datagrams = true, packet_splitting = false, splitting_policy = ::NONE
+        auto default_ep = test_net.endpoint(default_addr, default_dgram);
+        REQUIRE_NOTHROW(default_ep->listen(server_tls));
 
-            REQUIRE(default_ep->datagrams_enabled());
-            REQUIRE_FALSE(default_ep->packet_splitting_enabled());
-            REQUIRE(default_ep->splitting_policy() == Splitting::NONE);
+        REQUIRE(default_ep->datagrams_enabled());
+        REQUIRE_FALSE(default_ep->packet_splitting_enabled());
+        REQUIRE(default_ep->splitting_policy() == Splitting::NONE);
 
-            // datagrams = true, packet_splitting = true
-            auto splitting_ep = test_net.endpoint(default_addr, split_dgram);
-            REQUIRE_NOTHROW(splitting_ep->listen(server_tls));
+        // datagrams = true, packet_splitting = true
+        auto splitting_ep = test_net.endpoint(default_addr, split_dgram);
+        REQUIRE_NOTHROW(splitting_ep->listen(server_tls));
 
-            REQUIRE(splitting_ep->datagrams_enabled());
-            REQUIRE(splitting_ep->packet_splitting_enabled());
-            REQUIRE(splitting_ep->splitting_policy() == Splitting::ACTIVE);
+        REQUIRE(splitting_ep->datagrams_enabled());
+        REQUIRE(splitting_ep->packet_splitting_enabled());
+        REQUIRE(splitting_ep->splitting_policy() == Splitting::ACTIVE);
 
-            // datagrams = true, packet_splitting = true
-            auto bufsize_ep = test_net.endpoint(default_addr, bsize_dgram);
-            REQUIRE_NOTHROW(bufsize_ep->listen(server_tls));
+        // datagrams = true, packet_splitting = true
+        auto bufsize_ep = test_net.endpoint(default_addr, bsize_dgram);
+        REQUIRE_NOTHROW(bufsize_ep->listen(server_tls));
 
-            REQUIRE(bufsize_ep->datagrams_enabled());
-            REQUIRE(bufsize_ep->packet_splitting_enabled());
-            REQUIRE(bufsize_ep->splitting_policy() == Splitting::ACTIVE);
-            REQUIRE(bufsize_ep->datagram_bufsize() == bsize);
+        REQUIRE(bufsize_ep->datagrams_enabled());
+        REQUIRE(bufsize_ep->packet_splitting_enabled());
+        REQUIRE(bufsize_ep->splitting_policy() == Splitting::ACTIVE);
+        REQUIRE(bufsize_ep->datagram_bufsize() == bsize);
 
-            test_net.close();
-        };
+        test_net.shutdown();
+    };
 
-        SECTION("Query max datagram size from datagram-disabled endpoint")
-        {
-            Network test_net{};
+    TEST_CASE("007 - Datagram support: Query param info from datagram-disabled endpoint", "[007][datagrams][types]")
+    {
+        Network test_net{};
 
-            std::promise<bool> tls;
-            std::future<bool> tls_future = tls.get_future();
+        std::promise<bool> tls;
+        std::future<bool> tls_future = tls.get_future();
 
-            gnutls_callback outbound_tls_cb =
-                    [&](gnutls_session_t, unsigned int, unsigned int, unsigned int, const gnutls_datum_t*) {
-                        log::debug(log_cat, "Calling client TLS callback... handshake completed...");
+        gnutls_callback outbound_tls_cb =
+                [&](gnutls_session_t, unsigned int, unsigned int, unsigned int, const gnutls_datum_t*) {
+                    log::debug(log_cat, "Calling client TLS callback... handshake completed...");
 
-                        tls.set_value(true);
-                        return 0;
-                    };
+                    tls.set_value(true);
+                    return 0;
+                };
 
-            opt::local_addr server_local{};
-            opt::local_addr client_local{};
+        opt::local_addr server_local{};
+        opt::local_addr client_local{};
 
-            auto server_tls = GNUTLSCreds::make("./serverkey.pem"s, "./servercert.pem"s, "./clientcert.pem"s);
-            auto client_tls = GNUTLSCreds::make("./clientkey.pem"s, "./clientcert.pem"s, "./servercert.pem"s);
-            client_tls->set_client_tls_policy(outbound_tls_cb);
+        auto server_tls = GNUTLSCreds::make("./serverkey.pem"s, "./servercert.pem"s, "./clientcert.pem"s);
+        auto client_tls = GNUTLSCreds::make("./clientkey.pem"s, "./clientcert.pem"s, "./servercert.pem"s);
+        client_tls->set_client_tls_policy(outbound_tls_cb);
 
-            auto server_endpoint = test_net.endpoint(server_local);
-            REQUIRE_NOTHROW(server_endpoint->listen(server_tls));
+        auto server_endpoint = test_net.endpoint(server_local);
+        REQUIRE_NOTHROW(server_endpoint->listen(server_tls));
 
-            opt::remote_addr client_remote{"127.0.0.1"s, server_endpoint->local().port()};
+        opt::remote_addr client_remote{"127.0.0.1"s, server_endpoint->local().port()};
 
-            auto client_endpoint = test_net.endpoint(client_local);
-            auto conn_interface = client_endpoint->connect(client_remote, client_tls);
+        auto client_endpoint = test_net.endpoint(client_local);
+        auto conn_interface = client_endpoint->connect(client_remote, client_tls);
 
-            REQUIRE(tls_future.get());
-            REQUIRE_FALSE(conn_interface->datagrams_enabled());
-            REQUIRE_FALSE(conn_interface->packet_splitting_enabled());
-            REQUIRE_FALSE(conn_interface->packet_splitting_enabled());
-            REQUIRE(conn_interface->get_max_datagram_size() == 0);
+        REQUIRE(tls_future.get());
+        REQUIRE_FALSE(conn_interface->datagrams_enabled());
+        REQUIRE_FALSE(conn_interface->packet_splitting_enabled());
+        REQUIRE_FALSE(conn_interface->packet_splitting_enabled());
+        REQUIRE(conn_interface->get_max_datagram_size() == 0);
 
-            test_net.close();
-        };
+        test_net.shutdown();
+    };
 
-        SECTION("Query max datagram size from default datagram-enabled endpoints")
-        {
-            Network test_net{};
+    TEST_CASE("007 - Datagram support: Query param info from default datagram-enabled endpoint", "[007][datagrams][types]")
+    {
+        Network test_net{};
 
-            std::promise<bool> tls;
-            std::future<bool> tls_future = tls.get_future();
+        std::promise<bool> tls;
+        std::future<bool> tls_future = tls.get_future();
 
-            gnutls_callback outbound_tls_cb =
-                    [&](gnutls_session_t, unsigned int, unsigned int, unsigned int, const gnutls_datum_t*) {
-                        log::debug(log_cat, "Calling client TLS callback... handshake completed...");
+        gnutls_callback outbound_tls_cb =
+                [&](gnutls_session_t, unsigned int, unsigned int, unsigned int, const gnutls_datum_t*) {
+                    log::debug(log_cat, "Calling client TLS callback... handshake completed...");
 
-                        tls.set_value(true);
-                        return 0;
-                    };
+                    tls.set_value(true);
+                    return 0;
+                };
 
-            opt::enable_datagrams default_gram{};
+        opt::enable_datagrams default_gram{};
 
-            opt::local_addr server_local{};
-            opt::local_addr client_local{};
+        opt::local_addr server_local{};
+        opt::local_addr client_local{};
 
-            auto server_tls = GNUTLSCreds::make("./serverkey.pem"s, "./servercert.pem"s, "./clientcert.pem"s);
-            auto client_tls = GNUTLSCreds::make("./clientkey.pem"s, "./clientcert.pem"s, "./servercert.pem"s);
-            client_tls->set_client_tls_policy(outbound_tls_cb);
+        auto server_tls = GNUTLSCreds::make("./serverkey.pem"s, "./servercert.pem"s, "./clientcert.pem"s);
+        auto client_tls = GNUTLSCreds::make("./clientkey.pem"s, "./clientcert.pem"s, "./servercert.pem"s);
+        client_tls->set_client_tls_policy(outbound_tls_cb);
 
-            auto server_endpoint = test_net.endpoint(server_local, default_gram);
-            REQUIRE_NOTHROW(server_endpoint->listen(server_tls));
+        auto server_endpoint = test_net.endpoint(server_local, default_gram);
+        REQUIRE_NOTHROW(server_endpoint->listen(server_tls));
 
-            opt::remote_addr client_remote{"127.0.0.1"s, server_endpoint->local().port()};
+        opt::remote_addr client_remote{"127.0.0.1"s, server_endpoint->local().port()};
 
-            auto client_endpoint = test_net.endpoint(client_local, default_gram);
-            auto conn_interface = client_endpoint->connect(client_remote, client_tls);
+        auto client_endpoint = test_net.endpoint(client_local, default_gram);
+        auto conn_interface = client_endpoint->connect(client_remote, client_tls);
 
-            REQUIRE(tls_future.get());
-            REQUIRE(conn_interface->datagrams_enabled());
-            REQUIRE_FALSE(conn_interface->packet_splitting_enabled());
-            REQUIRE_FALSE(conn_interface->packet_splitting_enabled());
+        REQUIRE(tls_future.get());
+        REQUIRE(conn_interface->datagrams_enabled());
+        REQUIRE_FALSE(conn_interface->packet_splitting_enabled());
+        REQUIRE_FALSE(conn_interface->packet_splitting_enabled());
 
-            std::this_thread::sleep_for(5ms);
-            REQUIRE(conn_interface->get_max_datagram_size() < MAX_PMTUD_UDP_PAYLOAD);
+        std::this_thread::sleep_for(5ms);
+        REQUIRE(conn_interface->get_max_datagram_size() < MAX_PMTUD_UDP_PAYLOAD);
 
-            test_net.close();
-        };
+        test_net.shutdown();
+    };
 
-        SECTION("Query max datagram size from split-datagram enabled endpoint")
-        {
-            Network test_net{};
+    TEST_CASE("007 - Datagram support: Query params from split-datagram enabled endpoint", "[007][datagrams][types]")
+    {
+        Network test_net{};
 
-            std::promise<bool> tls;
-            std::future<bool> tls_future = tls.get_future();
+        std::promise<bool> tls;
+        std::future<bool> tls_future = tls.get_future();
 
-            gnutls_callback outbound_tls_cb =
-                    [&](gnutls_session_t, unsigned int, unsigned int, unsigned int, const gnutls_datum_t*) {
-                        log::debug(log_cat, "Calling client TLS callback... handshake completed...");
+        gnutls_callback outbound_tls_cb =
+                [&](gnutls_session_t, unsigned int, unsigned int, unsigned int, const gnutls_datum_t*) {
+                    log::debug(log_cat, "Calling client TLS callback... handshake completed...");
 
-                        tls.set_value(true);
-                        return 0;
-                    };
+                    tls.set_value(true);
+                    return 0;
+                };
 
-            opt::enable_datagrams split_dgram{Splitting::ACTIVE};
-            opt::local_addr server_local{};
-            opt::local_addr client_local{};
+        opt::enable_datagrams split_dgram{Splitting::ACTIVE};
+        opt::local_addr server_local{};
+        opt::local_addr client_local{};
 
-            auto server_tls = GNUTLSCreds::make("./serverkey.pem"s, "./servercert.pem"s, "./clientcert.pem"s);
-            auto client_tls = GNUTLSCreds::make("./clientkey.pem"s, "./clientcert.pem"s, "./servercert.pem"s);
-            client_tls->set_client_tls_policy(outbound_tls_cb);
+        auto server_tls = GNUTLSCreds::make("./serverkey.pem"s, "./servercert.pem"s, "./clientcert.pem"s);
+        auto client_tls = GNUTLSCreds::make("./clientkey.pem"s, "./clientcert.pem"s, "./servercert.pem"s);
+        client_tls->set_client_tls_policy(outbound_tls_cb);
 
-            auto server_endpoint = test_net.endpoint(server_local, split_dgram);
-            REQUIRE_NOTHROW(server_endpoint->listen(server_tls));
+        auto server_endpoint = test_net.endpoint(server_local, split_dgram);
+        REQUIRE_NOTHROW(server_endpoint->listen(server_tls));
 
-            opt::remote_addr client_remote{"127.0.0.1"s, server_endpoint->local().port()};
+        opt::remote_addr client_remote{"127.0.0.1"s, server_endpoint->local().port()};
 
-            auto client_endpoint = test_net.endpoint(client_local, split_dgram);
-            auto conn_interface = client_endpoint->connect(client_remote, client_tls);
+        auto client_endpoint = test_net.endpoint(client_local, split_dgram);
+        auto conn_interface = client_endpoint->connect(client_remote, client_tls);
 
-            REQUIRE(tls_future.get());
-            REQUIRE(conn_interface->datagrams_enabled());
-            REQUIRE(conn_interface->packet_splitting_enabled());
+        REQUIRE(tls_future.get());
+        REQUIRE(conn_interface->datagrams_enabled());
+        REQUIRE(conn_interface->packet_splitting_enabled());
 
-            std::this_thread::sleep_for(5ms);
-            REQUIRE(conn_interface->get_max_datagram_size() < MAX_GREEDY_PMTUD_UDP_PAYLOAD);
+        std::this_thread::sleep_for(5ms);
+        REQUIRE(conn_interface->get_max_datagram_size() < MAX_GREEDY_PMTUD_UDP_PAYLOAD);
 
-            test_net.close();
-        };
+        test_net.shutdown();
     };
 
     TEST_CASE("007 - Datagram support: Execute, No Splitting Policy", "[007][datagrams][execute][nosplit]")
@@ -246,7 +243,7 @@ namespace oxen::quic::test
 
             REQUIRE(data_future.get());
 
-            test_net.close();
+            test_net.shutdown();
         };
     };
 
@@ -317,7 +314,7 @@ namespace oxen::quic::test
 
             REQUIRE(data_future.get());
             REQUIRE(data_counter == 1);
-            test_net.close();
+            test_net.shutdown();
         };
     };
 
@@ -414,7 +411,7 @@ namespace oxen::quic::test
 
             REQUIRE(server_ci->last_cleared() == 0);
 
-            test_net.close();
+            test_net.shutdown();
         };
     };
 
@@ -513,7 +510,7 @@ namespace oxen::quic::test
 
             REQUIRE(data_counter == int(n));
 
-            test_net.close();
+            test_net.shutdown();
         };
     };
 
@@ -614,7 +611,7 @@ namespace oxen::quic::test
             REQUIRE(counter == bufsize);
             REQUIRE(received == successful_msg);
 
-            test_net.close();
+            test_net.shutdown();
         };
 #endif
     };
@@ -743,7 +740,7 @@ namespace oxen::quic::test
 
             conn_interface->test_suite.datagram_flip_flop_enabled = false;
 
-            test_net.close();
+            test_net.shutdown();
         };
 #endif
     };

--- a/tests/007-datagrams.cpp
+++ b/tests/007-datagrams.cpp
@@ -60,8 +60,6 @@ namespace oxen::quic::test
         REQUIRE(bufsize_ep->packet_splitting_enabled());
         REQUIRE(bufsize_ep->splitting_policy() == Splitting::ACTIVE);
         REQUIRE(bufsize_ep->datagram_bufsize() == bsize);
-
-        test_net.shutdown();
     };
 
     TEST_CASE("007 - Datagram support: Query param info from datagram-disabled endpoint", "[007][datagrams][types]")
@@ -99,8 +97,6 @@ namespace oxen::quic::test
         REQUIRE_FALSE(conn_interface->packet_splitting_enabled());
         REQUIRE_FALSE(conn_interface->packet_splitting_enabled());
         REQUIRE(conn_interface->get_max_datagram_size() == 0);
-
-        test_net.shutdown();
     };
 
     TEST_CASE("007 - Datagram support: Query param info from default datagram-enabled endpoint", "[007][datagrams][types]")
@@ -142,8 +138,6 @@ namespace oxen::quic::test
 
         std::this_thread::sleep_for(5ms);
         REQUIRE(conn_interface->get_max_datagram_size() < MAX_PMTUD_UDP_PAYLOAD);
-
-        test_net.shutdown();
     };
 
     TEST_CASE("007 - Datagram support: Query params from split-datagram enabled endpoint", "[007][datagrams][types]")
@@ -183,8 +177,6 @@ namespace oxen::quic::test
 
         std::this_thread::sleep_for(5ms);
         REQUIRE(conn_interface->get_max_datagram_size() < MAX_GREEDY_PMTUD_UDP_PAYLOAD);
-
-        test_net.shutdown();
     };
 
     TEST_CASE("007 - Datagram support: Execute, No Splitting Policy", "[007][datagrams][execute][nosplit]")
@@ -242,8 +234,6 @@ namespace oxen::quic::test
             conn_interface->send_datagram(msg);
 
             REQUIRE(data_future.get());
-
-            test_net.shutdown();
         };
     };
 
@@ -314,7 +304,6 @@ namespace oxen::quic::test
 
             REQUIRE(data_future.get());
             REQUIRE(data_counter == 1);
-            test_net.shutdown();
         };
     };
 
@@ -410,8 +399,6 @@ namespace oxen::quic::test
             auto server_ci = server_endpoint->get_all_conns(Direction::INBOUND).front();
 
             REQUIRE(server_ci->last_cleared() == 0);
-
-            test_net.shutdown();
         };
     };
 
@@ -509,8 +496,6 @@ namespace oxen::quic::test
                 REQUIRE(f.get());
 
             REQUIRE(data_counter == int(n));
-
-            test_net.shutdown();
         };
     };
 
@@ -610,8 +595,6 @@ namespace oxen::quic::test
 
             REQUIRE(counter == bufsize);
             REQUIRE(received == successful_msg);
-
-            test_net.shutdown();
         };
 #endif
     };
@@ -739,8 +722,6 @@ namespace oxen::quic::test
             REQUIRE(conn_interface->test_suite.datagram_flip_flip_counter < (int)n);
 
             conn_interface->test_suite.datagram_flip_flop_enabled = false;
-
-            test_net.shutdown();
         };
 #endif
     };

--- a/tests/dgram-speed-client.cpp
+++ b/tests/dgram-speed-client.cpp
@@ -207,8 +207,6 @@ int main(int argc, char* argv[])
     fmt::print("Elapsed time: {:.5f}s\n", elapsed);
     fmt::print("Speed: {:.5f}MB/s\n", size / 1'000'000.0 / elapsed);
 
-    client_net.shutdown();
-
     return 0;
 #else
     log::error(log_cat, "Error: library must be compiled with cmake flag -DENABLE_PERF_TESTING=1 to enable test binaries");

--- a/tests/dgram-speed-client.cpp
+++ b/tests/dgram-speed-client.cpp
@@ -207,7 +207,7 @@ int main(int argc, char* argv[])
     fmt::print("Elapsed time: {:.5f}s\n", elapsed);
     fmt::print("Speed: {:.5f}MB/s\n", size / 1'000'000.0 / elapsed);
 
-    client_net.close();
+    client_net.shutdown();
 
     return 0;
 #else

--- a/tests/dgram-speed-server.cpp
+++ b/tests/dgram-speed-server.cpp
@@ -161,7 +161,7 @@ int main(int argc, char* argv[])
     t_fut.get();
 
     log::warning(test_cat, "Shutting down test server");
-    server_net.close();
+    server_net.shutdown();
 #else
     log::error(log_cat, "Error: library must be compiled with cmake flag -DENABLE_PERF_TESTING=1 to enable test binaries");
 #endif

--- a/tests/dgram-speed-server.cpp
+++ b/tests/dgram-speed-server.cpp
@@ -161,7 +161,6 @@ int main(int argc, char* argv[])
     t_fut.get();
 
     log::warning(test_cat, "Shutting down test server");
-    server_net.shutdown();
 #else
     log::error(log_cat, "Error: library must be compiled with cmake flag -DENABLE_PERF_TESTING=1 to enable test binaries");
 #endif

--- a/tests/speedtest-client.cpp
+++ b/tests/speedtest-client.cpp
@@ -368,7 +368,5 @@ int main(int argc, char* argv[])
     fmt::print("Elapsed time: {:.3f}s\n", elapsed);
     fmt::print("Speed: {:.3f}MB/s\n", size / 1'000'000.0 / elapsed);
 
-    client_net.shutdown();
-
     return 0;
 }

--- a/tests/speedtest-client.cpp
+++ b/tests/speedtest-client.cpp
@@ -368,7 +368,7 @@ int main(int argc, char* argv[])
     fmt::print("Elapsed time: {:.3f}s\n", elapsed);
     fmt::print("Speed: {:.3f}MB/s\n", size / 1'000'000.0 / elapsed);
 
-    client_net.close();
+    client_net.shutdown();
 
     return 0;
 }


### PR DESCRIPTION
Re-doing how `Network` is shut down both gracefully and immediately

Close handling looked like it became its own focus in #32, so pushed it to its own PR