### PR TITLE
Add non-public range lists

### DIFF
--- a/include/quic/address.hpp
+++ b/include/quic/address.hpp
@@ -62,7 +62,30 @@ namespace oxen::quic
             return *this;
         }
 
+        // Converts an IPv4 address into an IPv4-mapped IPv6 address.  The address must already be
+        // an IPv4 address (throws if not).
         void map_ipv4_as_ipv6();
+
+        // Returns true if this address is an IPv4-mapped IPv6 address.
+        bool is_ipv4_mapped_ipv6() const;
+
+        // Undoes `map_ipv4_as_ipv6`, converting the address to an IPv4 address; the address must be
+        // a IPv4-mapped IPv6 address (throws if not).
+        void unmap_ipv4_from_ipv6();
+
+        // Wrappers around map_.../unmap_... that return a mapped/unmapped copy.
+        Address mapped_ipv4_as_ipv6() const
+        {
+            Address tmp{*this};
+            tmp.map_ipv4_as_ipv6();
+            return tmp;
+        }
+        Address unmapped_ipv4_from_ipv6() const
+        {
+            Address tmp{*this};
+            tmp.unmap_ipv4_from_ipv6();
+            return tmp;
+        }
 
         bool is_set() const { return is_ipv4() || is_ipv6(); }
 

--- a/include/quic/address.hpp
+++ b/include/quic/address.hpp
@@ -103,6 +103,10 @@ namespace oxen::quic
         /// Returns true if this is an addressable address, i.e. not the "any" address or port
         bool is_addressable() const { return !is_any_addr() && !is_any_port(); }
 
