### PR TITLE
Address: just-port construction; is_loopback; other fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,18 +3,6 @@ cmake_minimum_required(VERSION 3.13...3.25)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
-if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
-    set(libquic_IS_TOPLEVEL_PROJECT TRUE)
-else()
-    set(libquic_IS_TOPLEVEL_PROJECT FALSE)
-endif()
-
-option(BUILD_SHARED_LIBS "Build as shared library" OFF)
-option(BUILD_STATIC_DEPS "Download, build, and statically link against core dependencies" OFF)
-option(WARNINGS_AS_ERRORS "treat all warnings as errors. turn off for development, on for release" OFF)
-option(LIBQUIC_WARN_DEPRECATED "warn deprecated" ON)
-option(LIBQUIC_BUILD_TESTS "Build libquic test suite and programs" ${libquic_IS_TOPLEVEL_PROJECT})
-
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 set(LANGS C CXX)
@@ -28,10 +16,24 @@ if(CCACHE_PROGRAM)
   endforeach()
 endif()
 
-project(libquicinet 
+project(libquic
     VERSION 0.0.5
     DESCRIPTION "Modular QUIC library for stream and connection management"
     LANGUAGES ${LANGS})
+
+
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+    set(libquic_IS_TOPLEVEL_PROJECT TRUE)
+else()
+    set(libquic_IS_TOPLEVEL_PROJECT FALSE)
+endif()
+
+option(BUILD_SHARED_LIBS "Build as shared library" OFF)
+option(BUILD_STATIC_DEPS "Download, build, and statically link against core dependencies" OFF)
+option(WARNINGS_AS_ERRORS "treat all warnings as errors. turn off for development, on for release" OFF)
+option(LIBQUIC_WARN_DEPRECATED "warn deprecated" ON)
+option(LIBQUIC_BUILD_TESTS "Build libquic test suite and programs" ${libquic_IS_TOPLEVEL_PROJECT})
+
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/include/quic/address.hpp
+++ b/include/quic/address.hpp
@@ -21,12 +21,8 @@ namespace oxen::quic
         }
 
       public:
