### PR TITLE
Optional options

### DIFF
--- a/include/quic/btstream.hpp
+++ b/include/quic/btstream.hpp
@@ -112,6 +112,13 @@ namespace oxen::quic
       private:
         void handle_req_opts(std::function<void(message)> func) { cb = std::move(func); }
         void handle_req_opts(std::chrono::milliseconds exp) { timeout = exp; }
+
+        template <typename Opt>
+        void handle_req_opts(std::optional<Opt> option)
+        {
+            if (option)
+                handle_req_opts(std::move(*option));
+        }
     };
 
     class BTRequestStream : public Stream

--- a/include/quic/context.hpp
+++ b/include/quic/context.hpp
@@ -66,6 +66,16 @@ namespace oxen::quic
         void handle_ioctx_opt(stream_constructor_callback func);
         void handle_ioctx_opt(connection_established_callback func);
         void handle_ioctx_opt(connection_closed_callback func);
+
+        /// Unwraps an optional option: does nothing if nullopt, otherwise applies the option.  This
+        /// is here to make runtime-dependent options (i.e. options whose presence depends on a
+        /// condition not knowable at compile time) easier to manage.
+        template <typename Opt>
+        void handle_ioctx_opt(std::optional<Opt> option)
+        {
+            if (option)
+                handle_ioctx_opt(std::move(*option));
+        }
     };
 
 }  // namespace oxen::quic

--- a/include/quic/endpoint.hpp
+++ b/include/quic/endpoint.hpp
@@ -45,6 +45,16 @@ namespace oxen::quic
         void handle_ep_opt(connection_established_callback conn_established_cb);
         void handle_ep_opt(connection_closed_callback conn_closed_cb);
 
+        // Takes a std::optional-wrapped option that does nothing if the optional is empty,
+        // otherwise passes it through to the above.  This is here to allow runtime-dependent
+        // options (i.e. where whether or not the option is required is not known at compile time).
+        template <typename Opt>
+        void handle_ep_opt(std::optional<Opt> option)
+        {
+            if (option)
+                handle_ep_opt(std::move(*option));
+        }
+
       public:
         // Non-movable/non-copyable; you must always hold a Endpoint in a shared_ptr
         Endpoint(const Endpoint&) = delete;

--- a/include/quic/endpoint.hpp
+++ b/include/quic/endpoint.hpp
@@ -55,8 +55,6 @@ namespace oxen::quic
         connection_established_callback connection_established_cb;
         connection_closed_callback connection_close_cb;
 
-        std::string local_addr() { return _local.to_string(); }
-
         template <typename... Opt>
         Endpoint(Network& n, const Address& listen_addr, Opt&&... opts) : net{n}, _local{listen_addr}
         {

--- a/include/quic/opt.hpp
+++ b/include/quic/opt.hpp
@@ -59,17 +59,20 @@ namespace oxen::quic::opt
     struct outbound_alpns
     {
         std::vector<std::string> alpns;
+        explicit outbound_alpns(std::vector<std::string> alpns = {}) : alpns{std::move(alpns)} {}
     };
 
     // supported ALPNs for inbound connections
     struct inbound_alpns
     {
         std::vector<std::string> alpns;
+        explicit inbound_alpns(std::vector<std::string> alpns = {}) : alpns{std::move(alpns)} {}
     };
 
-    struct handshake_timeout : public std::chrono::nanoseconds
+    struct handshake_timeout
     {
-        using std::chrono::nanoseconds::nanoseconds;
+        std::chrono::nanoseconds timeout;
+        explicit handshake_timeout(std::chrono::nanoseconds ns = 0ns) : timeout{ns} {}
     };
 
 }  // namespace oxen::quic::opt

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -47,7 +47,7 @@ namespace oxen::quic
 
     void Endpoint::handle_ep_opt(opt::handshake_timeout timeout)
     {
-        handshake_timeout = timeout;
+        handshake_timeout = timeout.timeout;
     }
 
     void Endpoint::handle_ep_opt(dgram_data_callback func)

--- a/tests/009-alpns.cpp
+++ b/tests/009-alpns.cpp
@@ -43,7 +43,7 @@ namespace oxen::quic::test
 
         SECTION("No Server ALPNs specified (defaulted)")
         {
-            opt::outbound_alpns client_alpns{.alpns{"client"}};
+            opt::outbound_alpns client_alpns{{"client"}};
 
             auto server_endpoint = test_net.endpoint(server_local, timeout);
             REQUIRE(server_endpoint->listen(server_tls));
@@ -59,7 +59,7 @@ namespace oxen::quic::test
 
         SECTION("No Client ALPNs specified (defaulted)")
         {
-            opt::inbound_alpns server_alpns{.alpns{"client", "relay"}};
+            opt::inbound_alpns server_alpns{{"client", "relay"}};
 
             auto server_endpoint = test_net.endpoint(server_local, server_alpns, timeout);
             REQUIRE(server_endpoint->listen(server_tls));
@@ -75,8 +75,8 @@ namespace oxen::quic::test
 
         SECTION("Client ALPNs not supported")
         {
-            opt::inbound_alpns server_alpns{.alpns{"client", "relay"}};
-            opt::outbound_alpns client_alpns{.alpns{"foobar"}};
+            opt::inbound_alpns server_alpns{{"client", "relay"}};
+            opt::outbound_alpns client_alpns{{"foobar"}};
 
             auto server_endpoint = test_net.endpoint(server_local, server_alpns, timeout);
             REQUIRE(server_endpoint->listen(server_tls));
@@ -92,9 +92,9 @@ namespace oxen::quic::test
 
         SECTION("Select first ALPN both sides support")
         {
-            opt::inbound_alpns server_alpns{.alpns{"client", "relay"}};
-            opt::outbound_alpns client_alpns{.alpns{"client"}};
-            opt::outbound_alpns client_alpns2{.alpns{"relay"}};
+            opt::inbound_alpns server_alpns{{"client", "relay"}};
+            opt::outbound_alpns client_alpns{{"client"}};
+            opt::outbound_alpns client_alpns2{{"relay"}};
 
             auto server_endpoint = test_net.endpoint(server_local, server_alpns, timeout);
             REQUIRE(server_endpoint->listen(server_tls));


### PR DESCRIPTION
Certain options in the current interface in awkward in contexts such as Python where whether you want an option is dependent on some runtime value: such as being passed a `datagram=True` keyword argument.

Currently the only way we could do it would be to have two separate paths for each non-nullable option, i.e. something like:

```C++
    std::shared_ptr<Endpoint> e;
    if (want_datagram) {
        e = net.endpoint(addr, opt::whatever{},
            opt::datagram_enabled{});
    } else {
        e = net.endpoint(addr, opt::whatever{});
    }
```
because there's no way to make a `opt::datagram_enabled` that means *don't* enable datagrams.

While we *could* add such a feature to datagram_enabled and any other using-this-turns-it-on option, it seems a lot simpler to add a generic `std::optional<T>` handle to option parsing so that you can pass a `nullopt` anywhere you don't want to pass an option, i.e. the above can become:

```C++
    auto e = net.endpoint(addr, opt::whatever{},
        want_datagrams ? std::make_optional<opt::datagram_enabled>() : std::nullopt);
```
and similarly for any other of the templated option types.