### PR TITLE
Remove perf testing define

### DIFF
--- a/include/quic/connection.hpp
+++ b/include/quic/connection.hpp
@@ -17,10 +17,6 @@
 #include "types.hpp"
 #include "utils.hpp"
 
-#ifdef ENABLE_PERF_TESTING
-extern std::atomic<bool> datagram_test_enabled;
-#endif
-
 namespace oxen::quic
 {
     struct dgram_interface;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,8 +53,6 @@ else()
     message(STATUS "Building without sendmmsg/GSO packet sending")
 endif()
 
-target_compile_definitions(quic PUBLIC ENABLE_PERF_TESTING)
-
 option(LIBQUIC_RECVMMSG "Use recvmmsg when receiving UDP packets" ${libquic_recvmmsg_default})
 if(LIBQUIC_RECVMMSG)
     target_compile_definitions(quic PUBLIC OXEN_LIBQUIC_RECVMMSG)

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -979,6 +979,11 @@ namespace oxen::quic
 
         if (_packet_splitting)
         {
+            if (data.size() < 2)
+            {
+                log::warning(log_cat, "Ignoring invalid datagram: too short for packet splitting");
+                return 0;
+            }
             uint16_t dgid = oxenc::load_big_to_host<uint16_t>(data.data());
 
 #ifndef ENABLE_PERF_TESTING

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -32,10 +32,6 @@ extern "C"
 #include "stream.hpp"
 #include "utils.hpp"
 
-#ifdef ENABLE_PERF_TESTING
-std::atomic<bool> datagram_test_enabled = false;
-#endif
-
 namespace oxen::quic
 {
     using namespace std::literals;
@@ -984,14 +980,9 @@ namespace oxen::quic
                 log::warning(log_cat, "Ignoring invalid datagram: too short for packet splitting");
                 return 0;
             }
-            uint16_t dgid = oxenc::load_big_to_host<uint16_t>(data.data());
 
-#ifndef ENABLE_PERF_TESTING
-            if (!datagram_test_enabled)
-                data.remove_prefix(2);
-#else
+            uint16_t dgid = oxenc::load_big_to_host<uint16_t>(data.data());
             data.remove_prefix(2);
-#endif
 
             if (dgid % 4 == 0)
                 log::trace(log_cat, "Datagram sent unsplit, bypassing rotating buffer");

--- a/tests/dgram-speed-server.cpp
+++ b/tests/dgram-speed-server.cpp
@@ -106,7 +106,7 @@ int main(int argc, char* argv[])
             return;
         }
 
-        // Subsequent packets start with a \x00 until the final one, that has first byte set to \x01.
+        // Subsequent packets start with a \x00 until the final one; that has first byte set to \x01.
         const bool done = data[0] != std::byte{0};
 
         auto& info = dgram_data;


### PR DESCRIPTION
This was added so that dgram speedtest could get the dgid itself to use it to figure out the packet sequence.  The downside is that it required a compile-time change in the library.

This removes that compile-time change by changing the dgram speedtest test to mutate the last packet so that we can identify it without needing to worry about the dgid.