### PR TITLE
Stream open/queuing redux

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -64,7 +64,7 @@ endif()
 
 # oxenc
 if (NOT TARGET oxenc)
-    system_or_submodule(OXENC oxenc liboxenc>=1.0.9 oxen-encoding)
+    system_or_submodule(OXENC oxenc liboxenc>=1.0.10 oxen-encoding)
 endif()
 
 # libevent

--- a/include/quic/address.hpp
+++ b/include/quic/address.hpp
@@ -41,7 +41,7 @@ namespace oxen::quic
         template <
                 typename T,
                 std::enable_if_t<
-                        std::is_same_v<T, sockaddr> || std::is_same_v<T, sockaddr_in> || std::is_same_v<T, sockaddr>,
+                        std::is_same_v<T, sockaddr> || std::is_same_v<T, sockaddr_in> || std::is_same_v<T, sockaddr_in6>,
                         int> = 0>
         Address& operator=(const T* s)
         {

--- a/include/quic/address.hpp
+++ b/include/quic/address.hpp
@@ -59,6 +59,22 @@ namespace oxen::quic
             return *this;
         }
 
+        void set_port(uint16_t port)
+        {
+            if (_sock_addr.ss_family == AF_INET6)
+            {
+                auto& sin6 = reinterpret_cast<sockaddr_in6&>(_sock_addr);
+                sin6.sin6_port = oxenc::host_to_big(port);
+            }
+            else if (_sock_addr.ss_family == AF_INET)
+            {
+                auto& sin4 = reinterpret_cast<sockaddr_in&>(_sock_addr);
+                sin4.sin_port = oxenc::host_to_big(port);
+            }
+            else
+                throw std::invalid_argument{"Error: could not set port in unknown sock_addr"};
+        }
+
         // Converts an IPv4 address into an IPv4-mapped IPv6 address.  The address must already be
         // an IPv4 address (throws if not).
         void map_ipv4_as_ipv6();

--- a/include/quic/btstream.hpp
+++ b/include/quic/btstream.hpp
@@ -48,7 +48,6 @@ namespace oxen::quic
         void respond(bstring_view body, bool error = false);
         void respond(std::string_view body, bool error = false) { respond(convert_sv<std::byte>(body), error); }
 
-        bool timed_out{false};
         bool is_error{false};
 
         //  To be used to determine if the message was a result of an error as such:
@@ -61,7 +60,7 @@ namespace oxen::quic
         //      if (m)
         //      { // success logic }
         //  }
-        operator bool() const { return not timed_out && not is_error; }
+        operator bool() const { return not is_error; }
 
         template <typename Char = char, typename = std::enable_if_t<sizeof(Char) == 1>>
         std::basic_string_view<Char> view() const
@@ -70,7 +69,10 @@ namespace oxen::quic
         }
 
         int64_t rid() const { return req_id; }
-        std::string_view type() const { return {reinterpret_cast<const char*>(data.data()) + req_type.first, req_type.second}; }
+        std::string_view type() const
+        {
+            return {reinterpret_cast<const char*>(data.data()) + req_type.first, req_type.second};
+        }
         std::string_view endpoint() const { return {reinterpret_cast<const char*>(data.data()) + ep.first, ep.second}; }
         std::string endpoint_str() const { return std::string{endpoint()}; }
 

--- a/include/quic/btstream.hpp
+++ b/include/quic/btstream.hpp
@@ -29,7 +29,9 @@ namespace oxen::quic
 
       private:
         int64_t req_id;
-        bstring data;
+        bstring data;  // Wrapped in a shared pointer because: a) we store views into this and need
+                       // them to stay valid across moves; and b) we want message to be copyable so
+                       // that it can be captured in lambda args.
         std::string_view req_type;
         std::string_view ep;
         std::string_view req_body;
@@ -39,6 +41,11 @@ namespace oxen::quic
         message(BTRequestStream& bp, bstring req, bool is_error = false);
 
       public:
+        message(message&& m);
+        message(const message& m);
+        message& operator=(message&& m);
+        message& operator=(const message& m);
+
         void respond(bstring_view body, bool error = false);
         void respond(std::string_view body, bool error = false) { respond(convert_sv<std::byte>(body), error); }
 

--- a/include/quic/btstream.hpp
+++ b/include/quic/btstream.hpp
@@ -66,10 +66,10 @@ namespace oxen::quic
 
         std::shared_ptr<BTRequestStream> stream() const
         {
-            if (return_sender.expired())
-                throw std::runtime_error{"Cannot access expired pointer to BT stream!"};
+            if (auto ptr = return_sender.lock())
+                return ptr;
 
-            return return_sender.lock();
+            throw std::runtime_error{"Cannot access expired pointer to BT stream!"};
         }
     };
 

--- a/include/quic/btstream.hpp
+++ b/include/quic/btstream.hpp
@@ -110,7 +110,7 @@ namespace oxen::quic
 
         template <typename... Opt>
         sent_request(BTRequestStream& bp, std::string_view d, int64_t rid, Opt&&... opts) :