+        /// Returns true if this is an addressable, public IP (i.e. addressable and not in a private
+        /// range).
+        bool is_public() const;
+
         inline bool is_ipv4() const
         {
             return _addr.addrlen == sizeof(sockaddr_in) &&

--- a/src/address.cpp
+++ b/src/address.cpp
@@ -1,5 +1,7 @@
 #include "address.hpp"
 
+#include <oxenc/endian.h>
+
 namespace oxen::quic
 {
     Address::Address(const std::string& addr, uint16_t port)
@@ -29,7 +31,7 @@ namespace oxen::quic
         if (rv == 0)  // inet_pton returns this on invalid input
             throw std::invalid_argument{"Cannot construct address: invalid IP"};
         if (rv < 0)
-            std::system_error{errno, std::system_category()};
+            throw std::system_error{errno, std::system_category()};
     }
 
     void Address::map_ipv4_as_ipv6()
@@ -63,6 +65,162 @@ namespace oxen::quic
         std::memcpy(&a4.sin_addr.s_addr, &a6.sin6_addr.s6_addr[12], 4);
         std::memcpy(&_sock_addr, &a4, sizeof(a4));
         update_socklen(sizeof(a4));
+    }
+
+    namespace
+    {
+        struct ipv4
+        {
+            uint32_t addr;
+            constexpr ipv4(uint32_t a) : addr{a} {}
+            constexpr ipv4(uint8_t a, uint8_t b, uint8_t c, uint8_t d) :
+                    ipv4{uint32_t{a} << 24 | uint32_t{b} << 16 | uint32_t{c} << 8 | uint32_t{d}}
+            {}
+
+            constexpr bool operator==(const ipv4& a) const { return addr == a.addr; }
+
+            constexpr ipv4 to_base(uint8_t mask) const
+            {
+                return mask < 32 ? ipv4{(addr >> (32 - mask)) << (32 - mask)} : *this;
+            }
+        };
+
+        struct ipv4_net
+        {
+            ipv4 base;
+            uint8_t mask;
+
+            constexpr bool contains(const ipv4& addr) const { return addr.to_base(mask) == base; }
+        };
+
+        constexpr ipv4_net operator/(const ipv4& a, uint8_t mask)
+        {
+            return ipv4_net{a.to_base(mask), mask};
+        }
+
+        static_assert((ipv4(10, 0, 0, 0) / 8).contains(ipv4(10, 0, 0, 0)));
+        static_assert((ipv4(10, 0, 0, 0) / 8).contains(ipv4(10, 255, 255, 255)));
+        static_assert((ipv4(10, 123, 45, 67) / 8).contains(ipv4(10, 123, 123, 123)));
+        static_assert((ipv4(10, 255, 255, 255) / 8).contains(ipv4(10, 0, 0, 0)));
+        static_assert((ipv4(10, 255, 255, 255) / 8).contains(ipv4(10, 123, 123, 123)));
+        static_assert(not(ipv4(10, 0, 0, 0) / 8).contains(ipv4(11, 0, 0, 0)));
+        static_assert(not(ipv4(10, 0, 0, 0) / 8).contains(ipv4(9, 255, 255, 255)));
+
+        struct ipv6
+        {
+            uint64_t hi, lo;
+            ipv6(const unsigned char* addr) :
+                    hi{oxenc::load_big_to_host<uint64_t>(addr)}, lo{oxenc::load_big_to_host<uint64_t>(addr + 8)}
+            {}
+            constexpr ipv6(
+                    uint16_t a = 0x0000,
+                    uint16_t b = 0x0000,
+                    uint16_t c = 0x0000,
+                    uint16_t d = 0x0000,
+                    uint16_t e = 0x0000,
+                    uint16_t f = 0x0000,
+                    uint16_t g = 0x0000,
+                    uint16_t h = 0x0000) :
+                    hi{uint64_t{a} << 48 | uint64_t{b} << 32 | uint64_t{c} << 16 | uint64_t{d}},
+                    lo{uint64_t{e} << 48 | uint64_t{f} << 32 | uint64_t{g} << 16 | uint64_t{h}}
+            {}
+
+            constexpr bool operator==(const ipv6& a) const { return hi == a.hi && lo == a.lo; }
+
+            constexpr ipv6 to_base(uint8_t mask) const
+            {
+                ipv6 b;
+                if (mask >= 64)
+                {
+                    b.hi = hi;
+                    b.lo = mask < 128 ? (lo >> (128 - mask)) << (128 - mask) : lo;
+                }
+                else
+                {
+                    b.hi = (hi >> (64 - mask)) << (64 - mask);
+                }
+                return b;
+            }
+        };
+
+        struct ipv6_net
+        {
+            ipv6 base;
+            uint8_t mask;
+
+            constexpr bool contains(const ipv6& addr) const { return addr.to_base(mask) == base; }
+        };
+
+        constexpr ipv6_net operator/(const ipv6 a, uint8_t mask)
+        {
+            return {a.to_base(mask), mask};
+        }
+
+        static_assert((ipv6(0x2001, 0xdb8) / 32).contains(ipv6(0x2001, 0xdb8)));
+        static_assert((ipv6(0x2001, 0xdb8) / 32).contains(ipv6(0x2001, 0xdb8, 0xffff, 0xffff)));
+        static_assert((ipv6(0x2001, 0xdb8, 0xffff) / 32).contains(ipv6(0x2001, 0xdb8)));
+        static_assert((ipv6(0x2001, 0xdb8, 0xffff) / 32).contains(ipv6(0x2001, 0xdb8)));
+
+        const std::array ipv4_nonpublic = {
+                ipv4(0, 0, 0, 0) / 8,        // Special purpose for current/local/this network
+                ipv4(10, 0, 0, 0) / 8,       // Private range
+                ipv4(100, 64, 0, 0) / 10,    // Carrier grade NAT private range
+                ipv4(127, 0, 0, 0) / 8,      // Loopback
+                ipv4(169, 254, 0, 0) / 16,   // Link-local addresses
+                ipv4(172, 16, 0, 0) / 12,    // Private range
+                ipv4(192, 0, 0, 0) / 24,     // DS-Lite
+                ipv4(192, 0, 2, 0) / 24,     // Test range 1 for docs/examples
+                ipv4(192, 88, 99, 0) / 24,   // Reserved; deprecated IPv6-to-IPv4 relay
+                ipv4(192, 168, 0, 0) / 16,   // Private range
+                ipv4(198, 18, 0, 0) / 15,    // Multi-subnmet benchmark testing range
+                ipv4(198, 51, 100, 0) / 24,  // Test range 2 for docs/examples
+                ipv4(203, 0, 113, 0) / 24,   // Test range 3 for docs/examples
+                ipv4(224, 0, 0, 0) / 4,      // Multicast
+                ipv4(240, 0, 0, 0) / 4,      // Multicast
+        };
+
+        const std::array ipv6_nonpublic = {
+                ipv6() / 128,                        // unspecified addr
+                ipv6(0, 0, 0, 0, 0, 0, 0, 1) / 128,  // lookback
+                ipv6(0, 0, 0, 0, 0, 0xffff) / 96,    // IPv4-mapped address
+                ipv6(0, 0, 0, 0, 0xffff) / 96,       // IPv4 translated addr
+                ipv6(0x64, 0xff9b) / 96,             // IPv4/IPv6 translation
+                ipv6(0x64, 0xff9b, 1) / 48,          // IPv4/IPv6 translation
+                ipv6(0x100) / 64,                    // Discard
+                ipv6(0x200) / 7,                     // Deprecated NSPA-mapped IPv6; Yggdrasil
+                ipv6(0x2001, 0x0) / 32,              // Toredo
+                ipv6(0x2001, 0x20) / 28,             // ORCHIDv2
+                ipv6(0x2001, 0xdb8) / 32,            // Documentation/example
+                ipv6(0x2002) / 16,                   // Deprecated 6to4 addressing scheme
+                ipv6(0xfc00) / 7,                    // Unique local address
+                ipv6(0xfe80) / 10,                   // link-local unicast addressing
+                ipv6(0xff00) / 8,                    // Multicast
+        };
+    }  // namespace
+
+    bool Address::is_public() const
+    {
+        if (!is_addressable())
+            return false;
+        if (is_ipv4())
+        {
+            ipv4 addr{oxenc::big_to_host<uint32_t>(in4().sin_addr.s_addr)};
+            for (const auto& range : ipv4_nonpublic)
+                if (range.contains(addr))
+                    return false;
+        }
+        else if (is_ipv4_mapped_ipv6())
+        {
+            return unmapped_ipv4_from_ipv6().is_public();
+        }
+        else if (is_ipv6())
+        {
+            ipv6 addr{in6().sin6_addr.s6_addr};
+            for (const auto& range : ipv6_nonpublic)
+                if (range.contains(addr))
+                    return false;
+        }
+        return true;
     }
 
     std::string Address::host() const

