### PR TITLE
Fix promise sync in bool_waiter; rename to callback_waiter

### DIFF
--- a/tests/001-handshake.cpp
+++ b/tests/001-handshake.cpp
@@ -114,8 +114,8 @@ namespace oxen::quic::test
 
         SECTION("Endpoint::connect() - IPv6 Addressing")
         {
-            auto client_established = bool_waiter{[](connection_interface&) {}};
-            auto server_established = bool_waiter{[](connection_interface&) {}};
+            auto client_established = callback_waiter{[](connection_interface&) {}};
+            auto server_established = callback_waiter{[](connection_interface&) {}};
 
             Network test_net{};
 
@@ -134,16 +134,15 @@ namespace oxen::quic::test
 
             REQUIRE_NOTHROW(client_endpoint->connect(client_remote, client_tls));
 
-            REQUIRE(client_established.wait_ready());
-            REQUIRE(client_established.get());
-            REQUIRE(server_established.get());
+            REQUIRE(client_established.wait());
+            REQUIRE(server_established.wait());
         };
     };
 
     TEST_CASE("001 - Handshaking: Execution", "[001][handshake][tls][execute]")
     {
-        auto client_established = bool_waiter{[](connection_interface&) {}};
-        auto server_established = bool_waiter{[](connection_interface&) {}};
+        auto client_established = callback_waiter{[](connection_interface&) {}};
+        auto server_established = callback_waiter{[](connection_interface&) {}};
 
         Network test_net{};
 
@@ -161,9 +160,7 @@ namespace oxen::quic::test
         auto client_endpoint = test_net.endpoint(client_local, client_established);
         auto conn_interface = client_endpoint->connect(client_remote, client_tls);
 
-        REQUIRE(client_established.wait_ready());
-        REQUIRE(server_established.wait_ready());
-        REQUIRE(client_established.get());
-        REQUIRE(server_established.get());
+        REQUIRE(client_established.wait());
+        REQUIRE(server_established.wait());
     };
 }  // namespace oxen::quic::test