-                req_id{rid}, return_sender{bp}, total_len{d.length()}, req_time{get_time()}, expiry{req_time}
+                req_id{rid}, return_sender{bp}, total_len{d.size()}, req_time{get_time()}, expiry{req_time}
         {
             if (total_len > MAX_REQ_LEN)
                 throw std::invalid_argument{"Request body too long!"};
@@ -163,8 +163,6 @@ namespace oxen::quic
         {
             ((void)handle_bp_opt(std::forward<Opt>(opts)), ...);
         }
-
-        ~BTRequestStream() override { sent_reqs.clear(); }
 
         std::weak_ptr<BTRequestStream> weak_from_this()
         {

--- a/include/quic/btstream.hpp
+++ b/include/quic/btstream.hpp
@@ -20,9 +20,6 @@ namespace oxen::quic
     // enough to hold `MAX_REQ_LEN` followed by a `:`.
     inline constexpr size_t MAX_REQ_LEN_ENCODED = 9;  // "10000000:"
 
-    // Application error
-    inline constexpr uint64_t BPARSER_EXCEPTION = (1ULL << 60) + 69;
-
     class BTRequestStream;
 
     struct message

--- a/include/quic/btstream.hpp
+++ b/include/quic/btstream.hpp
@@ -156,14 +156,16 @@ namespace oxen::quic
         std::atomic<int64_t> next_rid{0};
 
         friend struct sent_request;
+        friend class Network;
 
-      public:
+      protected:
         template <typename... Opt>
         explicit BTRequestStream(Connection& _c, Endpoint& _e, Opt&&... opts) : Stream{_c, _e}
         {
             ((void)handle_bp_opt(std::forward<Opt>(opts)), ...);
         }
 
+      public:
         std::weak_ptr<BTRequestStream> weak_from_this()
         {
             return std::dynamic_pointer_cast<BTRequestStream>(shared_from_this());

--- a/include/quic/btstream.hpp
+++ b/include/quic/btstream.hpp
@@ -28,7 +28,7 @@ namespace oxen::quic
     struct message
     {
         friend class BTRequestStream;
-        friend class sent_request;
+        friend struct sent_request;
 
       private:
         int64_t req_id;

--- a/include/quic/btstream.hpp
+++ b/include/quic/btstream.hpp
@@ -16,6 +16,10 @@ namespace oxen::quic
     // request sizes
     inline constexpr long long MAX_REQ_LEN = 10_M;
 
+    // maximum length of the bencoded request length string, including the `:`.  This must be large
+    // enough to hold `MAX_REQ_LEN` followed by a `:`.
+    inline constexpr size_t MAX_REQ_LEN_ENCODED = 9;  // "10000000:"
+
     // Application error
     inline constexpr uint64_t BPARSER_EXCEPTION = (1ULL << 60) + 69;
 

--- a/include/quic/connection.hpp
+++ b/include/quic/connection.hpp
@@ -133,7 +133,7 @@ namespace oxen::quic
 #endif
     };
 
-    class Connection : public connection_interface, public std::enable_shared_from_this<Connection>
+    class Connection : public connection_interface
     {
       public:
         // Non-movable/non-copyable; you must always hold a Connection in a shared_ptr

--- a/include/quic/connection.hpp
+++ b/include/quic/connection.hpp
@@ -187,7 +187,7 @@ namespace oxen::quic
 
         TLSSession* get_session() const;
 
-        ustring_view remote_key() const override { return tls_session->remote_key(); }
+        ustring_view remote_key() const override;
 
         Direction direction() const override { return dir; }
 

--- a/include/quic/connection.hpp
+++ b/include/quic/connection.hpp
@@ -113,6 +113,10 @@ namespace oxen::quic
         virtual const Address& local() const = 0;
         virtual const Address& remote() const = 0;
         virtual bool is_validated() const = 0;
+        virtual Direction direction() const = 0;
+        bool is_inbound() const { return direction() == Direction::INBOUND; }
+        bool is_outbound() const { return direction() == Direction::OUTBOUND; }
+        std::string_view direction_str() const { return direction() == Direction::INBOUND ? "server"sv : "client"sv; }
 
         // WIP functions: these are meant to expose specific aspects of the internal state of connection
         // and the datagram IO object for debugging and application (user) utilization.
@@ -173,10 +177,7 @@ namespace oxen::quic
         std::shared_ptr<Stream> get_new_stream_impl(
                 std::function<std::shared_ptr<Stream>(Connection& c, Endpoint& e)> make_stream) override;
 
-        Direction direction() const { return dir; }
-        bool is_inbound() const { return dir == Direction::INBOUND; }
-        bool is_outbound() const { return dir == Direction::OUTBOUND; }
-        std::string_view direction_str() const { return dir == Direction::INBOUND ? "server"sv : "client"sv; }
+        Direction direction() const override { return dir; }
 
         void halt_events();
         bool is_closing() const { return closing; }

--- a/include/quic/connection.hpp
+++ b/include/quic/connection.hpp
@@ -74,9 +74,11 @@ namespace oxen::quic
             // We defer resolution of `Endpoint` here via `EndpointDeferred` because the header only
             // has a forward declaration; the user of this method needs to have the full definition
             // available to call this.
-            return std::static_pointer_cast<StreamT>(queue_stream_impl([&](Connection& c, EndpointDeferred& e) {
+            auto s = std::dynamic_pointer_cast<StreamT>(queue_stream_impl([&](Connection& c, EndpointDeferred& e) {
                 return e.template make_shared<StreamT>(c, e, std::forward<Args>(args)...);
             }));
+            assert(s);
+            return s;
         }
 
         template <
@@ -86,9 +88,11 @@ namespace oxen::quic
                 std::enable_if_t<std::is_base_of_v<Stream, StreamT>, int> = 0>
         std::shared_ptr<StreamT> get_new_stream(Args&&... args)
         {
-            return std::static_pointer_cast<StreamT>(get_new_stream_impl([&](Connection& c, EndpointDeferred& e) {
+            auto s = std::dynamic_pointer_cast<StreamT>(get_new_stream_impl([&](Connection& c, EndpointDeferred& e) {
                 return e.template make_shared<StreamT>(c, e, std::forward<Args>(args)...);
             }));
+            assert(s);
+            return s;
         }
 
         template <typename StreamT = Stream, std::enable_if_t<std::is_base_of_v<Stream, StreamT>, int> = 0>

--- a/include/quic/connection.hpp
+++ b/include/quic/connection.hpp
@@ -126,6 +126,7 @@ namespace oxen::quic
         virtual const Address& remote() const = 0;
         virtual bool is_validated() const = 0;
         virtual Direction direction() const = 0;
+        virtual ustring_view remote_key() const = 0;
         bool is_inbound() const { return direction() == Direction::INBOUND; }
         bool is_outbound() const { return direction() == Direction::OUTBOUND; }
         std::string_view direction_str() const { return direction() == Direction::INBOUND ? "server"sv : "client"sv; }
@@ -184,6 +185,8 @@ namespace oxen::quic
         void packet_io_ready();
 
         TLSSession* get_session() const;
+
+        ustring_view remote_key() const override { return tls_session->remote_key(); }
 
         Direction direction() const override { return dir; }
 

--- a/include/quic/connection.hpp
+++ b/include/quic/connection.hpp
@@ -126,10 +126,12 @@ namespace oxen::quic
 
         virtual void close_connection(uint64_t error_code = 0) = 0;
 
-        virtual ~connection_interface() = default;
-
 #ifndef NDEBUG
+        virtual ~connection_interface();
+
         debug_interface test_suite;
+#else
+        virtual ~connection_interface() = default;
 #endif
     };
 
@@ -331,6 +333,10 @@ namespace oxen::quic
 
         // returns number of currently pending streams for use in test cases
         size_t num_pending() const { return pending_streams.size(); }
+
+#ifndef NDEBUG
+        ~Connection() override;
+#endif
     };
 
     extern "C"

--- a/include/quic/connection.hpp
+++ b/include/quic/connection.hpp
@@ -127,6 +127,7 @@ namespace oxen::quic
         virtual bool is_validated() const = 0;
         virtual Direction direction() const = 0;
         virtual ustring_view remote_key() const = 0;
+        virtual std::shared_ptr<Stream> get_stream(int64_t ID) const = 0;
         bool is_inbound() const { return direction() == Direction::INBOUND; }
         bool is_outbound() const { return direction() == Direction::OUTBOUND; }
         std::string_view direction_str() const { return direction() == Direction::INBOUND ? "server"sv : "client"sv; }
@@ -286,8 +287,6 @@ namespace oxen::quic
 
         void schedule_packet_retransmit(std::chrono::steady_clock::time_point ts);
 
-        std::shared_ptr<Stream> get_stream(int64_t ID) const;
-
         bool draining = false;
         bool closing = false;
 
@@ -328,6 +327,8 @@ namespace oxen::quic
         std::shared_ptr<dgram_interface> di;
 
       public:
+        // public to grab btstream from application level
+        std::shared_ptr<Stream> get_stream(int64_t ID) const override;
         // public to be called by endpoint handing this connection a packet
         void handle_conn_packet(const Packet& pkt);
         // these are public so ngtcp2 can access them from callbacks

--- a/include/quic/connection.hpp
+++ b/include/quic/connection.hpp
@@ -128,7 +128,8 @@ namespace oxen::quic
             auto s = get_stream_impl(id);
             if (!s)
                 return nullptr;
-            if constexpr (!std::is_same_v<StreamT, Stream>) {
+            if constexpr (!std::is_same_v<StreamT, Stream>)
+            {
                 if (auto st = std::dynamic_pointer_cast<StreamT>(std::move(s)))
                     return st;
                 throw std::invalid_argument{"Stream ID {} is not an instance of the requested Stream subclass"_format(id)};

--- a/include/quic/connection.hpp
+++ b/include/quic/connection.hpp
@@ -104,8 +104,8 @@ namespace oxen::quic
 
         virtual void send_datagram(bstring_view data, std::shared_ptr<void> keep_alive = nullptr) = 0;
 
-        virtual int get_max_streams() const = 0;
-        virtual int get_streams_available() const = 0;
+        virtual uint64_t get_max_streams() const = 0;
+        virtual uint64_t get_streams_available() const = 0;
         virtual size_t get_max_datagram_size() const = 0;
         virtual bool datagrams_enabled() const = 0;
         virtual bool packet_splitting_enabled() const = 0;
@@ -198,9 +198,9 @@ namespace oxen::quic
 
         ustring_view selected_alpn() const override;
 
-        int get_streams_available() const override;
+        uint64_t get_streams_available() const override;
         size_t get_max_datagram_size() const override;
-        int get_max_streams() const override { return _max_streams; }
+        uint64_t get_max_streams() const override { return _max_streams; }
         bool datagrams_enabled() const override { return _datagrams_enabled; }
         bool packet_splitting_enabled() const override { return _packet_splitting; }
 
@@ -241,7 +241,7 @@ namespace oxen::quic
         const ConnectionID _source_cid;
         ConnectionID _dest_cid;
         Path _path;
-        const int _max_streams{DEFAULT_MAX_BIDI_STREAMS};
+        const uint64_t _max_streams{DEFAULT_MAX_BIDI_STREAMS};
         const bool _datagrams_enabled{false};
         const bool _packet_splitting{false};
         std::atomic<bool> _congested{false};
@@ -312,7 +312,7 @@ namespace oxen::quic
         int stream_ack(int64_t id, size_t size);
         int stream_receive(int64_t id, bstring_view data, bool fin);
         void stream_closed(int64_t id, uint64_t app_code);
-        void check_pending_streams(int available);
+        void check_pending_streams(uint64_t available);
         int recv_datagram(bstring_view data, bool fin);
         int ack_datagram(uint64_t dgram_id);
 

--- a/include/quic/connection.hpp
+++ b/include/quic/connection.hpp
@@ -302,7 +302,7 @@ namespace oxen::quic
 
         io_result read_packet(const Packet& pkt);
 
-        dgram_interface di;
+        std::shared_ptr<dgram_interface> di;
 
       public:
         // public to be called by endpoint handing this connection a packet

--- a/include/quic/connection.hpp
+++ b/include/quic/connection.hpp
@@ -128,7 +128,7 @@ namespace oxen::quic
         }
 
         virtual void send_datagram(bstring_view data, std::shared_ptr<void> keep_alive = nullptr) = 0;
-
+        virtual size_t active_streams() const = 0;
         virtual uint64_t get_max_streams() const = 0;
         virtual uint64_t get_streams_available() const = 0;
         virtual size_t get_max_datagram_size() const = 0;
@@ -202,6 +202,8 @@ namespace oxen::quic
         ustring_view remote_key() const override;
 
         Direction direction() const override { return dir; }
+
+        size_t active_streams() const override { return streams.size(); }
 
         void halt_events();
         bool is_closing() const { return closing; }

--- a/include/quic/connection.hpp
+++ b/include/quic/connection.hpp
@@ -185,12 +185,6 @@ namespace oxen::quic
 
         TLSSession* get_session() const;
 
-        std::shared_ptr<Stream> queue_stream_impl(
-                std::function<std::shared_ptr<Stream>(Connection& c, Endpoint& e)> make_stream) override;
-
-        std::shared_ptr<Stream> get_new_stream_impl(
-                std::function<std::shared_ptr<Stream>(Connection& c, Endpoint& e)> make_stream) override;
-
         Direction direction() const override { return dir; }
 
         void halt_events();
@@ -293,6 +287,18 @@ namespace oxen::quic
 
         bool draining = false;
         bool closing = false;
+
+        // Invokes the stream_construct_cb, if present; if not present, or if it returns nullptr,
+        // then the given `make_stream` gets invoked to create a default stream.
+        std::shared_ptr<Stream> construct_stream(
+                const std::function<std::shared_ptr<Stream>(Connection& c, Endpoint& e)>& make_stream,
+                std::optional<int64_t> stream_id = std::nullopt);
+
+        std::shared_ptr<Stream> queue_stream_impl(
+                std::function<std::shared_ptr<Stream>(Connection& c, Endpoint& e)> make_stream) override;
+
+        std::shared_ptr<Stream> get_new_stream_impl(
+                std::function<std::shared_ptr<Stream>(Connection& c, Endpoint& e)> make_stream) override;
 
         // holds a mapping of active streams
         std::map<int64_t, std::shared_ptr<Stream>> streams;

--- a/include/quic/context.hpp
+++ b/include/quic/context.hpp
@@ -16,13 +16,15 @@ namespace oxen::quic
     struct user_config
     {
         // max streams
-        uint64_t max_streams = 0;
+        uint64_t max_streams{0};
+        // keep alive timeout
+        std::chrono::milliseconds keep_alive{0ms};
         // datagram support
-        bool datagram_support = false;
+        bool datagram_support{false};
         // datagram splitting support
-        bool split_packet = false;
+        bool split_packet{false};
         // splitting policy
-        Splitting policy = Splitting::NONE;
+        Splitting policy{Splitting::NONE};
 
         user_config() = default;
     };
@@ -59,6 +61,7 @@ namespace oxen::quic
       private:
         void handle_ioctx_opt(std::shared_ptr<TLSCreds> tls);
         void handle_ioctx_opt(opt::max_streams ms);
+        void handle_ioctx_opt(opt::keep_alive ka);
         void handle_ioctx_opt(stream_data_callback func);
         void handle_ioctx_opt(stream_open_callback func);
         void handle_ioctx_opt(stream_close_callback func);

--- a/include/quic/context.hpp
+++ b/include/quic/context.hpp
@@ -16,7 +16,7 @@ namespace oxen::quic
     struct user_config
     {
         // max streams
-        int max_streams = 0;
+        uint64_t max_streams = 0;
         // datagram support
         bool datagram_support = false;
         // datagram splitting support

--- a/include/quic/crypto.hpp
+++ b/include/quic/crypto.hpp
@@ -31,6 +31,7 @@ namespace oxen::quic
         ngtcp2_crypto_conn_ref conn_ref;
         virtual void* get_session() = 0;
         virtual ustring_view selected_alpn() = 0;
+        virtual ustring_view remote_key() const = 0;
         virtual void set_expected_remote_key(ustring key) = 0;
         virtual ~TLSSession() = default;
     };

--- a/include/quic/datagram.hpp
+++ b/include/quic/datagram.hpp
@@ -53,9 +53,10 @@ namespace oxen::quic
 
     class IOChannel
     {
-      public:
+      protected:
         IOChannel(Connection& c, Endpoint& e);
 
+      public:
         virtual ~IOChannel() { log::trace(log_cat, "{} called", __PRETTY_FUNCTION__); };
 
         Connection& conn;
@@ -108,8 +109,13 @@ namespace oxen::quic
 
     class DatagramIO : public IOChannel
     {
-      public:
+
+      protected:
+        // Construct via net.make_shared<DatagramIO>(...)
+        friend class Network;
         DatagramIO(Connection& c, Endpoint& e, dgram_data_callback data_cb = nullptr);
+
+      public:
         dgram_data_callback dgram_data_cb;
 
         /// Datagram Numbering:

--- a/include/quic/datagram.hpp
+++ b/include/quic/datagram.hpp
@@ -12,7 +12,7 @@ namespace oxen::quic
     class connection_interface;
     struct ConnectionID;
 
-    struct dgram_interface
+    struct dgram_interface : public std::enable_shared_from_this<dgram_interface>
     {
         dgram_interface(Connection& c);
         connection_interface& ci;

--- a/include/quic/datagram.hpp
+++ b/include/quic/datagram.hpp
@@ -100,7 +100,6 @@ namespace oxen::quic
             send(std::basic_string_view<Char>{buf.data(), buf.size()}, std::make_shared<std::vector<Char>>(std::move(buf)));
         }
 
-
       protected:
         // This is the (single) send implementation that implementing classes must provide; other
         // calls to send are converted into calls to this.

--- a/include/quic/endpoint.hpp
+++ b/include/quic/endpoint.hpp
@@ -73,14 +73,14 @@ namespace oxen::quic
         }
 
         template <typename... Opt>
-        bool listen(Opt&&... opts)
+        void listen(Opt&&... opts)
         {
 
             static_assert(
                     (0 + ... + std::is_convertible_v<remove_cvref_t<Opt>, std::shared_ptr<TLSCreds>>) == 1,
                     "Endpoint listen requires exactly one std::shared_ptr<TLSCreds> argument");
 
-            std::promise<bool> p;
+            std::promise<void> p;
             auto f = p.get_future();
 
             net.call([&opts..., &p, this]() mutable {
@@ -93,7 +93,7 @@ namespace oxen::quic
 
                     log::debug(log_cat, "Inbound context ready for incoming connections");
 
-                    p.set_value(true);
+                    p.set_value();
                 }
                 catch (...)
                 {
@@ -101,7 +101,7 @@ namespace oxen::quic
                 }
             });
 
-            return f.get();
+            f.get();
         }
 
         // creates new outbound connection to remote; emplaces conn/interface pair in outbound map

--- a/include/quic/endpoint.hpp
+++ b/include/quic/endpoint.hpp
@@ -202,9 +202,9 @@ namespace oxen::quic
 
         void drop_connection(Connection& conn);
 
-        void close_connection(Connection& conn, io_error ec = io_error{0}, std::string_view msg = "NO_ERROR"sv);
+        void close_connection(Connection& conn, io_error ec = io_error{0}, std::optional<std::string> msg = std::nullopt);
 
-        void close_connection(ConnectionID cid, io_error code = io_error{0}, std::string_view msg = "NO_ERROR"sv);
+        void close_connection(ConnectionID cid, io_error code = io_error{0}, std::optional<std::string> msg = std::nullopt);
 
         const Address& local() const { return _local; }
 
@@ -251,6 +251,8 @@ namespace oxen::quic
         void _set_context_globals(std::shared_ptr<IOContext>& ctx);
 
         void on_receive(const Packet& pkt);
+
+        void _close_connection(Connection& conn, io_error ec, std::string msg);
 
         // Data structures used to keep track of various types of connections
         //

--- a/include/quic/endpoint.hpp
+++ b/include/quic/endpoint.hpp
@@ -170,6 +170,14 @@ namespace oxen::quic
 
         const std::unique_ptr<UDPSocket>& get_socket() { return socket; }
 
+        // Shortcut for calling net.make_shared<T> to make a std::shared_ptr<T> that has destruction
+        // synchronized to the network event loop.
+        template <typename T, typename... Args>
+        std::shared_ptr<T> make_shared(Args&&... args)
+        {
+            return net.make_shared<T>(std::forward<Args>(args)...);
+        }
+
         // query a list of all active inbound and outbound connections paired with a conn_interface
         std::list<std::shared_ptr<connection_interface>> get_all_conns(std::optional<Direction> d = std::nullopt);
 

--- a/include/quic/error.hpp
+++ b/include/quic/error.hpp
@@ -4,38 +4,66 @@
 
 namespace oxen::quic
 {
-    constexpr uint64_t LIBQUIC_ERROR_BASE = 0x6c696271756963;  // "libquic"
+    // Maximum allowed application error code; this is defined by the QUIC protocol itself, that
+    // uses 2 bits of an integer to indicate the integer length.
+    inline constexpr uint64_t APP_ERRCODE_MAX = (1ULL << 62) - 1;
 
-    enum class error : uint64_t {
-        NO_ERR = 0,
+    // Stream/connection error codes.  We put our libquic-generated error codes as 777'000'000 + n
+    // just because that makes it recognizable and is big enough to be unlikely to interfere with
+    // application error codes, without going so big that we need 64-bit encoding.
+    inline constexpr uint64_t ERROR_BASE = 777'000'000;
 
-        CONN_WRITE_CLOSE_FAIL = LIBQUIC_ERROR_BASE,
-        CONN_SEND_CLOSE_FAIL = LIBQUIC_ERROR_BASE + 1,
+    // Error code we send to a stream close callback if the stream's connection expires
+    inline constexpr uint64_t STREAM_ERROR_CONNECTION_EXPIRED = ERROR_BASE + 1;
 
-        STREAM_EXCEPTION = LIBQUIC_ERROR_BASE + 32,
-        STREAM_CONNECTION_EXPIRED = LIBQUIC_ERROR_BASE + 33,
+    // Application error code we close with if the stream data handle throws
+    inline constexpr uint64_t STREAM_ERROR_EXCEPTION = ERROR_BASE + 100;
 
-        DATAGRAM_EXCEPTION = LIBQUIC_ERROR_BASE + 64
+    // Application error if a bt request stream handle throws an exception
+    inline constexpr uint64_t BPARSER_ERROR_EXCEPTION = ERROR_BASE + 105;
+
+    // Application error code we close with if the datagram data handle throws
+    inline constexpr uint64_t DATAGRAM_ERROR_EXCEPTION = ERROR_BASE + 200;
+
+    /// Custom exception type that a stream handler can throw to send a custom stream error code to
+    /// the other side.
+    class application_stream_error : public std::exception
+    {
+      public:
+        uint64_t code;
+
+        explicit application_stream_error(uint64_t errcode) : code{errcode}, _what{"application error {}"_format(errcode)} {}
+        const char* what() const noexcept override { return _what.c_str(); }
+
+      private:
+        std::string _what;
     };
 
-    inline const char* quic_strerror(uint64_t e)
+    // Failed to write connection close:
+    inline constexpr uint64_t CONN_WRITE_CLOSE_FAIL = ERROR_BASE + 1000;
+    // Failed to send connection close:
+    inline constexpr uint64_t CONN_SEND_CLOSE_FAIL = ERROR_BASE + 1001;
+
+    inline std::string quic_strerror(uint64_t e)
     {
-        switch (static_cast<error>(e))
+        switch (e)
         {
-            case error::NO_ERR:
-                return "No error";
-            case error::DATAGRAM_EXCEPTION:
-                return "Error - datagram exception";
-            case error::STREAM_EXCEPTION:
-                return "Error - stream exception";
-            case error::STREAM_CONNECTION_EXPIRED:
-                return "Error - stream connection expired";
-            case error::CONN_WRITE_CLOSE_FAIL:
-                return "Error - Failed to write connection close";
-            case error::CONN_SEND_CLOSE_FAIL:
-                return "Error - Failed to send connection close";
+            case 0:
+                return "No error"s;
+            case DATAGRAM_ERROR_EXCEPTION:
+                return "Error - datagram exception"s;
+            case STREAM_ERROR_EXCEPTION:
+                return "Error - stream exception"s;
+            case BPARSER_ERROR_EXCEPTION:
+                return "Error - bt request stream exception"s;
+            case STREAM_ERROR_CONNECTION_EXPIRED:
+                return "Error - stream connection expired"s;
+            case CONN_WRITE_CLOSE_FAIL:
+                return "Error - Failed to write connection close"s;
+            case CONN_SEND_CLOSE_FAIL:
+                return "Error - Failed to send connection close"s;
             default:
-                return "Application-Specified Error";
+                return "Application error code {}"_format(e);
         }
     }
 
@@ -48,9 +76,8 @@ namespace oxen::quic
         bool is_ngtcp2 = false;
 
         io_error() = default;
-        explicit io_error(int e) : _code{static_cast<uint64_t>(e)} { is_ngtcp2 = true; }
-        explicit io_error(uint64_t e) : _code{e} { is_ngtcp2 = false; }
-        explicit io_error(error e) : _code{static_cast<uint64_t>(e)} {}
+        explicit io_error(int e) : _code{static_cast<uint64_t>(e)}, is_ngtcp2{true} {}
+        explicit io_error(uint64_t e) : _code{e} {}
 
         uint64_t code() const { return _code; }
 
@@ -59,17 +86,11 @@ namespace oxen::quic
         uint64_t ngtcp2() const
         {
             if (not is_ngtcp2)
-                log::info(log_cat, "Error code {} is not an ngtcp2 error code", _code);
+                log::warning(log_cat, "Error code {} is not an ngtcp2 error code", _code);
             return _code;
         }
 
-        const char* strerror() const
-        {
-            if (is_ngtcp2)
-                return ngtcp2_strerror(_code);
-            else
-                return quic_strerror(_code);
-        }
+        std::string strerror() const { return is_ngtcp2 ? ngtcp2_strerror(static_cast<int>(_code)) : quic_strerror(_code); }
     };
 
 }  // namespace oxen::quic

--- a/include/quic/gnutls_crypto.hpp
+++ b/include/quic/gnutls_crypto.hpp
@@ -335,9 +335,9 @@ namespace oxen::quic
 
         bool is_client;
 
-        gnutls_key expected_remote_key{};
+        gnutls_key _expected_remote_key{};
 
-        gnutls_key remote_key{};
+        gnutls_key _remote_key{};
 
         void set_tls_hook_functions();  // TODO: which and when?
       public:
@@ -350,6 +350,8 @@ namespace oxen::quic
         ~GNUTLSSession();
 
         void* get_session() override { return session; };
+
+        ustring_view remote_key() const override { return _remote_key.view(); }
 
         ustring_view selected_alpn() override;
 
@@ -364,7 +366,7 @@ namespace oxen::quic
 
         int validate_remote_key();
 
-        void set_expected_remote_key(ustring key) override { expected_remote_key(key); }
+        void set_expected_remote_key(ustring key) override { _expected_remote_key(key); }
     };
 
     GNUTLSSession* get_session_from_gnutls(gnutls_session_t g_session);

--- a/include/quic/opt.hpp
+++ b/include/quic/opt.hpp
@@ -8,11 +8,20 @@
 
 namespace oxen::quic::opt
 {
+    using namespace std::chrono_literals;
+
     struct max_streams
     {
-        uint64_t stream_count = DEFAULT_MAX_BIDI_STREAMS;
+        uint64_t stream_count{DEFAULT_MAX_BIDI_STREAMS};
         max_streams() = default;
         explicit max_streams(uint64_t s) : stream_count{s} {}
+    };
+
+    struct keep_alive
+    {
+        std::chrono::milliseconds time{0ms};
+        keep_alive() = default;
+        explicit keep_alive(std::chrono::milliseconds val) : time{val} {}
     };
 
     /// This can be initialized a few different ways. Simply passing a default constructed struct
@@ -36,10 +45,10 @@ namespace oxen::quic::opt
     /// destroyed and re-initialized with the desired settings.
     struct enable_datagrams
     {
-        bool split_packets = false;
-        Splitting mode = Splitting::NONE;
+        bool split_packets{false};
+        Splitting mode{Splitting::NONE};
         // Note: this is the size of the entire buffer, divided amongst 4 rows
-        int bufsize = 4096;
+        int bufsize{4096};
 
         enable_datagrams() = default;
         explicit enable_datagrams(bool e) = delete;

--- a/include/quic/opt.hpp
+++ b/include/quic/opt.hpp
@@ -10,9 +10,9 @@ namespace oxen::quic::opt
 {
     struct max_streams
     {
-        int stream_count = DEFAULT_MAX_BIDI_STREAMS;
+        uint64_t stream_count = DEFAULT_MAX_BIDI_STREAMS;
         max_streams() = default;
-        explicit max_streams(int s) : stream_count{s} {}
+        explicit max_streams(uint64_t s) : stream_count{s} {}
     };
 
     /// This can be initialized a few different ways. Simply passing a default constructed struct

--- a/include/quic/stream.hpp
+++ b/include/quic/stream.hpp
@@ -81,6 +81,10 @@ namespace oxen::quic
                 close_callback(*this, app_code);
         }
 
+        // Called immediately after set_ready so that a subclass can do thing as soon as the stream
+        // becomes ready.  The default does nothing.
+        virtual void on_ready() {}
+
         void send_impl(bstring_view data, std::shared_ptr<void> keep_alive = nullptr) override;
 
       private:
@@ -263,11 +267,7 @@ namespace oxen::quic
         {
             log::trace(log_cat, "Setting stream ready");
             ready = true;
-        }
-        inline void set_not_ready()
-        {
-            log::trace(log_cat, "Setting stream not ready");
-            ready = false;
+            on_ready();
         }
     };
 }  // namespace oxen::quic

--- a/include/quic/stream.hpp
+++ b/include/quic/stream.hpp
@@ -56,7 +56,7 @@ namespace oxen::quic
 
         std::shared_ptr<Stream> get_stream() override;
 
-        void close(io_error ec = io_error{});
+        void close(uint64_t app_err_code = 0);
 
         void set_stream_data_cb(stream_data_callback cb) { data_callback = std::move(cb); }
 

--- a/include/quic/stream.hpp
+++ b/include/quic/stream.hpp
@@ -40,7 +40,7 @@ namespace oxen::quic
                Endpoint& ep,
                stream_data_callback data_cb = nullptr,
                stream_close_callback close_cb = nullptr);
-        ~Stream();
+        ~Stream() override;
 
         bool available() const { return !(_is_closing || is_shutdown || _sent_fin); }
         bool is_stream() const override { return true; }

--- a/include/quic/stream.hpp
+++ b/include/quic/stream.hpp
@@ -34,12 +34,15 @@ namespace oxen::quic
     class Stream : public IOChannel, public std::enable_shared_from_this<Stream>
     {
         friend class Connection;
+        friend class Network;
 
-      public:
+      protected:
         Stream(Connection& conn,
                Endpoint& ep,
                stream_data_callback data_cb = nullptr,
                stream_close_callback close_cb = nullptr);
+
+      public:
         ~Stream() override;
 
         bool available() const { return !(_is_closing || is_shutdown || _sent_fin); }

--- a/include/quic/utils.hpp
+++ b/include/quic/utils.hpp
@@ -111,7 +111,7 @@ namespace oxen::quic
         return x * 1024 * 1_Gi;
     }
 
-    inline constexpr int DEFAULT_MAX_BIDI_STREAMS = 32;
+    inline constexpr uint64_t DEFAULT_MAX_BIDI_STREAMS = 32;
 
     // NGTCP2 sets the path_pmtud_payload to 1200 on connection creation, then discovers upwards
     // to a theoretical max of 1452. In 'lazy' mode, we take in split packets under the current max
@@ -147,23 +147,23 @@ namespace oxen::quic
     using remove_cvref_t = std::remove_cv_t<std::remove_reference_t<T>>;
 
     // strang literals
-    inline ustring operator""_us(const char* __str, size_t __len) noexcept
+    inline ustring operator""_us(const char* str, size_t len) noexcept
     {
-        return ustring(reinterpret_cast<const unsigned char*>(__str), __len);
+        return {reinterpret_cast<const unsigned char*>(str), len};
     }
-    inline ustring_view operator""_usv(const char* __str, size_t __len) noexcept
+    inline ustring_view operator""_usv(const char* str, size_t len) noexcept
     {
-        return ustring_view(reinterpret_cast<const unsigned char*>(__str), __len);
-    }
-
-    inline bstring_view operator""_bsv(const char* __str, size_t __len) noexcept
-    {
-        return bstring_view(reinterpret_cast<const std::byte*>(__str), __len);
+        return {reinterpret_cast<const unsigned char*>(str), len};
     }
 
-    inline bstring operator""_bs(const char* _str, size_t _len) noexcept
+    inline bstring_view operator""_bsv(const char* str, size_t len) noexcept
     {
-        return bstring(reinterpret_cast<const std::byte*>(_str), _len);
+        return {reinterpret_cast<const std::byte*>(str), len};
+    }
+
+    inline bstring operator""_bs(const char* str, size_t len) noexcept
+    {
+        return {reinterpret_cast<const std::byte*>(str), len};
     }
 
     template <

--- a/include/quic/utils.hpp
+++ b/include/quic/utils.hpp
@@ -146,13 +146,6 @@ namespace oxen::quic
     template <typename T>
     using remove_cvref_t = std::remove_cv_t<std::remove_reference_t<T>>;
 
-    // Application error code we close with if the stream data handle throws
-    inline constexpr uint64_t STREAM_ERROR_EXCEPTION = (1ULL << 62) - 2;
-    // Application error code we close with if the datagram data handle throws
-    inline constexpr uint64_t DATAGRAM_ERROR_EXCEPTION = (1ULL << 62) - 32;
-    // Error code we send to a stream close callback if the stream's connection expires
-    inline constexpr uint64_t STREAM_ERROR_CONNECTION_EXPIRED = (1ULL << 62) + 1;
-
     // strang literals
     inline ustring operator""_us(const char* __str, size_t __len) noexcept
     {

--- a/src/btstream.cpp
+++ b/src/btstream.cpp
@@ -5,7 +5,8 @@
 namespace oxen::quic
 {
 
-    static std::pair<std::ptrdiff_t, std::size_t> get_location(bstring& data, std::string_view substr) {
+    static std::pair<std::ptrdiff_t, std::size_t> get_location(bstring& data, std::string_view substr)
+    {
         auto* bsubstr = reinterpret_cast<const std::byte*>(substr.data());
         // Make sure the given substr actually is a substr of data:
         assert(bsubstr >= data.data() && bsubstr + substr.size() <= data.data() + data.size());
@@ -88,7 +89,8 @@ namespace oxen::quic
 
     void BTRequestStream::register_command(std::string ep, std::function<void(message)> func)
     {
-        endpoint.call([&]() { func_map[std::move(ep)] = std::move(func); });
+        endpoint.call(
+                [this, ep = std::move(ep), func = std::move(func)]() mutable { func_map[std::move(ep)] = std::move(func); });
     }
 
     void BTRequestStream::handle_input(message msg)

--- a/src/btstream.cpp
+++ b/src/btstream.cpp
@@ -25,6 +25,8 @@ namespace oxen::quic
             ep = get_location(data, btlc.consume_string_view());
 
         req_body = get_location(data, btlc.consume_string_view());
+
+        btlc.finish();
     }
 
     void message::respond(bstring_view body, bool error)

--- a/src/btstream.cpp
+++ b/src/btstream.cpp
@@ -236,7 +236,7 @@ namespace oxen::quic
         auto [ptr, ec] = std::from_chars(req.data(), req.data() + pos, current_len);
 
         const char* bad = nullptr;
-        if (ec != std::errc())
+        if (ec != std::errc() || ptr != req.data() + pos)
             bad = "Invalid incoming request encoding!";
         else if (current_len == 0)
             bad = "Invalid empty bt request!";

--- a/src/btstream.cpp
+++ b/src/btstream.cpp
@@ -73,13 +73,13 @@ namespace oxen::quic
         catch (const std::exception& e)
         {
             log::error(bp_cat, "Exception caught: {}", e.what());
-            close(io_error{BPARSER_EXCEPTION});
+            close(BPARSER_ERROR_EXCEPTION);
         }
     }
 
     void BTRequestStream::closed(uint64_t app_code)
     {
-        log::info(bp_cat, "bparser close callback called!");
+        log::info(bp_cat, "bparser close callback called with {}", quic_strerror(app_code));
         close_callback(*this, app_code);
     }
 
@@ -239,7 +239,7 @@ namespace oxen::quic
 
         if (bad)
         {
-            close(io_error{BPARSER_EXCEPTION});
+            close(BPARSER_ERROR_EXCEPTION);
             throw std::invalid_argument{bad};
         }
 

--- a/src/btstream.cpp
+++ b/src/btstream.cpp
@@ -14,7 +14,7 @@ namespace oxen::quic
     }
 
     message::message(BTRequestStream& bp, bstring req, bool is_error) :
-            data{std::move(req)}, return_sender{bp.weak_from_this()}, cid{bp.conn_id()}, timed_out{is_error}
+            data{std::move(req)}, return_sender{bp.weak_from_this()}, cid{bp.conn_id()}, is_error{is_error}
     {
         oxenc::bt_list_consumer btlc(data);
 
@@ -23,8 +23,6 @@ namespace oxen::quic
 
         if (auto rt = type(); rt == "C")
             ep = get_location(data, btlc.consume_string_view());
-        else if (rt == "E")
-            is_error = true;
 
         req_body = get_location(data, btlc.consume_string_view());
     }

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -349,10 +349,10 @@ namespace oxen::quic
     // so, we move them to the streams map, where they will get picked up by flush_streams and dump
     // their buffers. If none are ready, we keep chugging along and make another stream as usual. Though
     // if none of the pending streams are ready, the new stream really shouldn't be ready, but here we are
-    void Connection::check_pending_streams(int available)
+    void Connection::check_pending_streams(uint64_t available)
     {
         log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
-        int popped = 0;
+        uint64_t popped = 0;
 
         while (!pending_streams.empty() && popped < available)
         {
@@ -1049,13 +1049,10 @@ namespace oxen::quic
         datagrams->send(data, std::move(keep_alive));
     }
 
-    int Connection::get_streams_available() const
+    uint64_t Connection::get_streams_available() const
     {
         log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
-        uint64_t open = ngtcp2_conn_get_streams_bidi_left(conn.get());
-        if (open > std::numeric_limits<uint64_t>::max())
-            return -1;
-        return open;
+        return ngtcp2_conn_get_streams_bidi_left(conn.get());
     }
 
     size_t Connection::get_max_datagram_size() const

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -987,7 +987,7 @@ namespace oxen::quic
 
             try
             {
-                datagrams->dgram_data_cb(di, (maybe_data ? std::move(*maybe_data) : bstring{data.begin(), data.end()}));
+                datagrams->dgram_data_cb(*di, (maybe_data ? std::move(*maybe_data) : bstring{data.begin(), data.end()}));
                 good = true;
             }
             catch (const std::exception& e)
@@ -1157,6 +1157,8 @@ namespace oxen::quic
 #ifndef NDEBUG
             callbacks.ack_datagram = on_ack_datagram;
 #endif
+
+            di = std::make_shared<dgram_interface>(*this);
         }
         else
         {
@@ -1187,8 +1189,7 @@ namespace oxen::quic
             _max_streams{context->config.max_streams ? context->config.max_streams : DEFAULT_MAX_BIDI_STREAMS},
             _datagrams_enabled{context->config.datagram_support},
             _packet_splitting{context->config.split_packet},
-            tls_creds{context->tls_creds},
-            di{*this}
+            tls_creds{context->tls_creds}
     {
         // If a connection_{established/closed}_callback was passed to IOContext via `Endpoint::{listen,connect}(...)`...
         //  - If this is an outbound, steal the callback to be used once. Outbound connections

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -226,6 +226,11 @@ namespace oxen::quic
         return datagrams->recv_buffer.last_cleared;
     }
 
+    ustring_view Connection::remote_key() const
+    {
+        return dynamic_cast<GNUTLSSession*>(get_session())->remote_key();
+    }
+
     TLSSession* Connection::get_session() const
     {
         return tls_session.get();

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -812,7 +812,7 @@ namespace oxen::quic
 
         auto stream = (context->stream_construct_cb)
                             ? context->stream_construct_cb(*this, _endpoint, id)
-                            : std::make_shared<Stream>(*this, _endpoint, context->stream_data_cb, context->stream_close_cb);
+                            : _endpoint.make_shared<Stream>(*this, _endpoint, context->stream_data_cb, context->stream_close_cb);
         stream->_stream_id = id;
         stream->set_ready();
 
@@ -1154,7 +1154,7 @@ namespace oxen::quic
             callbacks.ack_datagram = on_ack_datagram;
 #endif
 
-            di = std::make_shared<dgram_interface>(*this);
+            di = _endpoint.make_shared<dgram_interface>(*this);
         }
         else
         {
@@ -1199,8 +1199,8 @@ namespace oxen::quic
                                ? is_outbound() ? std::move(context->conn_closed_cb) : context->conn_closed_cb
                                : nullptr;
 
-        datagrams = std::make_unique<DatagramIO>(*this, _endpoint, ep.dgram_recv_cb);
-        pseudo_stream = std::make_shared<Stream>(*this, _endpoint);
+        datagrams = _endpoint.make_shared<DatagramIO>(*this, _endpoint, ep.dgram_recv_cb);
+        pseudo_stream = _endpoint.make_shared<Stream>(*this, _endpoint);
         pseudo_stream->_stream_id = -1;
 
         const auto is_outbound = (dir == Direction::OUTBOUND);

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -389,10 +389,10 @@ namespace oxen::quic
             std::function<std::shared_ptr<Stream>(Connection& c, Endpoint& e)> make_stream)
     {
         return _endpoint.call_get([this, &make_stream]() {
-            auto stream = construct_stream(make_stream);
+            auto stream = construct_stream(make_stream, next_incoming_stream_id);
 
             stream->set_not_ready();
-            stream->_stream_id = next_incoming_stream_id;
+            // stream->_stream_id = next_incoming_stream_id;
             next_incoming_stream_id += 4;
 
             auto& str = stream_queue[stream->_stream_id];

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -425,6 +425,15 @@ namespace oxen::quic
         });
     }
 
+    std::shared_ptr<Stream> Connection::get_stream_impl(int64_t id)
+    {
+        return _endpoint.call_get([this, id]() -> std::shared_ptr<Stream> {
+            if (auto it = streams.find(id); it != streams.end())
+                return it->second;
+            return nullptr;
+        });
+    }
+
     stream_data_callback Connection::get_default_data_callback() const
     {
         return context->stream_data_cb;
@@ -801,11 +810,6 @@ namespace oxen::quic
             tv.tv_usec = 0;
         }
         event_add(packet_retransmit_timer.get(), &tv);
-    }
-
-    std::shared_ptr<Stream> Connection::get_stream(int64_t ID) const
-    {
-        return _endpoint.call_get([this, ID] { return streams.at(ID); });
     }
 
     int Connection::stream_opened(int64_t id)

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -1282,6 +1282,8 @@ namespace oxen::quic
             throw std::runtime_error{"Failed to initialize connection object: "s + ngtcp2_strerror(rv)};
         }
 
+        ngtcp2_conn_set_keep_alive_timeout(connptr, context->config.keep_alive.count());
+
         tls_session = tls_creds->make_session(is_outbound, alpns);
 
         if (remote_pk)

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -1313,4 +1313,18 @@ namespace oxen::quic
         return conn;
     }
 
+#ifndef NDEBUG
+
+    connection_interface::~connection_interface()
+    {
+        log::debug(log_cat, "connection_interface @{} destroyed", (void*)this);
+    }
+
+    Connection::~Connection()
+    {
+        log::debug(log_cat, "Connection @{} destroyed", (void*)this);
+    }
+
+#endif
+
 }  // namespace oxen::quic

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -392,7 +392,7 @@ namespace oxen::quic
             auto stream = construct_stream(make_stream, next_incoming_stream_id);
 
             stream->set_not_ready();
-            // stream->_stream_id = next_incoming_stream_id;
+            stream->_stream_id = next_incoming_stream_id;
             next_incoming_stream_id += 4;
 
             auto& str = stream_queue[stream->_stream_id];
@@ -907,7 +907,7 @@ namespace oxen::quic
             return 0;
         }
 
-        log::debug(log_cat, "Stream (ID: {}) received data: {}", id, buffer_printer{data});
+        log::trace(log_cat, "Stream (ID: {}) received data: {}", id, buffer_printer{data});
 
         std::optional<uint64_t> error;
         try

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -452,6 +452,10 @@ namespace oxen::quic
         return _endpoint.call_get([this, id]() -> std::shared_ptr<Stream> {
             if (auto it = streams.find(id); it != streams.end())
                 return it->second;
+
+            if (auto it = stream_queue.find(id); it != stream_queue.end())
+                return it->second;
+
             return nullptr;
         });
     }

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -15,6 +15,12 @@ namespace oxen::quic
         log::trace(log_cat, "User passed max_streams_bidi config value: {}", config.max_streams);
     }
 
+    void IOContext::handle_ioctx_opt(opt::keep_alive ka)
+    {
+        config.keep_alive = ka.time;
+        log::trace(log_cat, "User passed connection keep_alive config value: {}", config.keep_alive.count());
+    }
+
     void IOContext::handle_ioctx_opt(stream_data_callback func)
     {
         log::trace(log_cat, "IO context stored stream close callback");

--- a/src/datagram.cpp
+++ b/src/datagram.cpp
@@ -38,7 +38,7 @@ namespace oxen::quic
         ci.send_datagram(data, std::move(keep_alive));
     }
 
-    void DatagramIO::send(bstring_view data, std::shared_ptr<void> keep_alive)
+    void DatagramIO::send_impl(bstring_view data, std::shared_ptr<void> keep_alive)
     {
         // check this first and once; already considers policy when returning
         const auto max_size = conn.get_max_datagram_size();

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -300,7 +300,7 @@ namespace oxen::quic
             log::warning(
                     log_cat,
                     "Error: Failed to write connection close packet: {}",
-                    (written < 0) ? strerror(written) : "[Error Unknown: closing pkt is 0 bytes?]"s);
+                    (written < 0) ? ngtcp2_strerror(written) : "[Error Unknown: closing pkt is 0 bytes?]"s);
 
             delete_connection(conn.scid());
             return;

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -540,16 +540,14 @@ namespace oxen::quic
     {
         auto now = get_time();
 
-        const auto& f = draining.begin();
-
-        while (!draining.empty() && f->first < now)
+        for (auto it = draining.begin(); it != draining.end() && it->first < now; )
         {
-            if (auto itr = conns.find(f->second); itr != conns.end())
+            if (auto itr = conns.find(it->second); itr != conns.end())
             {
                 log::debug(log_cat, "Deleting connection {}", *itr->first.data);
                 conns.erase(itr);
             }
-            draining.erase(f);
+            it = draining.erase(it);
         }
     }
 

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -243,6 +243,10 @@ namespace oxen::quic
         if (conn.is_closing() || conn.is_draining())
             return;
 
+        // mark connection as closing so that if we re-enter we won't try closing a second time
+        conn.set_closing();
+        conn.halt_events();
+
         if (ec.ngtcp2_code() == NGTCP2_ERR_IDLE_CLOSE)
         {
             log::info(
@@ -264,10 +268,6 @@ namespace oxen::quic
                     "Connection (CID: {}) passed idle expiry timer; closing now with close packet",
                     *conn.scid().data);
         }
-
-        // mark connection as closing
-        conn.halt_events();
-        conn.set_closing();
 
         // prioritize connection level callback over endpoint level
         if (conn.conn_closed_cb)

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -540,7 +540,7 @@ namespace oxen::quic
     {
         auto now = get_time();
 
-        for (auto it = draining.begin(); it != draining.end() && it->first < now; )
+        for (auto it = draining.begin(); it != draining.end() && it->first < now;)
         {
             if (auto itr = conns.find(it->second); itr != conns.end())
             {

--- a/src/gnutls_session.cpp
+++ b/src/gnutls_session.cpp
@@ -78,7 +78,7 @@ namespace oxen::quic
         log::trace(log_cat, "Entered {}", __PRETTY_FUNCTION__);
 
         if (expected_key)
-            expected_remote_key = *expected_key;
+            _expected_remote_key = *expected_key;
 
         auto direction_string = (is_client) ? "Client"s : "Server"s;
         log::trace(log_cat, "Creating {} GNUTLSSession", direction_string);
@@ -311,11 +311,11 @@ namespace oxen::quic
                 buffer_printer{cert_data, cert_size});
 
         // pubkey comes as 12 bytes header + 32 bytes key
-        remote_key.write(cert_data, cert_size);
+        _remote_key.write(cert_data, cert_size);
 
         if (is_client)
         {  // Client does validation through a remote pubkey provided when calling endpoint::connect
-            if (remote_key == expected_remote_key)
+            if (_remote_key == _expected_remote_key)
             {
                 log::debug(log_cat, "Client successfully validated remote key!");
                 return 1;
@@ -336,7 +336,7 @@ namespace oxen::quic
                 // provided a certificate and is only called by the server, we can assume the following returns:
                 //      true: the certificate was verified, and the connection is marked as validated
                 //      false: the certificate was not verified, and the connection is rejected
-                return creds.key_verify(remote_key.view(), alpn);
+                return creds.key_verify(_remote_key.view(), alpn);
             }
 
             log::debug(log_cat, "Server did not provide key verify callback! Allowing connection");

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -161,7 +161,7 @@ namespace oxen::quic
     void Stream::send_impl(bstring_view data, std::shared_ptr<void> keep_alive)
     {
         if (data.empty())
-            throw std::invalid_argument{"Cannot send empty byte string"};
+            return;
 
         endpoint.call([this, data, keep_alive]() {
             log::trace(log_cat, "Stream (ID: {}) sending message: {}", _stream_id, buffer_printer{data});

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -158,7 +158,7 @@ namespace oxen::quic
         return nbufs;
     }
 
-    void Stream::send(bstring_view data, std::shared_ptr<void> keep_alive)
+    void Stream::send_impl(bstring_view data, std::shared_ptr<void> keep_alive)
     {
         if (data.empty())
             throw std::invalid_argument{"Cannot send empty byte string"};

--- a/tests/001-handshake.cpp
+++ b/tests/001-handshake.cpp
@@ -132,7 +132,7 @@ namespace oxen::quic::test
         Address client_local{};
 
         auto server_endpoint = test_net.endpoint(server_local, server_established);
-        REQUIRE(server_endpoint->listen(server_tls));
+        REQUIRE_NOTHROW(server_endpoint->listen(server_tls));
 
         SECTION("Endpoint::listen() + Endpoint::Connect() - Incorrect pubkey in remote")
         {
@@ -207,7 +207,7 @@ namespace oxen::quic::test
         Address client_local{};
 
         auto server_endpoint = test_net.endpoint(server_local, server_established);
-        REQUIRE(server_endpoint->listen(server_tls));
+        REQUIRE_NOTHROW(server_endpoint->listen(server_tls));
 
         auto client_endpoint = test_net.endpoint(client_local, client_established);
         RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
@@ -240,7 +240,7 @@ namespace oxen::quic::test
             Address client_local{};
 
             auto server_endpoint = test_net.endpoint(server_local, server_established);
-            REQUIRE(server_endpoint->listen(server_tls));
+            REQUIRE_NOTHROW(server_endpoint->listen(server_tls));
 
             RemoteAddress client_remote{defaults::SERVER_PUBKEY, "::1"s, server_endpoint->local().port()};
 
@@ -266,7 +266,7 @@ namespace oxen::quic::test
         Address client_local{};
 
         auto server_endpoint = test_net.endpoint(server_local, server_established);
-        REQUIRE(server_endpoint->listen(server_tls));
+        REQUIRE_NOTHROW(server_endpoint->listen(server_tls));
 
         RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
 

--- a/tests/001-handshake.cpp
+++ b/tests/001-handshake.cpp
@@ -146,7 +146,7 @@ namespace oxen::quic::test
             auto client_endpoint = test_net.endpoint(client_local, client_established_2, client_closed);
             auto client_ci = client_endpoint->connect(client_remote, client_tls);
 
-            REQUIRE(not client_established.wait());
+            REQUIRE(not client_established_2.wait());
             REQUIRE(client_attempt != 1000);
             REQUIRE(client_error == 1000);
         };
@@ -168,8 +168,11 @@ namespace oxen::quic::test
         {
             auto client_ci = client_endpoint->connect(client_remote, client_tls);
 
-            // This will return false until the connection has had time to establish and validate
-            REQUIRE_FALSE(client_ci->is_validated());
+            // This will return false until the connection has had time to establish and validate. Depending
+            // on the architecture running the test, the connection may be already established and validated
+            // by the time this line es executed
+            CHECK_NOFAIL(client_ci->is_validated());
+
             REQUIRE(client_established.wait());
             REQUIRE(server_established.wait());
             REQUIRE(client_ci->is_validated());

--- a/tests/002-send-receive.cpp
+++ b/tests/002-send-receive.cpp
@@ -443,6 +443,10 @@ namespace oxen::quic::test
         auto done = done_prom.get_future();
         int responses = 0, good_responses = 0;
 
+        // Make sure debug logging is off for these because at debug log this produces so much log
+        // output it can take too long to run the tests within our 5s future wait.
+        log_level_raiser log_relief{log::Level::info};
+
         SECTION("Huge but not too huge")
         {
             std::string req_msg(9'000'000, 'a');

--- a/tests/002-send-receive.cpp
+++ b/tests/002-send-receive.cpp
@@ -436,12 +436,7 @@ namespace oxen::quic::test
         Address server_local{};
         Address client_local{};
 
-        static constexpr int num_requests = 10;
-
-        std::mutex mut;
-        std::promise<void> done_prom;
-        auto done = done_prom.get_future();
-        int responses = 0, good_responses = 0;
+        static constexpr int num_requests = 5;
 
         // Make sure debug logging is off for these because at debug log this produces so much log
         // output it can take too long to run the tests within our 5s future wait.
@@ -449,10 +444,15 @@ namespace oxen::quic::test
 
         SECTION("Huge but not too huge")
         {
+            std::promise<void> done_prom;
+            auto done = done_prom.get_future();
+
+            std::atomic<int> responses = 0, good_responses = 0;
+
             std::string req_msg(9'000'000, 'a');
             constexpr auto res_msg = "oh look some a's"sv;
 
-            auto server_handler = [&](message msg) {
+            auto server_handler = [&](message msg) mutable {
                 if (msg)
                 {
                     if (msg.body() == req_msg)
@@ -462,14 +462,13 @@ namespace oxen::quic::test
                 }
             };
 
-            auto client_reply_handler = [&](message msg) {
+            auto client_reply_handler = [&](message msg) mutable {
                 if (msg)
                 {
-                    std::lock_guard lock{mut};
-                    responses++;
-                    log::debug(log_cat, "Client bparser received response {}: {}", responses, msg.view());
+                    ++responses;
+                    log::debug(log_cat, "Client bparser received response {}: {}", responses.load(), msg.view());
                     if (msg.body() == res_msg)
-                        good_responses++;
+                        ++good_responses;
                     if (responses == num_requests)
                         done_prom.set_value();
                 }
@@ -501,59 +500,62 @@ namespace oxen::quic::test
             }
 
             CHECK(done.wait_for(5s) == std::future_status::ready);
-            std::lock_guard lock{mut};
             CHECK(good_responses == num_requests);
             CHECK(responses == good_responses);
         }
 
-        std::string req_msg(10'000'000, 'a');
-
-        auto server_handler = [&](message) {
-            REQUIRE(false);  // Should not get here!
-        };
-
-        auto client_reply_handler = [&](message msg) {
-            if (msg)
-                log::debug(log_cat, "Client bparser received response {}: {}", responses, msg.view());
-            else
-                log::debug(log_cat, "got back a failed message response");
-        };
-
-        stream_constructor_callback server_constructor = [&](Connection& c, Endpoint& e, std::optional<int64_t>) {
-            auto s = e.make_shared<BTRequestStream>(c, e);
-            s->register_command("test_endpoint"s, server_handler);
-            return s;
-        };
-
-        auto server_endpoint = test_net.endpoint(server_local);
-        REQUIRE_NOTHROW(server_endpoint->listen(server_tls, server_constructor));
-
-        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
-
-        auto client_endpoint = test_net.endpoint(client_local);
-        auto conn_interface = client_endpoint->connect(client_remote, client_tls);
-
-        SECTION("Too huge send failure")
+        SECTION("Too huge")
         {
-            std::shared_ptr<BTRequestStream> client_bp = conn_interface->open_stream<BTRequestStream>();
-            CHECK_THROWS_WITH(client_bp->command("test_endpoint"s, req_msg, client_reply_handler), "Request body too long!");
-        }
+            std::string req_msg(10'000'000, 'a');
 
-        SECTION("Too huge receive failure")
-        {
-            // Construct a bt request manually so that we can send invalid (too long) data at the
-            // server (normally a client won't let us do that, as tested in the above section)
-            std::string payload = "li123e1:C{}:{}e"_format(req_msg.size(), req_msg);
-            payload = "{}:{}"_format(payload.size(), payload);
+            auto server_handler = [&](message) mutable {
+                REQUIRE(false);  // Should not get here!
+            };
 
-            std::atomic<uint64_t> close_err = -1;
-            auto stream_close_cb = callback_waiter{[&](Stream&, uint64_t error_code) { close_err = error_code; }};
-            auto str = conn_interface->open_stream<Stream>(nullptr, stream_close_cb);
+            auto client_reply_handler = [&](message msg) mutable {
+                if (msg)
+                    log::debug(log_cat, "Client bparser received response: {}", msg.view());
+                else
+                    log::debug(log_cat, "got back a failed message response");
+            };
 
-            str->send(std::move(payload));
+            stream_constructor_callback server_constructor = [&](Connection& c, Endpoint& e, std::optional<int64_t>) {
+                auto s = e.make_shared<BTRequestStream>(c, e);
+                s->register_command("test_endpoint"s, server_handler);
+                return s;
+            };
 
-            REQUIRE(stream_close_cb.wait());
-            CHECK(close_err.load() == BPARSER_ERROR_EXCEPTION);
+            auto server_endpoint = test_net.endpoint(server_local);
+            REQUIRE_NOTHROW(server_endpoint->listen(server_tls, server_constructor));
+
+            RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+
+            auto client_endpoint = test_net.endpoint(client_local);
+            auto conn_interface = client_endpoint->connect(client_remote, client_tls);
+
+            SECTION("Send failure")
+            {
+                std::shared_ptr<BTRequestStream> client_bp = conn_interface->open_stream<BTRequestStream>();
+                CHECK_THROWS_WITH(
+                        client_bp->command("test_endpoint"s, req_msg, client_reply_handler), "Request body too long!");
+            }
+
+            SECTION("Receive failure")
+            {
+                // Construct a bt request manually so that we can send invalid (too long) data at the
+                // server (normally a client won't let us do that, as tested in the above section)
+                std::string payload = "li123e1:C{}:{}e"_format(req_msg.size(), req_msg);
+                payload = "{}:{}"_format(payload.size(), payload);
+
+                std::atomic<uint64_t> close_err = -1;
+                auto stream_close_cb = callback_waiter{[&](Stream&, uint64_t error_code) { close_err = error_code; }};
+                auto str = conn_interface->open_stream<Stream>(nullptr, stream_close_cb);
+
+                str->send(std::move(payload));
+
+                REQUIRE(stream_close_cb.wait());
+                CHECK(close_err.load() == BPARSER_ERROR_EXCEPTION);
+            }
         }
     }
 

--- a/tests/002-send-receive.cpp
+++ b/tests/002-send-receive.cpp
@@ -549,7 +549,7 @@ namespace oxen::quic::test
             str->send(std::move(payload));
 
             REQUIRE(stream_close_cb.wait());
-            CHECK(close_err.load() == BPARSER_EXCEPTION);
+            CHECK(close_err.load() == BPARSER_ERROR_EXCEPTION);
         }
     }
 

--- a/tests/002-send-receive.cpp
+++ b/tests/002-send-receive.cpp
@@ -248,7 +248,7 @@ namespace oxen::quic::test
             }};
 
             stream_constructor_callback server_constructor = [&](Connection& c, Endpoint& e, std::optional<int64_t>) {
-                auto s = std::make_shared<BTRequestStream>(c, e);
+                auto s = e.make_shared<BTRequestStream>(c, e);
                 s->register_command("test_endpoint"s, server_bp_cb);
                 return s;
             };
@@ -287,13 +287,13 @@ namespace oxen::quic::test
             }};
 
             stream_constructor_callback server_constructor = [&](Connection& c, Endpoint& e, std::optional<int64_t>) {
-                auto s = std::make_shared<BTRequestStream>(c, e);
+                auto s = e.make_shared<BTRequestStream>(c, e);
                 s->register_command("test_endpoint"s, server_bp_cb);
                 return s;
             };
 
             stream_constructor_callback client_constructor = [&](Connection& c, Endpoint& e, std::optional<int64_t>) {
-                return std::make_shared<BTRequestStream>(c, e);
+                return e.make_shared<BTRequestStream>(c, e);
             };
 
             auto server_endpoint = test_net.endpoint(server_local);
@@ -331,7 +331,7 @@ namespace oxen::quic::test
             }};
 
             stream_constructor_callback server_constructor = [&](Connection& c, Endpoint& e, std::optional<int64_t>) {
-                auto s = std::make_shared<BTRequestStream>(c, e);
+                auto s = e.make_shared<BTRequestStream>(c, e);
                 s->register_command("test_endpoint"s, server_bp_cb);
                 return s;
             };
@@ -401,7 +401,7 @@ namespace oxen::quic::test
         };
 
         stream_constructor_callback server_constructor = [&](Connection& c, Endpoint& e, std::optional<int64_t>) {
-            auto s = std::make_shared<BTRequestStream>(c, e);
+            auto s = e.make_shared<BTRequestStream>(c, e);
             s->register_command("test_endpoint"s, server_handler);
             return s;
         };
@@ -476,7 +476,7 @@ namespace oxen::quic::test
             };
 
             stream_constructor_callback server_constructor = [&](Connection& c, Endpoint& e, std::optional<int64_t>) {
-                auto s = std::make_shared<BTRequestStream>(c, e);
+                auto s = e.make_shared<BTRequestStream>(c, e);
                 s->register_command("test_endpoint"s, server_handler);
                 return s;
             };