--- a/src/address.cpp
+++ b/src/address.cpp
@@ -34,6 +34,8 @@ namespace oxen::quic
 
     void Address::map_ipv4_as_ipv6()
     {
+        if (!is_ipv4())
+            throw std::logic_error{"Address::map_ipv4_as_ipv6 cannot be called on a non-IPv4 address"};
         const auto& a4 = in4();
         sockaddr_in6 a6{};
         a6.sin6_family = AF_INET6;
@@ -43,6 +45,24 @@ namespace oxen::quic
         std::memcpy(&a6.sin6_addr.s6_addr[12], &a4.sin_addr.s_addr, 4);
         std::memcpy(&_sock_addr, &a6, sizeof(a6));
         update_socklen(sizeof(a6));
+    }
+
+    bool Address::is_ipv4_mapped_ipv6() const
+    {
+        return is_ipv6() && std::memcmp(in6().sin6_addr.s6_addr, "\0\0\0\0\0\0\0\0\0\0\xff\xff", 12) == 0;
+    }
+
+    void Address::unmap_ipv4_from_ipv6()
+    {
+        if (!is_ipv4_mapped_ipv6())
+            throw std::logic_error{"Address::unmap_ipv4_ipv6 cannot be called on a non-IPv4-mapped IPv6 address"};
+        const auto& a6 = in6();
+        sockaddr_in a4{};
+        a4.sin_family = AF_INET;
+        a4.sin_port = a6.sin6_port;
+        std::memcpy(&a4.sin_addr.s_addr, &a6.sin6_addr.s6_addr[12], 4);
+        std::memcpy(&_sock_addr, &a4, sizeof(a4));
+        update_socklen(sizeof(a4));
     }
 
     std::string Address::host() const


### PR DESCRIPTION
This allows us to do a check for whether an address is public from new Lokinet code that is transitioning to use oxen::quic::Address in some places rather than Lokinet's painful `hnuintnuhuh_t` types.

See llarp/net/bogon_ranges.hpp for the current lokinet equivalent.  This also fixes some omissions in the IPv6 ranges (e.g. 0xfc00/8 in lokinet is incorrect and should be a /7).