### PR TITLE
public endpoint shared_from_this

### DIFF
--- a/include/quic/endpoint.hpp
+++ b/include/quic/endpoint.hpp
@@ -34,7 +34,7 @@ extern "C"
 
 namespace oxen::quic
 {
-    class Endpoint : std::enable_shared_from_this<Endpoint>
+    class Endpoint : public std::enable_shared_from_this<Endpoint>
     {
       private:
         void handle_ep_opt(opt::enable_datagrams dc);


### PR DESCRIPTION
In order to hold Endpoints as shared_ptr's in pybind wrappers, this inheritance needs to be public rather than implicit private