@@ -516,7 +516,7 @@ namespace oxen::quic::test
         };
 
         stream_constructor_callback server_constructor = [&](Connection& c, Endpoint& e, std::optional<int64_t>) {
-            auto s = std::make_shared<BTRequestStream>(c, e);
+            auto s = e.make_shared<BTRequestStream>(c, e);
             s->register_command("test_endpoint"s, server_handler);
             return s;
         };

--- a/tests/002-send-receive.cpp
+++ b/tests/002-send-receive.cpp
@@ -190,23 +190,29 @@ namespace oxen::quic::test
         auto conn_to_a = server_endpoint_b->connect(server_remote_a, server_tls);
         auto stream_to_a = conn_to_a->get_new_stream();
 
-        SECTION("Sending bstring_view of long-lived buffer") {
-            for (int i = 0; i < tests; i++) {
+        SECTION("Sending bstring_view of long-lived buffer")
+        {
+            for (int i = 0; i < tests; i++)
+            {
                 // There is no ownership issue here: we're just viewing into our `good_msg` which we
                 // are keeping alive already for the duration of this test.
                 stream_to_a->send(bstring_view{good_msg});
             }
         }
-        SECTION("Sending bstring buffer with transferred ownership") {
-            for (int i = 0; i < tests; i++) {
+        SECTION("Sending bstring buffer with transferred ownership")
+        {
+            for (int i = 0; i < tests; i++)
+            {
                 // Deliberately construct a new temporary string here, and move it into `send()` to
                 // transfer ownership of it off to the stream to manage:
                 bstring copy{good_msg};
                 stream_to_a->send(std::move(copy));
             }
         }
-        SECTION("Sending bstring_view buffer with managed keep-alive") {
-            for (int i = 0; i < tests; i++) {
+        SECTION("Sending bstring_view buffer with managed keep-alive")
+        {
+            for (int i = 0; i < tests; i++)
+            {
                 // Similar to the above, but keep the data alive via a manual shared_ptr keep-alive
                 // object.
                 auto ptr = std::make_shared<bstring>(good_msg);

--- a/tests/002-send-receive.cpp
+++ b/tests/002-send-receive.cpp
@@ -39,7 +39,7 @@ namespace oxen::quic::test
         auto conn_interface = client_endpoint->connect(client_remote, client_tls);
 
         // client make stream and send; message displayed by server_data_cb
-        auto client_stream = conn_interface->get_new_stream();
+        auto client_stream = conn_interface->open_stream();
 
         REQUIRE_NOTHROW(client_stream->send(good_msg));
 
@@ -81,7 +81,7 @@ namespace oxen::quic::test
         RemoteAddress server_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint_a->local().port()};
 
         auto server_ci = server_endpoint_b->connect(server_remote, server_tls);
-        auto server_stream = server_ci->get_new_stream();
+        auto server_stream = server_ci->open_stream();
 
         server_stream->send(good_msg);
 
@@ -91,7 +91,7 @@ namespace oxen::quic::test
         auto conn_interface = client_endpoint->connect(client_remote, client_tls);
 
         // client make stream and send; message displayed by server_data_cb
-        auto client_stream = conn_interface->get_new_stream();
+        auto client_stream = conn_interface->open_stream();
 
         REQUIRE_NOTHROW(client_stream->send(good_msg));
 
@@ -132,7 +132,7 @@ namespace oxen::quic::test
         RemoteAddress server_remote_b{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint_b->local().port()};
 
         auto server_a_ci = server_endpoint_b->connect(server_remote_a, server_tls);
-        auto server_a_stream = server_a_ci->get_new_stream();
+        auto server_a_stream = server_a_ci->open_stream();
 
         server_a_stream->send(good_msg);
 
@@ -140,7 +140,7 @@ namespace oxen::quic::test
 
         auto server_b_ci = server_endpoint_a->connect(server_remote_b, server_tls);
 
-        auto server_b_stream = server_b_ci->get_new_stream();
+        auto server_b_stream = server_b_ci->open_stream();
 
         server_b_stream->send(good_msg);
 
@@ -190,7 +190,7 @@ namespace oxen::quic::test
         RemoteAddress server_remote_b{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint_b->local().port()};
 
         auto conn_to_a = server_endpoint_b->connect(server_remote_a, server_tls);
-        auto stream_to_a = conn_to_a->get_new_stream();
+        auto stream_to_a = conn_to_a->open_stream();
 
         SECTION("Sending bstring_view of long-lived buffer")
         {
@@ -261,7 +261,7 @@ namespace oxen::quic::test
             auto client_endpoint = test_net.endpoint(client_local);
             auto conn_interface = client_endpoint->connect(client_remote, client_tls);
 
-            auto client_bp = conn_interface->get_new_stream<BTRequestStream>();
+            auto client_bp = conn_interface->open_stream<BTRequestStream>();
 
             client_bp->command("test_endpoint"s, "test_request_body"s);
 
@@ -304,7 +304,7 @@ namespace oxen::quic::test
             auto client_endpoint = test_net.endpoint(client_local);
             auto conn_interface = client_endpoint->connect(client_remote, client_tls, client_constructor);
 
-            std::shared_ptr<BTRequestStream> client_bp = conn_interface->get_new_stream<BTRequestStream>();
+            std::shared_ptr<BTRequestStream> client_bp = conn_interface->open_stream<BTRequestStream>();
 
             client_bp->command("test_endpoint"s, "test_request_body"s, client_bp_cb);
 
@@ -344,7 +344,7 @@ namespace oxen::quic::test
             auto client_endpoint = test_net.endpoint(client_local);
             auto conn_interface = client_endpoint->connect(client_remote, client_tls);
 
-            auto client_bp = conn_interface->get_new_stream<BTRequestStream>();
+            auto client_bp = conn_interface->open_stream<BTRequestStream>();
 
             client_bp->command("test_endpoint"s, "test_request_body"s, client_bp_cb);
 
@@ -414,7 +414,7 @@ namespace oxen::quic::test
         auto client_endpoint = test_net.endpoint(client_local);
         auto conn_interface = client_endpoint->connect(client_remote, client_tls);
 
-        std::shared_ptr<BTRequestStream> client_bp = conn_interface->get_new_stream<BTRequestStream>();
+        std::shared_ptr<BTRequestStream> client_bp = conn_interface->open_stream<BTRequestStream>();
 
         for (int i = 0; i < num_requests; i++)
         {
@@ -493,7 +493,7 @@ namespace oxen::quic::test
             auto client_endpoint = test_net.endpoint(client_local);
             auto conn_interface = client_endpoint->connect(client_remote, client_tls);
 
-            std::shared_ptr<BTRequestStream> client_bp = conn_interface->get_new_stream<BTRequestStream>();
+            std::shared_ptr<BTRequestStream> client_bp = conn_interface->open_stream<BTRequestStream>();
 
             for (int i = 0; i < num_requests; i++)
             {
@@ -535,7 +535,7 @@ namespace oxen::quic::test
 
         SECTION("Too huge send failure")
         {
-            std::shared_ptr<BTRequestStream> client_bp = conn_interface->get_new_stream<BTRequestStream>();
+            std::shared_ptr<BTRequestStream> client_bp = conn_interface->open_stream<BTRequestStream>();
             CHECK_THROWS_WITH(client_bp->command("test_endpoint"s, req_msg, client_reply_handler), "Request body too long!");
         }
 
@@ -548,7 +548,7 @@ namespace oxen::quic::test
 
             std::atomic<uint64_t> close_err = -1;
             auto stream_close_cb = callback_waiter{[&](Stream&, uint64_t error_code) { close_err = error_code; }};
-            auto str = conn_interface->get_new_stream(nullptr, stream_close_cb);
+            auto str = conn_interface->open_stream<Stream>(nullptr, stream_close_cb);
 
             str->send(std::move(payload));
 

--- a/tests/002-send-receive.cpp
+++ b/tests/002-send-receive.cpp
@@ -13,7 +13,6 @@ namespace oxen::quic::test
     {
         Network test_net{};
         auto good_msg = "hello from the other siiiii-iiiiide"_bsv;
-        bstring_view bad_msg;
 
         std::promise<bool> d_promise;
         std::future<bool> d_future = d_promise.get_future();
@@ -41,7 +40,6 @@ namespace oxen::quic::test
         auto client_stream = conn_interface->get_new_stream();
 
         REQUIRE_NOTHROW(client_stream->send(good_msg));
-        REQUIRE_THROWS(client_stream->send(bad_msg));
 
         REQUIRE(d_future.get());
     };
@@ -50,7 +48,6 @@ namespace oxen::quic::test
     {
         Network test_net{};
         auto good_msg = "hello from the other siiiii-iiiiide"_bsv;
-        bstring_view bad_msg;
 
         std::vector<std::promise<bool>> d_promises{2};
         std::vector<std::future<bool>> d_futures{2};
@@ -95,7 +92,6 @@ namespace oxen::quic::test
         auto client_stream = conn_interface->get_new_stream();
 
         REQUIRE_NOTHROW(client_stream->send(good_msg));
-        REQUIRE_THROWS(client_stream->send(bad_msg));
 
         REQUIRE(d_futures[1].get());
     };

--- a/tests/002-send-receive.cpp
+++ b/tests/002-send-receive.cpp
@@ -30,7 +30,7 @@ namespace oxen::quic::test
         Address client_local{};
 
         auto server_endpoint = test_net.endpoint(server_local);
-        REQUIRE(server_endpoint->listen(server_tls, server_data_cb));
+        REQUIRE_NOTHROW(server_endpoint->listen(server_tls, server_data_cb));
 
         RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
 
@@ -73,10 +73,10 @@ namespace oxen::quic::test
         Address client_local{};
 
         auto server_endpoint_a = test_net.endpoint(server_a_local);
-        REQUIRE(server_endpoint_a->listen(server_tls, server_data_cb));
+        REQUIRE_NOTHROW(server_endpoint_a->listen(server_tls, server_data_cb));
 
         auto server_endpoint_b = test_net.endpoint(server_a_local);
-        REQUIRE(server_endpoint_b->listen(server_tls, server_data_cb));
+        REQUIRE_NOTHROW(server_endpoint_b->listen(server_tls, server_data_cb));
 
         RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint_b->local().port()};
         RemoteAddress server_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint_a->local().port()};
@@ -125,10 +125,10 @@ namespace oxen::quic::test
         Address server_a_local{}, server_b_local{};
 
         auto server_endpoint_a = test_net.endpoint(server_a_local);
-        REQUIRE(server_endpoint_a->listen(server_tls, server_data_cb));
+        REQUIRE_NOTHROW(server_endpoint_a->listen(server_tls, server_data_cb));
 
         auto server_endpoint_b = test_net.endpoint(server_a_local);
-        REQUIRE(server_endpoint_b->listen(server_tls, server_data_cb));
+        REQUIRE_NOTHROW(server_endpoint_b->listen(server_tls, server_data_cb));
 
         RemoteAddress server_remote_a{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint_a->local().port()};
         RemoteAddress server_remote_b{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint_b->local().port()};
@@ -172,7 +172,7 @@ namespace oxen::quic::test
             };
 
             auto server_endpoint = test_net.endpoint(server_local);
-            REQUIRE(server_endpoint->listen(server_tls, server_constructor));
+            REQUIRE_NOTHROW(server_endpoint->listen(server_tls, server_constructor));
 
             RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
 
@@ -215,7 +215,7 @@ namespace oxen::quic::test
             };
 
             auto server_endpoint = test_net.endpoint(server_local);
-            REQUIRE(server_endpoint->listen(server_tls, server_constructor));
+            REQUIRE_NOTHROW(server_endpoint->listen(server_tls, server_constructor));
 
             RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
 
@@ -255,7 +255,7 @@ namespace oxen::quic::test
             };
 
             auto server_endpoint = test_net.endpoint(server_local);
-            REQUIRE(server_endpoint->listen(server_tls, server_constructor));
+            REQUIRE_NOTHROW(server_endpoint->listen(server_tls, server_constructor));
 
             RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
 

--- a/tests/003-multiclient.cpp
+++ b/tests/003-multiclient.cpp
@@ -62,7 +62,7 @@ namespace oxen::quic::test
         const auto& server_tls = tls.second;
 
         auto server_endpoint = test_net.endpoint(server_local);
-        REQUIRE(server_endpoint->listen(server_tls, server_data_cb));
+        REQUIRE_NOTHROW(server_endpoint->listen(server_tls, server_data_cb));
 
         RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
 

--- a/tests/003-multiclient.cpp
+++ b/tests/003-multiclient.cpp
@@ -78,8 +78,8 @@ namespace oxen::quic::test
             auto c_interface_b = client_b->connect(client_remote, client_tls);
 
             // open streams
-            auto stream_a = c_interface_a->get_new_stream();
-            auto stream_b = c_interface_b->get_new_stream();
+            auto stream_a = c_interface_a->open_stream();
+            auto stream_b = c_interface_b->open_stream();
 
             // send
             stream_a->send(msg);
@@ -98,8 +98,8 @@ namespace oxen::quic::test
             auto c_interface_d = client_d->connect(client_remote, client_tls);
 
             // open streams
-            auto stream_c = c_interface_c->get_new_stream();
-            auto stream_d = c_interface_d->get_new_stream();
+            auto stream_c = c_interface_c->open_stream();
+            auto stream_d = c_interface_d->open_stream();
 
             // send
             stream_c->send(msg);

--- a/tests/004-streams.cpp
+++ b/tests/004-streams.cpp
@@ -314,11 +314,11 @@ namespace oxen::quic::test
         std::future<bool> server_future = server_promise.get_future();
 
         stream_constructor_callback client_constructor = [&](Connection& c, Endpoint& e, std::optional<int64_t>) {
-            return std::make_shared<ServerStream>(c, e, std::move(client_promise));
+            return e.make_shared<ServerStream>(c, e, std::move(client_promise));
         };
 
         stream_constructor_callback server_constructor = [&](Connection& c, Endpoint& e, std::optional<int64_t>) {
-            return std::make_shared<ClientStream>(c, e, std::move(server_promise));
+            return e.make_shared<ClientStream>(c, e, std::move(server_promise));
         };
 
         auto [client_tls, server_tls] = defaults::tls_creds_from_ed_keys();
@@ -469,18 +469,18 @@ namespace oxen::quic::test
                     {
                         case 0:
                             log::info(bp_cat, "Server opening Custom Stream A!");
-                            return std::make_shared<CustomStreamA>(c, e, std::move(sp1));
+                            return e.make_shared<CustomStreamA>(c, e, std::move(sp1));
                         case 4:
                             log::info(bp_cat, "Server opening Custom Stream B!");
-                            return std::make_shared<CustomStreamB>(c, e, std::move(sp2));
+                            return e.make_shared<CustomStreamB>(c, e, std::move(sp2));
                         case 8:
                             log::info(bp_cat, "Server opening Custom Stream C!");
-                            return std::make_shared<CustomStreamC>(c, e, std::move(sp3));
+                            return e.make_shared<CustomStreamC>(c, e, std::move(sp3));
                         default:
-                            return std::make_shared<Stream>(c, e);
+                            return e.make_shared<Stream>(c, e);
                     }
                 }
-                return std::make_shared<Stream>(c, e);
+                return e.make_shared<Stream>(c, e);
             };
 
             auto [client_tls, server_tls] = defaults::tls_creds_from_ed_keys();

--- a/tests/004-streams.cpp
+++ b/tests/004-streams.cpp
@@ -1,6 +1,8 @@
 #include <catch2/catch_test_macros.hpp>
+#include <memory>
 #include <quic.hpp>
 #include <quic/gnutls_crypto.hpp>
+#include <stdexcept>
 #include <thread>
 
 #include "utils.hpp"
@@ -61,7 +63,7 @@ namespace oxen::quic::test
         auto client_endpoint = test_net.endpoint(client_local);
         auto conn_interface = client_endpoint->connect(client_remote, client_tls, max_streams);
 
-        auto client_stream = conn_interface->get_new_stream();
+        auto client_stream = conn_interface->open_stream();
         client_stream->send(msg);
 
         REQUIRE(data_future.get());
@@ -111,7 +113,7 @@ namespace oxen::quic::test
         REQUIRE(client_ci->get_streams_available() == server_config.stream_count);
         REQUIRE(server_ci->get_max_streams() == server_config.stream_count);
 
-        auto client_stream = client_ci->get_new_stream();
+        auto client_stream = client_ci->open_stream();
         client_stream->send(msg);
 
         REQUIRE(data_future.get());
@@ -177,7 +179,7 @@ namespace oxen::quic::test
 
         for (size_t i = 0; i < n_streams; ++i)
         {
-            streams[i] = conn_interface->get_new_stream();
+            streams[i] = conn_interface->open_stream();
             streams[i]->send(msg);
             send_promises[i].set_value(true);
         }
@@ -197,7 +199,7 @@ namespace oxen::quic::test
         // 5) open 2 more streams and send
         for (int i = 0; i < 2; ++i)
         {
-            streams[i] = conn_interface->get_new_stream();
+            streams[i] = conn_interface->open_stream();
             streams[i]->send(msg);
             // set send promise
             send_promises[i + n_streams].set_value(true);
@@ -289,7 +291,7 @@ namespace oxen::quic::test
         auto client_endpoint = test_net.endpoint(client_local);
         auto conn_interface = client_endpoint->connect(client_remote, client_tls, standard_client_cb);
 
-        auto client_stream = conn_interface->get_new_stream<ClientStream>(std::move(cc_p));
+        auto client_stream = conn_interface->open_stream<ClientStream>(std::move(cc_p));
 
         REQUIRE_NOTHROW(client_stream->send(msg));
 
@@ -297,7 +299,7 @@ namespace oxen::quic::test
         REQUIRE(cc_f.get());
 
         auto server_ci = server_endpoint->get_all_conns(Direction::INBOUND).front();
-        auto server_stream = server_ci->get_new_stream<ServerStream>(std::move(sc_p));
+        auto server_stream = server_ci->open_stream<ServerStream>(std::move(sc_p));
 
         REQUIRE_NOTHROW(server_stream->send(msg));
 
@@ -334,7 +336,7 @@ namespace oxen::quic::test
         auto client_endpoint = test_net.endpoint(client_local);
         auto conn_interface = client_endpoint->connect(client_remote, client_tls, client_constructor);
 
-        auto client_stream = conn_interface->get_new_stream();
+        auto client_stream = conn_interface->open_stream();
 
         REQUIRE_NOTHROW(client_stream->send(msg));
 
@@ -343,126 +345,96 @@ namespace oxen::quic::test
 
     struct CustomStream : public Stream
     {
-        std::promise<bool> p;
-        const bstring msg = "Stream!"_bs;
+        std::promise<std::string> p;
 
-        CustomStream(Connection& _c, Endpoint& _e, std::promise<bool> _p) : Stream{_c, _e}, p{std::move(_p)} {}
+        CustomStream(Connection& _c, Endpoint& _e, std::promise<std::string> _p) : Stream{_c, _e}, p{std::move(_p)} {}
 
-        void receive(bstring_view m) override
-        {
-            log::info(log_cat, "Custom stream received data. Identity: \n{}", buffer_printer{msg});
-            REQUIRE(m == msg);
-            p.set_value(true);
+        void receive(bstring_view m) override {
+            log::info(log_cat, "Custom stream received data:\n{}", buffer_printer{m});
+            p.set_value(std::string{convert_sv<char>(m)});
         }
     };
 
     struct CustomStreamA : public CustomStream
     {
-        const bstring msg = "Stream A!"_bs;
-
         using CustomStream::CustomStream;
-
-        void receive(bstring_view m) override
-        {
-            log::info(log_cat, "Custom stream received data. Identity: \n{}", buffer_printer{msg});
-            REQUIRE(m == msg);
-            p.set_value(true);
-        }
     };
 
     struct CustomStreamB : public CustomStream
     {
-        const bstring msg = "Stream B!"_bs;
-
         using CustomStream::CustomStream;
-
-        void receive(bstring_view m) override
-        {
-            log::info(log_cat, "Custom stream received data. Identity: \n{}", buffer_printer{msg});
-            REQUIRE(m == msg);
-            p.set_value(true);
-        }
     };
 
     struct CustomStreamC : public CustomStream
     {
-        const bstring msg = "Stream C!"_bs;
-
         using CustomStream::CustomStream;
-
-        void receive(bstring_view m) override
-        {
-            log::info(log_cat, "Custom stream received data. Identity: \n{}", buffer_printer{msg});
-            REQUIRE(m == msg);
-            p.set_value(true);
-        }
     };
 
-    TEST_CASE("004 - Subclassing quic::stream, sequential stream opening", "[004][customstream][sequential]")
+    TEST_CASE("004 - Subclassing quic::stream, sequential stream queuing", "[004][customstream][sequential][server]")
     {
         Network test_net{};
 
-        std::promise<bool> sp1, sp2, sp3, cp1, cp2, cp3;
-        std::future<bool> sf1 = sp1.get_future(), sf2 = sp2.get_future(), sf3 = sp3.get_future(), cf1 = cp1.get_future(),
-                          cf2 = cp2.get_future(), cf3 = cp3.get_future();
+        std::promise<std::string> sp1, sp2, sp3, sp4, cp1, cp2, cp3;
+        std::future<std::string> sf1 = sp1.get_future(), sf2 = sp2.get_future(), sf3 = sp3.get_future(), sf4 = sp4.get_future(),
+                          cf1 = cp1.get_future(), cf2 = cp2.get_future(), cf3 = cp3.get_future();
 
         std::shared_ptr<CustomStreamA> server_a, client_a;
         std::shared_ptr<CustomStreamB> server_b, client_b;
         std::shared_ptr<CustomStreamC> server_c, client_c;
+        std::shared_ptr<Stream> server_d, client_d;
 
         auto client_established = callback_waiter{[](connection_interface&) {}};
         auto server_closed = callback_waiter{[](connection_interface&, uint64_t) {}};
 
-        SECTION("Stream logic using connection open callback")
+        stream_data_callback server_generic_data_cb = [&](Stream&, bstring_view m) {
+            log::debug(log_cat, "Server generic data callback called");
+            sp4.set_value(std::string{convert_sv<char>(m)});
+        };
+
+        auto [client_tls, server_tls] = defaults::tls_creds_from_ed_keys();
+
+        std::atomic<int> server_stream_ctor_count = 0;
+        int expected_server_stream_ctor_count = 0;
+
+        Address server_local{};
+        Address client_local{};
+
+        std::shared_ptr<Endpoint> client_endpoint, server_endpoint;
+        std::shared_ptr<connection_interface> client_ci;
+        SECTION("Stream logic using queue_incoming_stream in connection open callback")
         {
             auto server_open_cb = callback_waiter{[&](connection_interface& ci) {
                 log::info(bp_cat, "Server queuing Custom Stream A!");
-                server_a = ci.queue_stream<CustomStreamA>(std::move(sp1));
+                server_a = ci.queue_incoming_stream<CustomStreamA>(std::move(sp1));
                 log::info(bp_cat, "Server queuing Custom Stream B!");
-                server_b = ci.queue_stream<CustomStreamB>(std::move(sp2));
+                server_b = ci.queue_incoming_stream<CustomStreamB>(std::move(sp2));
                 log::info(bp_cat, "Server queuing Custom Stream C!");
-                server_c = ci.queue_stream<CustomStreamC>(std::move(sp3));
+                server_c = ci.queue_incoming_stream<CustomStreamC>(std::move(sp3));
+                log::info(bp_cat, "Server queueing default stream D");
+                server_d = ci.queue_incoming_stream();
             }};
 
-            auto [client_tls, server_tls] = defaults::tls_creds_from_ed_keys();
-
-            Address server_local{};
-            Address client_local{};
-
-            auto server_endpoint = test_net.endpoint(server_local, server_open_cb, server_closed);
-            REQUIRE_NOTHROW(server_endpoint->listen(server_tls));
+            server_endpoint = test_net.endpoint(server_local, server_open_cb, server_closed);
+            REQUIRE_NOTHROW(server_endpoint->listen(server_tls, server_generic_data_cb));
 
             RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
 
-            auto client_endpoint = test_net.endpoint(client_local, client_established);
-            auto client_ci = client_endpoint->connect(client_remote, client_tls);
+            client_endpoint = test_net.endpoint(client_local, client_established);
+            client_ci = client_endpoint->connect(client_remote, client_tls);
 
             REQUIRE(client_established.wait());
             CHECK(server_open_cb.is_ready());
-
-            log::info(bp_cat, "Client opening Custom Stream A!");
-            client_a = client_ci->get_new_stream<CustomStreamA>(std::move(cp1));
-            REQUIRE_NOTHROW(client_a->send("Stream A!"_bs));
-            REQUIRE(sf1.get());
-
-            log::info(bp_cat, "Client opening Custom Stream B!");
-            client_b = client_ci->get_new_stream<CustomStreamB>(std::move(cp2));
-            REQUIRE_NOTHROW(client_b->send("Stream B!"_bs));
-            REQUIRE(sf2.get());
-
-            log::info(bp_cat, "Client opening Custom Stream C!");
-            client_c = client_ci->get_new_stream<CustomStreamC>(std::move(cp3));
-            REQUIRE_NOTHROW(client_c->send("Stream C!"_bs));
-            REQUIRE(sf3.get());
-
-            client_ci->close_connection();
-            REQUIRE(server_closed.wait());
         }
 
         SECTION("Stream logic using stream constructor callback")
         {
+            // Our stream constructor callback should get invoked for every stream as, in this
+            // section, we do everything through the constructor callback.
+            expected_server_stream_ctor_count = 4;
+
             stream_constructor_callback server_constructor =
                     [&](Connection& c, Endpoint& e, std::optional<int64_t> id) -> std::shared_ptr<Stream> {
+                server_stream_ctor_count++;
                 if (id)
                 {
                     switch (*id)
@@ -481,39 +453,232 @@ namespace oxen::quic::test
                 return nullptr;
             };
 
-            auto [client_tls, server_tls] = defaults::tls_creds_from_ed_keys();
-
-            Address server_local{};
-            Address client_local{};
-
-            auto server_endpoint = test_net.endpoint(server_local, server_closed);
-            REQUIRE_NOTHROW(server_endpoint->listen(server_tls, server_constructor));
+            server_endpoint = test_net.endpoint(server_local, server_closed);
+            REQUIRE_NOTHROW(server_endpoint->listen(server_tls, server_constructor, server_generic_data_cb));
 
             RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
 
-            auto client_endpoint = test_net.endpoint(client_local, client_established);
-            auto client_ci = client_endpoint->connect(client_remote, client_tls);
+            client_endpoint = test_net.endpoint(client_local, client_established);
+            client_ci = client_endpoint->connect(client_remote, client_tls);
 
             REQUIRE(client_established.wait());
-
-            log::info(bp_cat, "Client opening Custom Stream A!");
-            client_a = client_ci->get_new_stream<CustomStreamA>(std::move(cp1));
-            REQUIRE_NOTHROW(client_a->send("Stream A!"_bs));
-            REQUIRE(sf1.get());
-
-            log::info(bp_cat, "Client opening Custom Stream B!");
-            client_b = client_ci->get_new_stream<CustomStreamB>(std::move(cp2));
-            REQUIRE_NOTHROW(client_b->send("Stream B!"_bs));
-            REQUIRE(sf2.get());
-
-            log::info(bp_cat, "Client opening Custom Stream C!");
-            client_c = client_ci->get_new_stream<CustomStreamC>(std::move(cp3));
-            REQUIRE_NOTHROW(client_c->send("Stream C!"_bs));
-            REQUIRE(sf3.get());
-
-            client_ci->close_connection();
-            REQUIRE(server_closed.wait());
         }
+
+        SECTION("Stream logic using mixed queue/stream constructor callbacks")
+        {
+            // Our stream constructor callback should get invoked streams 4 and 8 (which we handle)
+            // and 12 (which we decline to fall back to a default stream), but not 0, because 0 gets
+            // created earlier via a queue_incoming_stream<CustomStreamA> call and so shouldn't end
+            // up in the callback.
+            expected_server_stream_ctor_count = 3;
+
+            stream_constructor_callback server_constructor =
+                    [&](Connection& c, Endpoint& e, std::optional<int64_t> id) -> std::shared_ptr<Stream> {
+                server_stream_ctor_count++;
+                if (id)
+                {
+                    switch (*id)
+                    {
+                        case 4:
+                            log::info(bp_cat, "Server opening Custom Stream B!");
+                            return e.make_shared<CustomStreamB>(c, e, std::move(sp2));
+                        case 8:
+                            log::info(bp_cat, "Server opening Custom Stream C!");
+                            return e.make_shared<CustomStreamC>(c, e, std::move(sp3));
+                    }
+                }
+                return nullptr;
+            };
+
+            auto server_open_cb = callback_waiter{[&](connection_interface& ci) {
+                log::info(bp_cat, "Server queuing Custom Stream A!");
+                server_a = ci.queue_incoming_stream<CustomStreamA>(std::move(sp1));
+            }};
+
+            server_endpoint = test_net.endpoint(server_local, server_closed);
+            REQUIRE_NOTHROW(server_endpoint->listen(server_tls, server_constructor, server_open_cb, server_generic_data_cb));
+
+            RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+
+            client_endpoint = test_net.endpoint(client_local, client_established);
+            client_ci = client_endpoint->connect(client_remote, client_tls);
+
+            REQUIRE(client_established.wait());
+        }
+
+        log::info(bp_cat, "Client opening Custom Stream A!");
+        client_a = client_ci->open_stream<CustomStreamA>(std::move(cp1));
+        REQUIRE_NOTHROW(client_a->send("Stream A!"_bs));
+        CHECK(require_future(sf1) == "Stream A!");
+
+        log::info(bp_cat, "Client opening Custom Stream B!");
+        client_b = client_ci->open_stream<CustomStreamB>(std::move(cp2));
+        REQUIRE_NOTHROW(client_b->send("Stream B!"_bs));
+        CHECK(require_future(sf2) == "Stream B!");
+
+        log::info(bp_cat, "Client opening Custom Stream C!");
+        client_c = client_ci->open_stream<CustomStreamC>(std::move(cp3));
+        REQUIRE_NOTHROW(client_c->send("Stream C!"_bs));
+        CHECK(require_future(sf3) == "Stream C!");
+
+        client_d = client_ci->open_stream();
+        client_d->send("Stream d!"_bs);
+        CHECK(require_future(sf4) == "Stream d!");
+
+        client_ci->close_connection();
+        REQUIRE(server_closed.wait());
+
+        CHECK(expected_server_stream_ctor_count == server_stream_ctor_count.load());
+    };
+
+    TEST_CASE("004 - subclass retrieval", "[004][customstream][get_stream]") {
+        Network test_net{};
+        Address server_local{};
+        Address client_local{};
+
+        auto [client_tls, server_tls] = defaults::tls_creds_from_ed_keys();
+
+        auto server_endpoint = test_net.endpoint(server_local);
+        server_endpoint->listen(server_tls);
+
+        auto client_endpoint = test_net.endpoint(client_local);
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+        auto client_ci = client_endpoint->connect(client_remote, client_tls);
+
+        auto a = client_ci->open_stream<CustomStreamA>(std::promise<std::string>{});
+        auto b = client_ci->open_stream<CustomStreamB>(std::promise<std::string>{});
+        auto c = client_ci->open_stream<CustomStreamC>(std::promise<std::string>{});
+        auto d = client_ci->open_stream();
+
+        CHECK(client_ci->get_stream(0) == a);
+        CHECK(client_ci->get_stream(4) == b);
+        CHECK(client_ci->get_stream(8) == c);
+        CHECK(client_ci->get_stream(12) == d);
+
+        CHECK(client_ci->get_stream<CustomStreamA>(0) == a);
+        CHECK(client_ci->get_stream<CustomStreamB>(4) == b);
+        CHECK(client_ci->get_stream<CustomStreamC>(8) == c);
+
+        CHECK(client_ci->get_stream<CustomStream>(0) == a);
+        CHECK(client_ci->get_stream<CustomStream>(4) == b);
+        CHECK(client_ci->get_stream<CustomStream>(8) == c);
+
+        CHECK(client_ci->maybe_stream<CustomStreamA>(0) == a);
+        CHECK(client_ci->maybe_stream<CustomStreamB>(4) == b);
+        CHECK(client_ci->maybe_stream<CustomStreamC>(8) == c);
+
+        CHECK(client_ci->maybe_stream<CustomStream>(0) == a);
+        CHECK(client_ci->maybe_stream<CustomStream>(4) == b);
+        CHECK(client_ci->maybe_stream<CustomStream>(8) == c);
+
+        CHECK_FALSE(client_ci->maybe_stream(16));
+        CHECK_FALSE(client_ci->maybe_stream<CustomStreamC>(16));
+
+        CHECK_THROWS_AS(client_ci->get_stream<CustomStreamB>(16), std::out_of_range);
+        CHECK_THROWS_AS(client_ci->get_stream(16), std::out_of_range);
+
+        CHECK_THROWS_AS(client_ci->get_stream<CustomStreamB>(0), std::invalid_argument);
+        CHECK_THROWS_AS(client_ci->get_stream<CustomStreamA>(4), std::invalid_argument);
+        CHECK_THROWS_AS(client_ci->get_stream<CustomStreamB>(8), std::invalid_argument);
+        CHECK_THROWS_AS(client_ci->maybe_stream<CustomStreamB>(0), std::invalid_argument);
+        CHECK_THROWS_AS(client_ci->maybe_stream<CustomStreamC>(4), std::invalid_argument);
+        CHECK_THROWS_AS(client_ci->maybe_stream<CustomStream>(12), std::invalid_argument);
+    }
+
+
+    TEST_CASE("004 - Subclassing quic::stream, sequential client stream queuing", "[004][customstream][sequential][client]")
+    {
+        Network test_net{};
+
+        std::mutex mut;
+        std::map<int64_t, int> server_seen;
+
+        std::promise<std::string> cp1, cp2, cp3, cp4;
+        std::future<std::string> cf1 = cp1.get_future(), cf2 = cp2.get_future(), cf3 = cp3.get_future(), cf4 = cp4.get_future();
+
+        auto client_established = callback_waiter{[](connection_interface&) {}};
+        auto server_closed = callback_waiter{[](connection_interface&, uint64_t) {}};
+
+        stream_data_callback server_data_cb = [&](Stream& s, bstring_view) {
+            std::lock_guard lock{mut};
+            server_seen[s.stream_id()]++;
+            s.send("🤔 {}"_format(s.stream_id()));
+        };
+
+        Address server_local{};
+        Address client_local{};
+        auto [client_tls, server_tls] = defaults::tls_creds_from_ed_keys();
+
+        auto server_endpoint = test_net.endpoint(server_local, server_closed);
+        REQUIRE_NOTHROW(server_endpoint->listen(server_tls, server_data_cb));
+
+        std::atomic<int> client_stream_ctor_count = 0;
+
+        auto client_stream_ctor = [&](Connection& c, Endpoint& e, std::optional<int64_t> id) -> std::shared_ptr<Stream> {
+            int count = ++client_stream_ctor_count;
+
+            // We won't have an id yet because we create all the streams
+            CHECK_FALSE(id);
+
+            // But we can just count to see how many times we've been called:
+            switch (count)
+            {
+                case 1:
+                    log::info(bp_cat, "Server opening Custom Stream A!");
+                    return e.make_shared<CustomStreamA>(c, e, std::move(cp1));
+                case 2:
+                    log::info(bp_cat, "Server opening Custom Stream C!");
+                    return e.make_shared<CustomStreamC>(c, e, std::move(cp3));
+            }
+            return nullptr;
+        };
+
+        auto client_generic_data_cb = [&](Stream&, bstring_view data) {
+            log::debug(log_cat, "Client generic data callback called");
+            cp4.set_value(std::string{convert_sv<char>(data)});
+        };
+
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+
+        auto client_endpoint = test_net.endpoint(client_local, client_established);
+        auto client_ci = client_endpoint->connect(client_remote, client_tls, client_generic_data_cb, client_stream_ctor);
+
+        REQUIRE(client_established.wait());
+
+        auto s1 = client_ci->open_stream();
+        CHECK(client_stream_ctor_count.load() == 1);
+        REQUIRE(std::dynamic_pointer_cast<CustomStreamA>(s1));
+
+        auto s2 = client_ci->open_stream<CustomStreamB>(std::move(cp2));
+        CHECK(client_stream_ctor_count.load() == 1);  // should *not* have hit the stream constructor
+        static_assert(std::is_same_v<decltype(s2), std::shared_ptr<CustomStreamB>>);
+
+        auto s3 = client_ci->open_stream();
+        CHECK(client_stream_ctor_count.load() == 2);
+        REQUIRE(std::dynamic_pointer_cast<CustomStreamA>(s1));
+
+        auto s4 = client_ci->open_stream();
+        CHECK(client_stream_ctor_count.load() == 3);
+        // This should be a generic Stream, not a CustomStreamA/B/C:
+        REQUIRE_FALSE(std::dynamic_pointer_cast<CustomStream>(s4));
+
+        s1->send("Stream A!"_bs);
+        s2->send("Stream B!"_bs);
+        s3->send("Stream C!"_bs);
+        s4->send("Stream D!"_bs);
+
+        CHECK(require_future(cf1) == "🤔 0");
+        CHECK(require_future(cf2) == "🤔 4");
+        CHECK(require_future(cf3) == "🤔 8");
+        CHECK(require_future(cf4) == "🤔 12");
+
+        {
+            std::lock_guard lock{mut};
+            CHECK(server_seen == std::map<int64_t,int>{{0, 1}, {4, 1}, {8,1}, {12,1}});
+        }
+
+        client_ci->close_connection();
+        REQUIRE(server_closed.wait());
     };
 
 }  // namespace oxen::quic::test

--- a/tests/004-streams.cpp
+++ b/tests/004-streams.cpp
@@ -554,6 +554,9 @@ namespace oxen::quic::test
         auto c = client_ci->open_stream<CustomStreamC>(std::promise<std::string>{});
         auto d = client_ci->open_stream();
 
+        // On slower setups, a small amount of time is needed to finish initializing all the streams
+        std::this_thread::sleep_for(5ms);
+
         CHECK(client_ci->get_stream(0) == a);
         CHECK(client_ci->get_stream(4) == b);
         CHECK(client_ci->get_stream(8) == c);

--- a/tests/004-streams.cpp
+++ b/tests/004-streams.cpp
@@ -23,7 +23,7 @@ namespace oxen::quic::test
         auto [client_tls, server_tls] = defaults::tls_creds_from_ed_keys();
 
         auto server_endpoint = test_net.endpoint(server_local);
-        REQUIRE(server_endpoint->listen(server_tls, max_streams));
+        REQUIRE_NOTHROW(server_endpoint->listen(server_tls, max_streams));
 
         RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
 
@@ -54,7 +54,7 @@ namespace oxen::quic::test
         auto [client_tls, server_tls] = defaults::tls_creds_from_ed_keys();
 
         auto server_endpoint = test_net.endpoint(server_local);
-        REQUIRE(server_endpoint->listen(server_tls, max_streams, server_data_cb));
+        REQUIRE_NOTHROW(server_endpoint->listen(server_tls, max_streams, server_data_cb));
 
         RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
 
@@ -92,7 +92,7 @@ namespace oxen::quic::test
         auto [client_tls, server_tls] = defaults::tls_creds_from_ed_keys();
 
         auto server_endpoint = test_net.endpoint(server_local);
-        REQUIRE(server_endpoint->listen(server_tls, server_config, server_data_cb));
+        REQUIRE_NOTHROW(server_endpoint->listen(server_tls, server_config, server_data_cb));
 
         RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
 
@@ -168,7 +168,7 @@ namespace oxen::quic::test
         auto [client_tls, server_tls] = defaults::tls_creds_from_ed_keys();
 
         auto server_endpoint = test_net.endpoint(server_local);
-        REQUIRE(server_endpoint->listen(server_tls, max_streams, server_data_cb));
+        REQUIRE_NOTHROW(server_endpoint->listen(server_tls, max_streams, server_data_cb));
 
         RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
 
@@ -284,7 +284,7 @@ namespace oxen::quic::test
         Address client_local{};
 
         auto server_endpoint = test_net.endpoint(server_local);
-        REQUIRE(server_endpoint->listen(server_tls, standard_server_cb));
+        REQUIRE_NOTHROW(server_endpoint->listen(server_tls, standard_server_cb));
 
         RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
 
@@ -329,7 +329,7 @@ namespace oxen::quic::test
         Address client_local{};
 
         auto server_endpoint = test_net.endpoint(server_local);
-        REQUIRE(server_endpoint->listen(server_tls, server_constructor));
+        REQUIRE_NOTHROW(server_endpoint->listen(server_tls, server_constructor));
 
         RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
 
@@ -432,7 +432,7 @@ namespace oxen::quic::test
             Address client_local{};
 
             auto server_endpoint = test_net.endpoint(server_local, server_open_cb, server_closed);
-            REQUIRE(server_endpoint->listen(server_tls));
+            REQUIRE_NOTHROW(server_endpoint->listen(server_tls));
 
             RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
 
@@ -491,7 +491,7 @@ namespace oxen::quic::test
             Address client_local{};
 
             auto server_endpoint = test_net.endpoint(server_local, server_closed);
-            REQUIRE(server_endpoint->listen(server_tls, server_constructor));
+            REQUIRE_NOTHROW(server_endpoint->listen(server_tls, server_constructor));
 
             RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
 

--- a/tests/004-streams.cpp
+++ b/tests/004-streams.cpp
@@ -476,11 +476,9 @@ namespace oxen::quic::test
                         case 8:
                             log::info(bp_cat, "Server opening Custom Stream C!");
                             return e.make_shared<CustomStreamC>(c, e, std::move(sp3));
-                        default:
-                            return e.make_shared<Stream>(c, e);
                     }
                 }
-                return e.make_shared<Stream>(c, e);
+                return nullptr;
             };
 
             auto [client_tls, server_tls] = defaults::tls_creds_from_ed_keys();

--- a/tests/005-chunked-sender.cpp
+++ b/tests/005-chunked-sender.cpp
@@ -41,7 +41,7 @@ namespace oxen::quic::test
         Address client_local{};
 
         auto server_endpoint = test_net.endpoint(server_local);
-        REQUIRE(server_endpoint->listen(server_tls, server_data_cb));
+        REQUIRE_NOTHROW(server_endpoint->listen(server_tls, server_data_cb));
 
         RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
 

--- a/tests/005-chunked-sender.cpp
+++ b/tests/005-chunked-sender.cpp
@@ -48,7 +48,7 @@ namespace oxen::quic::test
         auto client_endpoint = test_net.endpoint(client_local);
         auto conn_interface = client_endpoint->connect(client_remote, client_tls);
 
-        auto stream = conn_interface->get_new_stream();
+        auto stream = conn_interface->open_stream();
         stream->send("HELLO!"s);
 
         int i = 0;

--- a/tests/006-server-send.cpp
+++ b/tests/006-server-send.cpp
@@ -45,7 +45,7 @@ namespace oxen::quic::test
         Address client_local{};
 
         auto server_endpoint = test_net.endpoint(server_local);
-        REQUIRE(server_endpoint->listen(server_tls, server_io_open_cb, server_io_data_cb));
+        REQUIRE_NOTHROW(server_endpoint->listen(server_tls, server_io_open_cb, server_io_data_cb));
 
         RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
 
@@ -149,7 +149,7 @@ namespace oxen::quic::test
         Address client_local{};
 
         auto server_endpoint = test_net.endpoint(server_local);
-        REQUIRE(server_endpoint->listen(server_tls, server_io_data_cb, server_io_open_cb));
+        REQUIRE_NOTHROW(server_endpoint->listen(server_tls, server_io_data_cb, server_io_open_cb));
 
         RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
 

--- a/tests/006-server-send.cpp
+++ b/tests/006-server-send.cpp
@@ -52,7 +52,7 @@ namespace oxen::quic::test
         auto client_endpoint = test_net.endpoint(client_local);
         auto conn_interface = client_endpoint->connect(client_remote, client_tls, client_io_data_cb);
 
-        auto client_stream = conn_interface->get_new_stream();
+        auto client_stream = conn_interface->open_stream();
         client_stream->send(msg);
 
         REQUIRE(stream_future.get());
@@ -156,7 +156,7 @@ namespace oxen::quic::test
         auto client_endpoint = test_net.endpoint(client_local);
         auto client_ci = client_endpoint->connect(client_remote, client_tls, client_io_data_cb, client_io_open_cb);
 
-        auto client_stream = client_ci->get_new_stream();
+        auto client_stream = client_ci->open_stream();
         client_stream->send(msg);
 
         REQUIRE(server_futures[0].get());
@@ -164,7 +164,7 @@ namespace oxen::quic::test
 
         server_extracted_stream->send(response);
         server_ci = server_endpoint->get_all_conns(Direction::INBOUND).front();
-        auto server_stream = server_ci->get_new_stream();
+        auto server_stream = server_ci->open_stream();
         server_stream->send(msg);
 
         for (auto& c : client_futures)

--- a/tests/008-conn_hooks.cpp
+++ b/tests/008-conn_hooks.cpp
@@ -28,7 +28,7 @@ namespace oxen::quic::test
         SECTION("via Network::endpoint(...)")
         {
             auto server_endpoint = test_net.endpoint(server_local, server_established, server_closed);
-            REQUIRE(server_endpoint->listen(server_tls));
+            REQUIRE_NOTHROW(server_endpoint->listen(server_tls));
 
             RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
 
@@ -44,7 +44,7 @@ namespace oxen::quic::test
         SECTION("via Endpoint::{connect,listen}(...)")
         {
             auto server_endpoint = test_net.endpoint(server_local);
-            REQUIRE(server_endpoint->listen(server_tls, server_established, server_closed));
+            REQUIRE_NOTHROW(server_endpoint->listen(server_tls, server_established, server_closed));
 
             RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
 

--- a/tests/009-alpns.cpp
+++ b/tests/009-alpns.cpp
@@ -30,7 +30,7 @@ namespace oxen::quic::test
         SECTION("Default ALPN")
         {
             auto server_endpoint = test_net.endpoint(server_local, timeout);
-            REQUIRE(server_endpoint->listen(server_tls));
+            REQUIRE_NOTHROW(server_endpoint->listen(server_tls));
 
             RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
 
@@ -46,7 +46,7 @@ namespace oxen::quic::test
             opt::outbound_alpns client_alpns{{"client"}};
 
             auto server_endpoint = test_net.endpoint(server_local, timeout);
-            REQUIRE(server_endpoint->listen(server_tls));
+            REQUIRE_NOTHROW(server_endpoint->listen(server_tls));
 
             RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
 
@@ -62,7 +62,7 @@ namespace oxen::quic::test
             opt::inbound_alpns server_alpns{{"client", "relay"}};
 
             auto server_endpoint = test_net.endpoint(server_local, server_alpns, timeout);
-            REQUIRE(server_endpoint->listen(server_tls));
+            REQUIRE_NOTHROW(server_endpoint->listen(server_tls));
 
             RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
 
@@ -79,7 +79,7 @@ namespace oxen::quic::test
             opt::outbound_alpns client_alpns{{"foobar"}};
 
             auto server_endpoint = test_net.endpoint(server_local, server_alpns, timeout);
-            REQUIRE(server_endpoint->listen(server_tls));
+            REQUIRE_NOTHROW(server_endpoint->listen(server_tls));
 
             RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
 
@@ -97,7 +97,7 @@ namespace oxen::quic::test
             opt::outbound_alpns client_alpns2{{"relay"}};
 
             auto server_endpoint = test_net.endpoint(server_local, server_alpns, timeout);
-            REQUIRE(server_endpoint->listen(server_tls));
+            REQUIRE_NOTHROW(server_endpoint->listen(server_tls));
 
             RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
 

--- a/tests/speedtest-client.cpp
+++ b/tests/speedtest-client.cpp
@@ -294,7 +294,7 @@ int main(int argc, char* argv[])
     for (size_t i = 0; i < parallel; i++)
     {
         auto& s = *streams[i];
-        s.stream = client_ci->get_new_stream();
+        s.stream = client_ci->open_stream();
         std::string remaining_str;
         remaining_str.resize(8);
         oxenc::write_host_as_little(s.remaining, remaining_str.data());

--- a/tests/utils.hpp
+++ b/tests/utils.hpp
@@ -155,9 +155,10 @@ namespace oxen::quic
     }
 
     template <typename F>
-    void require_future(F& f, std::chrono::milliseconds timeout = 1s)
+    auto require_future(F& f, std::chrono::milliseconds timeout = 1s)
     {
         REQUIRE(f.wait_for(timeout) == std::future_status::ready);
+        return f.get();
     }
 
     template <typename T>


### PR DESCRIPTION
This PR addresses some issues with btrequest error/timeout flags; and some issues with how streams get constructed and queued with some conflicts when trying to mix queue_stream, get_new_stream, and a stream constructor callback.

(This is based on #71; only the last two commits here are relevant to this PR)

As for the stream changes:

There was a confusing behaviour with `queue_stream` and `get_new_stream` that, even if given an explicit stream type and arguments, those arguments and type would be ignored if there was a stream constructor callback and so you really had to go *only* stream constructor callback *or* get_new_stream/queue_stream because mixing them would break in unexpected ways.

This addresses the issue (along with related changes along the way):

- rename `queue_stream` to `queue_incoming_stream` to better reflect what it does.
- rename `get_new_stream` to `open_stream` to better reflect what it does.
- split `queue_incoming_stream` and `open_stream` into two versions:
    - an untemplated version that takes no arguments and always just constructs a default stream (firing the stream constructor callback, if set; making a basic Stream otherwise).
    - a templated version that always bypasses the stream constructor callback and always creates the requested type with the given arguments.
- Added a `maybe_stream` alternative to `get_stream` that returns nullptr if the stream id doesn't exist, and throws if the stream exists but isn't compatible with the given templated type (if given a Stream subclass to cast to).
- Changed `get_stream` to throw a different exception (invalid_argument) if the stream exists but has an incompatible type, and changed its stream-does-not-exist exception to a std::out_of_range.
- added a virtual `on_ready()` function to Stream that subclasses can override if they want to do something when the stream becomes ready.
- various test cases for the new stream queuing/opening/retrieving that adds various additional tests for edge cases and mixed queuing/constructor callback usage.