-        // Default constructor yields [::]:0
-        Address()
-        {
-            _sock_addr.ss_family = AF_INET6;
-            _addr.addrlen = sizeof(sockaddr_in6);
-        }
+        // Default constructor or single-port constructor yields [::]:port (or [::]:0 if port omitted)
+        explicit Address(uint16_t port = 0) : Address{"", port} {}
 
         Address(const sockaddr* s, socklen_t n)
         {
@@ -103,9 +99,16 @@ namespace oxen::quic
         /// Returns true if this is an addressable address, i.e. not the "any" address or port
         bool is_addressable() const { return !is_any_addr() && !is_any_port(); }
 
-        /// Returns true if this is an addressable, public IP (i.e. addressable and not in a private
-        /// range).
+        /// Returns true if this is an addressable, public IP and port (i.e. addressable and not in
+        /// a private range).
         bool is_public() const;
+
+        /// Returns true if this has an addressable public IP (but unlike `is_public()` this allows
+        /// port to be set to the 0 "any port").
+        bool is_public_ip() const;
+
+        /// Returns true if this address is a loopback address (IPv4 127.0.0.0/8 or IPv6 ::1)
+        bool is_loopback() const;
 
         inline bool is_ipv4() const
         {

--- a/include/quic/opt.hpp
+++ b/include/quic/opt.hpp
@@ -11,9 +11,6 @@ namespace oxen::quic::opt
     struct local_addr : public Address
     {
         using Address::Address;
-
-        // Constructing from just a port to bind to that port, any address
-        explicit local_addr(uint16_t port) : Address{"", port} {}
     };
 
     struct remote_addr : public Address

--- a/tests/001-handshake.cpp
+++ b/tests/001-handshake.cpp
@@ -20,13 +20,76 @@ namespace oxen::quic::test
         SECTION("Address objects")
         {
             opt::local_addr empty_addr{};
+            opt::local_addr empty_addr2{"", 0};
             opt::local_addr good_addr{"127.0.0.1", 4400};
+            opt::local_addr public_addr{"1.2.3.4", 56789};
+            opt::local_addr public_anyport{"4.5.6.7", 0};
+            opt::local_addr localnet_addr{"192.168.1.1", 80};
+            opt::local_addr ipv6_localhost{"::1", 123};
+            opt::local_addr localnet_ipv6{"fdab:1234:5::1", 123};
+            opt::local_addr public_ipv6{"2345::1", 45678};
 
-            REQUIRE(empty_addr.is_set());
-            REQUIRE_THROWS(opt::local_addr{"127.001", 4400});
-            REQUIRE_THROWS(opt::local_addr{""s, 0});
-            REQUIRE(empty_addr == opt::local_addr{"::", 0});
-            REQUIRE(good_addr.is_set());
+            CHECK(empty_addr.is_set());
+            CHECK_THROWS(opt::local_addr{"127.001", 4400});
+            CHECK_NOTHROW(opt::local_addr{"", 0});
+            CHECK(empty_addr == opt::local_addr{"::", 0});
+            CHECK(good_addr.is_set());
+
+            CHECK(empty_addr.is_any_addr());
+            CHECK(empty_addr.is_any_port());
+            CHECK_FALSE(empty_addr.is_addressable());
+            CHECK_FALSE(empty_addr.is_loopback());
+
+            CHECK(empty_addr == empty_addr2);
+
+            CHECK_FALSE(good_addr.is_public());
+            CHECK_FALSE(good_addr.is_public_ip());
+            CHECK_FALSE(good_addr.is_any_addr());
+            CHECK_FALSE(good_addr.is_any_port());
+            CHECK(good_addr.is_addressable());
+            CHECK(good_addr.is_loopback());
+
+            CHECK(public_addr.is_public());
+            CHECK(public_addr.is_public_ip());
+            CHECK_FALSE(public_addr.is_any_addr());
+            CHECK_FALSE(public_addr.is_any_port());
+            CHECK(public_addr.is_addressable());
+            CHECK_FALSE(public_addr.is_loopback());
+
+            CHECK_FALSE(public_anyport.is_public());
+            CHECK(public_anyport.is_public_ip());
+            CHECK_FALSE(public_anyport.is_any_addr());
+            CHECK(public_anyport.is_any_port());
+            CHECK_FALSE(public_anyport.is_addressable());
+            CHECK_FALSE(public_anyport.is_loopback());
+
+            CHECK_FALSE(localnet_addr.is_public());
+            CHECK_FALSE(localnet_addr.is_public_ip());
+            CHECK_FALSE(localnet_addr.is_any_addr());
+            CHECK_FALSE(localnet_addr.is_any_port());
+            CHECK(localnet_addr.is_addressable());
+            CHECK_FALSE(localnet_addr.is_loopback());
+
+            CHECK_FALSE(ipv6_localhost.is_public());
+            CHECK_FALSE(ipv6_localhost.is_public_ip());
+            CHECK_FALSE(ipv6_localhost.is_any_addr());
+            CHECK_FALSE(ipv6_localhost.is_any_port());
+            CHECK(ipv6_localhost.is_addressable());
+            CHECK(ipv6_localhost.is_loopback());
+
+            CHECK_FALSE(localnet_ipv6.is_public());
+            CHECK_FALSE(localnet_ipv6.is_public_ip());
+            CHECK_FALSE(localnet_ipv6.is_any_addr());
+            CHECK_FALSE(localnet_ipv6.is_any_port());
+            CHECK(localnet_ipv6.is_addressable());
+            CHECK_FALSE(localnet_ipv6.is_loopback());
+
+            CHECK(public_ipv6.is_public());
+            CHECK(public_ipv6.is_public_ip());
+            CHECK_FALSE(public_ipv6.is_any_addr());
+            CHECK_FALSE(public_ipv6.is_any_port());
+            CHECK(public_ipv6.is_addressable());
+            CHECK_FALSE(public_ipv6.is_loopback());
         };
 
         SECTION("Endpoint object creation - Default addressing")


### PR DESCRIPTION
- Fixes the cmake options being too early for the is-toplevel-project detection

- Allows constructing an Address with just a port (which becomes "[::]:$PORT"), and allows removing the just-a-port constructor from opt::local_addr

- Fixes construction from empty string IP; this was supposed to be `[::]`, but I implemented it wrong and it was throwing.

- Add `is_loopback` which does what it sounds like

- Add `is_public_ip` which is like `is_public`, except that it doesn't require an addressable port.

- Add a bunch of tests for Address methods.