### PR TITLE
Compile-time check for listen() having a tls credentials argument

### DIFF
--- a/include/quic/endpoint.hpp
+++ b/include/quic/endpoint.hpp
@@ -67,6 +67,11 @@ namespace oxen::quic
         template <typename... Opt>
         bool listen(Opt&&... opts)
         {
+
+            static_assert(
+                    (0 + ... + std::is_convertible_v<remove_cvref_t<Opt>, std::shared_ptr<TLSCreds>>) == 1,
+                    "Endpoint listen requires exactly one std::shared_ptr<TLSCreds> argument");
+
             std::promise<bool> p;
             auto f = p.get_future();
 

--- a/include/quic/utils.hpp
+++ b/include/quic/utils.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <type_traits>
+
 #include "format.hpp"
 
 extern "C"
@@ -133,6 +135,10 @@ namespace oxen::quic
     inline constexpr bool is_instantiation = false;
     template <template <typename...> class Class, typename... Us>
     inline constexpr bool is_instantiation<Class, Class<Us...>> = true;
+
+    // Backport of c++20 std::remove_cvref_t
+    template <typename T>
+    using remove_cvref_t = std::remove_cv_t<std::remove_reference_t<T>>;
 
     // Application error code we close with if the stream data handle throws
     inline constexpr uint64_t STREAM_ERROR_EXCEPTION = (1ULL << 62) - 2;

--- a/tests/001-handshake.cpp
+++ b/tests/001-handshake.cpp
@@ -50,7 +50,8 @@ namespace oxen::quic::test
             auto ep_notls = test_net.endpoint(default_addr);
             auto ep_tls = test_net.endpoint(local_addr);
 
-            // REQUIRE_THROWS(ep_notls->listen());  // Shouldn't compile if uncommented!
+            // ep_notls->listen();  // Shouldn't compile if uncommented!
+            // ep_notls->listen(local_tls, local_tls);  // Nor this
             REQUIRE_NOTHROW(ep_tls->listen(local_tls));
         };
 


### PR DESCRIPTION
This was throwing, but it's nicer to detect that failure case at compile time.