### PR TITLE
Add packet batch trigger for better packet handling

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -288,6 +288,7 @@ namespace oxen::quic
         if (is_draining())
         {
             log::debug(log_cat, "Note: connection is already draining; dropping");
+            return;
         }
 
         if (read_packet(pkt).success())


### PR DESCRIPTION
This adds an optional packet batch callback to endpoint that allows endpoint to signal the application when it is done processing a set of incoming packets for the endpoint -- either because it has processed them all, or because it hit the max-recv-per-loop limit (64).

This is designed to allow an application to more efficiently deal with packets, especially datagrams, in batches: by using this an application can use the datagram handler to collect incoming datagrams, then use the batch callback to process accumulated datagrams in one go.  Because the batch callback always fires *before* libquic goes back to potentially blocking waiting to read new packets, this means the application can do batch processing without needing to resort to timers or polling for packet handling.

This is particularly important for Lokinet, where we take the packet in the callback transfer it to a job in the Lokinet main loop thread to process it there: doing this one packet at a time is not likely to scale well because of the sheer number of jobs that would have to be put on the logic thread event queue; by batching them into groups of up to 64 packets at a time we ought to be able to do considerably better.