--- a/tests/002-send-receive.cpp
+++ b/tests/002-send-receive.cpp
@@ -163,7 +163,7 @@ namespace oxen::quic::test
 
         SECTION("Client sends a command")
         {
-            auto server_bp_cb = bool_waiter{[&](message msg) {
+            auto server_bp_cb = callback_waiter{[&](message msg) {
                 if (msg)
                     log::info(log_cat, "Server bparser received: {}", msg.view());
             }};
@@ -184,12 +184,12 @@ namespace oxen::quic::test
 
             client_bp->command("test_endpoint"s, "test_request_body"s);
 
-            REQUIRE(server_bp_cb.get());
+            REQUIRE(server_bp_cb.wait());
         }
 
         SECTION("Client sends a request, server sends a response")
         {
-            auto server_bp_cb = bool_waiter{[&](message msg) {
+            auto server_bp_cb = callback_waiter{[&](message msg) {
                 if (msg)
                 {
                     log::info(log_cat, "Server bparser received: {}", msg.view());
@@ -197,7 +197,7 @@ namespace oxen::quic::test
                 }
             }};
 
-            auto client_bp_cb = bool_waiter{[&](message msg) {
+            auto client_bp_cb = callback_waiter{[&](message msg) {
                 if (msg)
                 {
                     log::info(log_cat, "Client bparser received: {}", msg.view());
@@ -225,13 +225,13 @@ namespace oxen::quic::test
 
             client_bp->request("test_endpoint"s, "test_request_body"s);
 
-            REQUIRE(server_bp_cb.get());
-            REQUIRE(client_bp_cb.get());
+            REQUIRE(server_bp_cb.wait());
+            REQUIRE(client_bp_cb.wait());
         }
 
         SECTION("Client (alternate construction) sends a request, server sends a response")
         {
-            auto server_bp_cb = bool_waiter{[&](message msg) {
+            auto server_bp_cb = callback_waiter{[&](message msg) {
                 if (msg)
                 {
                     log::info(log_cat, "Server bparser received: {}", msg.view());
@@ -239,7 +239,7 @@ namespace oxen::quic::test
                 }
             }};
 
-            auto client_bp_cb = bool_waiter{[&](message msg) {
+            auto client_bp_cb = callback_waiter{[&](message msg) {
                 if (msg)
                 {
                     log::info(log_cat, "Client bparser received: {}", msg.view());
@@ -263,8 +263,8 @@ namespace oxen::quic::test
 
             client_bp->request("test_endpoint"s, "test_request_body"s);
 
-            REQUIRE(server_bp_cb.get());
-            REQUIRE(client_bp_cb.get());
+            REQUIRE(server_bp_cb.wait());
+            REQUIRE(client_bp_cb.wait());
         }
     };
 

--- a/tests/004-streams.cpp
+++ b/tests/004-streams.cpp
@@ -11,7 +11,7 @@ namespace oxen::quic::test
 
     TEST_CASE("004 - Multiple pending streams: max stream count", "[004][streams][pending][config]")
     {
-        auto client_established = bool_waiter{[](connection_interface&) {}};
+        auto client_established = callback_waiter{[](connection_interface&) {}};
 
         Network test_net{};
 
@@ -31,7 +31,7 @@ namespace oxen::quic::test
         auto client_endpoint = test_net.endpoint(client_local, client_established);
         auto conn_interface = client_endpoint->connect(client_remote, client_tls, max_streams);
 
-        REQUIRE(client_established.wait_ready());
+        REQUIRE(client_established.wait());
         REQUIRE(conn_interface->get_max_streams() == max_streams.stream_count);
     };
 
@@ -72,7 +72,7 @@ namespace oxen::quic::test
 
     TEST_CASE("004 - Multiple pending streams: different remote settings", "[004][streams][pending][config]")
     {
-        auto client_established = bool_waiter{[](connection_interface&) {}};
+        auto client_established = callback_waiter{[](connection_interface&) {}};
 
         Network test_net{};
         auto msg = "hello from the other siiiii-iiiiide"_bsv;
@@ -102,7 +102,7 @@ namespace oxen::quic::test
         auto client_endpoint = test_net.endpoint(client_local, client_established);
         auto client_ci = client_endpoint->connect(client_remote, client_tls, client_config);
 
-        REQUIRE(client_established.wait_ready());
+        REQUIRE(client_established.wait());
 
         server_ci = server_endpoint->get_all_conns(Direction::INBOUND).front();
         // some transport parameters are set after handshake is completed; querying the client connection too
@@ -127,7 +127,7 @@ namespace oxen::quic::test
 
     TEST_CASE("004 - Multiple pending streams: Execution", "[004][streams][pending][execute]")
     {
-        auto client_established = bool_waiter{[](connection_interface&) {}};
+        auto client_established = callback_waiter{[](connection_interface&) {}};
 
         Network test_net{};
         auto msg = "hello from the other siiiii-iiiiide"_bsv;
@@ -179,7 +179,7 @@ namespace oxen::quic::test
         auto client_endpoint = test_net.endpoint(client_local, client_established);
         auto conn_interface = client_endpoint->connect(client_remote, client_tls, max_streams);
 
-        REQUIRE(client_established.wait_ready());
+        REQUIRE(client_established.wait());
 
         for (int i = 0; i < n_streams; ++i)
         {
@@ -418,8 +418,8 @@ namespace oxen::quic::test
         std::shared_ptr<CustomStreamB> server_b, client_b;
         std::shared_ptr<CustomStreamC> server_c, client_c;
 
-        auto client_established = bool_waiter{[](connection_interface&) {}};
-        auto server_closed = bool_waiter{[](connection_interface&, uint64_t) {}};
+        auto client_established = callback_waiter{[](connection_interface&) {}};
+        auto server_closed = callback_waiter{[](connection_interface&, uint64_t) {}};
 
         SECTION("Stream logic using connection open callback")
         {
@@ -446,7 +446,7 @@ namespace oxen::quic::test
             auto client_endpoint = test_net.endpoint(client_local, client_established);
             auto client_ci = client_endpoint->connect(client_remote, client_tls);
 
-            REQUIRE(client_established.wait_ready());
+            REQUIRE(client_established.wait());
 
             log::info(bp_cat, "Client opening Custom Stream A!");
             client_a = client_ci->get_new_stream<CustomStreamA>(std::move(cp1));
@@ -464,7 +464,7 @@ namespace oxen::quic::test
             REQUIRE(sf3.get());
 
             client_ci->close_connection();
-            REQUIRE(server_closed.get());
+            REQUIRE(server_closed.wait());
         }
 
         SECTION("Stream logic using stream constructor callback")
@@ -505,7 +505,7 @@ namespace oxen::quic::test
             auto client_endpoint = test_net.endpoint(client_local, client_established);
             auto client_ci = client_endpoint->connect(client_remote, client_tls);
 
-            REQUIRE(client_established.wait_ready());
+            REQUIRE(client_established.wait());
 
             log::info(bp_cat, "Client opening Custom Stream A!");
             client_a = client_ci->get_new_stream<CustomStreamA>(std::move(cp1));
@@ -523,7 +523,7 @@ namespace oxen::quic::test
             REQUIRE(sf3.get());
 
             client_ci->close_connection();
-            REQUIRE(server_closed.get());
+            REQUIRE(server_closed.wait());
         }
     };
 

--- a/tests/007-datagrams.cpp
+++ b/tests/007-datagrams.cpp
@@ -64,7 +64,7 @@ namespace oxen::quic::test
 
     TEST_CASE("007 - Datagram support: Query param info from datagram-disabled endpoint", "[007][datagrams][types]")
     {
-        auto client_established = bool_waiter{[](connection_interface&) {}};
+        auto client_established = callback_waiter{[](connection_interface&) {}};
 
         Network test_net{};
 
@@ -82,7 +82,7 @@ namespace oxen::quic::test
         auto client_endpoint = test_net.endpoint(client_local, client_established);
         auto conn_interface = client_endpoint->connect(client_remote, client_tls);
 
-        REQUIRE(client_established.wait_ready());
+        REQUIRE(client_established.wait());
         REQUIRE_FALSE(conn_interface->datagrams_enabled());
         REQUIRE_FALSE(conn_interface->packet_splitting_enabled());
         REQUIRE_FALSE(conn_interface->packet_splitting_enabled());
@@ -91,7 +91,7 @@ namespace oxen::quic::test
 
     TEST_CASE("007 - Datagram support: Query param info from default datagram-enabled endpoint", "[007][datagrams][types]")
     {
-        auto client_established = bool_waiter{[](connection_interface&) {}};
+        auto client_established = callback_waiter{[](connection_interface&) {}};
 
         Network test_net{};
 
@@ -111,7 +111,7 @@ namespace oxen::quic::test
         auto client_endpoint = test_net.endpoint(client_local, default_gram, client_established);
         auto conn_interface = client_endpoint->connect(client_remote, client_tls);
 
-        REQUIRE(client_established.wait_ready());
+        REQUIRE(client_established.wait());
         REQUIRE(conn_interface->datagrams_enabled());
         REQUIRE_FALSE(conn_interface->packet_splitting_enabled());
         REQUIRE_FALSE(conn_interface->packet_splitting_enabled());
@@ -122,7 +122,7 @@ namespace oxen::quic::test
 
     TEST_CASE("007 - Datagram support: Query params from split-datagram enabled endpoint", "[007][datagrams][types]")
     {
-        auto client_established = bool_waiter{[](connection_interface&) {}};
+        auto client_established = callback_waiter{[](connection_interface&) {}};
 
         Network test_net{};
 
@@ -141,7 +141,7 @@ namespace oxen::quic::test
         auto client_endpoint = test_net.endpoint(client_local, split_dgram, client_established);
         auto conn_interface = client_endpoint->connect(client_remote, client_tls);
 
-        REQUIRE(client_established.get());
+        REQUIRE(client_established.wait());
         REQUIRE(conn_interface->datagrams_enabled());
         REQUIRE(conn_interface->packet_splitting_enabled());
 
@@ -153,7 +153,7 @@ namespace oxen::quic::test
     {
         SECTION("Simple datagram transmission")
         {
-            auto client_established = bool_waiter{[](connection_interface&) {}};
+            auto client_established = callback_waiter{[](connection_interface&) {}};
 
             Network test_net{};
             auto msg = "hello from the other siiiii-iiiiide"_bsv;
@@ -183,7 +183,7 @@ namespace oxen::quic::test
             auto client = test_net.endpoint(client_local, default_gram, client_established);
             auto conn_interface = client->connect(client_remote, client_tls);
 
-            REQUIRE(client_established.wait_ready());
+            REQUIRE(client_established.wait());
             REQUIRE(server_endpoint->datagrams_enabled());
             REQUIRE(client->datagrams_enabled());
 
@@ -203,7 +203,7 @@ namespace oxen::quic::test
     {
         SECTION("Simple datagram transmission")
         {
-            auto client_established = bool_waiter{[](connection_interface&) {}};
+            auto client_established = callback_waiter{[](connection_interface&) {}};
 
             Network test_net{};
 
@@ -234,7 +234,7 @@ namespace oxen::quic::test
             auto client = test_net.endpoint(client_local, split_dgram, client_established);
             auto conn_interface = client->connect(client_remote, client_tls);
 
-            REQUIRE(client_established.wait_ready());
+            REQUIRE(client_established.wait());
             REQUIRE(server_endpoint->datagrams_enabled());
             REQUIRE(client->datagrams_enabled());
 
@@ -270,7 +270,7 @@ namespace oxen::quic::test
         SECTION("Simple oversized datagram transmission - Clear first row")
         {
             log::trace(log_cat, "Beginning the unit test from hell");
-            auto client_established = bool_waiter{[](connection_interface&) {}};
+            auto client_established = callback_waiter{[](connection_interface&) {}};
 
             Network test_net{};
 
@@ -315,7 +315,7 @@ namespace oxen::quic::test
             auto client = test_net.endpoint(client_local, split_dgram, client_established);
             auto conn_interface = client->connect(client_remote, client_tls);
 
-            REQUIRE(client_established.wait_ready());
+            REQUIRE(client_established.wait());
 
             REQUIRE(server_endpoint->datagrams_enabled());
             REQUIRE(client->datagrams_enabled());
@@ -355,7 +355,7 @@ namespace oxen::quic::test
         SECTION("Simple datagram transmission - mixed sizes")
         {
             log::trace(log_cat, "Beginning the unit test from hell");
-            auto client_established = bool_waiter{[](connection_interface&) {}};
+            auto client_established = callback_waiter{[](connection_interface&) {}};
 
             Network test_net{};
 
@@ -400,7 +400,7 @@ namespace oxen::quic::test
             auto client = test_net.endpoint(client_local, split_dgram, client_established);
             auto conn_interface = client->connect(client_remote, client_tls);
 
-            REQUIRE(client_established.wait_ready());
+            REQUIRE(client_established.wait());
 
             REQUIRE(server_endpoint->datagrams_enabled());
             REQUIRE(client->datagrams_enabled());
@@ -443,7 +443,7 @@ namespace oxen::quic::test
         SECTION("Simple datagram transmission - induced loss")
         {
             log::trace(log_cat, "Beginning the unit test from hell");
-            auto client_established = bool_waiter{[](connection_interface&) {}};
+            auto client_established = callback_waiter{[](connection_interface&) {}};
 
             Network test_net{};
 
@@ -492,7 +492,7 @@ namespace oxen::quic::test
             auto client = test_net.endpoint(client_local, split_dgram, client_established);
             auto conn_interface = client->connect(client_remote, client_tls);
 
-            REQUIRE(client_established.wait_ready());
+            REQUIRE(client_established.wait());
 
             auto server_ci = server_endpoint->get_all_conns(Direction::INBOUND).front();
 
@@ -539,7 +539,7 @@ namespace oxen::quic::test
         SECTION("Simple datagram transmission - flip flop ordering")
         {
             log::trace(log_cat, "Beginning the unit test from hell");
-            auto client_established = bool_waiter{[](connection_interface&) {}};
+            auto client_established = callback_waiter{[](connection_interface&) {}};
 
             Network test_net{};
 
@@ -585,7 +585,7 @@ namespace oxen::quic::test
             auto client = test_net.endpoint(client_local, split_dgram, client_established);
             auto conn_interface = client->connect(client_remote, client_tls);
 
-            REQUIRE(client_established.wait_ready());
+            REQUIRE(client_established.wait());
 
             std::this_thread::sleep_for(5ms);
             auto max_size = conn_interface->get_max_datagram_size();


### PR DESCRIPTION
We were setting the promise in bool_waiter *before* we call the wrapped lambda, but that introduces a race condition because we have test code that waits on the promise and then checks a value that it expects to have been set inside the lambda.

This reverses it so that the promise is set *after* the lambda is called.

While here, I also refactored this to a `promise<void>` since we are never actually meaningfully using the `bool` value (it is only ever set to `true`) and removed the `get()` function (since the only difference between it and `wait_ready()` is that `get()` can hang forever), and then since it isn't a "bool" waiter anymore, renamed the whole thing to callback_waiter.

Edit: also renamed `wait_ready` to `wait`

Also documented its usage.