### PR TITLE
Throw an exception when a key doesn't exist + related changes

### DIFF
--- a/include/quic/utils.hpp
+++ b/include/quic/utils.hpp
@@ -163,6 +163,16 @@ namespace oxen::quic
         return {reinterpret_cast<const char*>(x.data()), x.size()};
     }
 
+    // Quasi-backport of C++20 str.starts_with/ends_with
+    inline constexpr bool starts_with(std::string_view str, std::string_view prefix)
+    {
+        return prefix.size() <= str.size() && str.substr(0, prefix.size()) == prefix;
+    }
+    inline constexpr bool ends_with(std::string_view str, std::string_view suffix)
+    {
+        return suffix.size() <= str.size() && str.substr(str.size() - suffix.size()) == suffix;
+    }
+
     void logger_config(std::string out = "stderr", log::Type type = log::Type::Print, log::Level reset = log::Level::trace);
 
     std::chrono::steady_clock::time_point get_time();


### PR DESCRIPTION
When running the test suite without keys existing, we were getting a cryptic error:

    due to unexpected exception with message:
      basic_string: construction from null is not valid

this commit addresses it by revamping the `datum` class, but cascaded into a few other related changes as well:

- Renames `datum` to `x509_loader` to better reflect its purpose.
- we now throw `invalid_argument` if the given input is neither neither an existing filename, nor something that looks like pem or der data.
- Use a variant of fs::path or std::string to fix undefined behaviour: when given in-memory data, we were pointing the `mem` at the passed-in string's data, but that goesn't out of scope at the end of the constructor, but we need to store this pointed-at data.
- Fix broken copy constructor/assignment that was memcpying the stuff in `mem` even though those are just pointers into who-knows-where memory that we don't own.
- Added move constructor/assignment op.
- Simplify conversion of path to c string, and make it implicitly convertible so that you can just pass the `x509_loader` instance to a gnutls argument expecting a `const char*` filename.
- Simplified cred-creation-from-ed25519 by using x509_loader instead of duplicating it by building its own gnutls_datum_t.
- Make the magic ASN.1 strings static constants instead of re-computed strings from hex in each call.