### PR TITLE
Fix speedtests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,8 @@ option(BUILD_SHARED_LIBS "Build as shared library" OFF)
 option(BUILD_STATIC_DEPS "Download, build, and statically link against core dependencies" OFF)
 option(WARNINGS_AS_ERRORS "treat all warnings as errors. turn off for development, on for release" OFF)
 option(LIBQUIC_WARN_DEPRECATED "warn deprecated" ON)
-option(LIBQUIC_BUILD_TESTS "Build libquic test suite and programs" ${libquic_IS_TOPLEVEL_PROJECT})
+option(LIBQUIC_BUILD_TESTS "Build libquic test suite" ${libquic_IS_TOPLEVEL_PROJECT})
+option(LIBQUIC_BUILD_SPEEDTEST "Build libquic speedtest programs" ${libquic_IS_TOPLEVEL_PROJECT})
 
 
 set(CMAKE_CXX_STANDARD 17)
@@ -102,6 +103,6 @@ target_link_libraries(libquic_internal INTERFACE libquic_internal-warnings)
 add_subdirectory(external)
 add_subdirectory(src)
 
-if(LIBQUIC_BUILD_TESTS)
+if(LIBQUIC_BUILD_TESTS OR LIBQUIC_BUILD_SPEEDTEST)
     add_subdirectory(tests)
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,27 +1,47 @@
-add_subdirectory(Catch2)
 
 # command-line arguments (for test programs)
 add_subdirectory(CLI11)
 
-add_executable(alltests
-    001-handshake.cpp
-    002-send-receive.cpp
-    003-multiclient.cpp
-    004-streams.cpp
-    005-chunked-sender.cpp
-    006-server-send.cpp
-    007-datagrams.cpp
-    008-conn_hooks.cpp
-    009-alpns.cpp
-    
-    main.cpp
-)
-target_link_libraries(alltests
-    PUBLIC quic Catch2::Catch2 CLI11::CLI11
-    PRIVATE libquic_internal-warnings
-)
+add_library(tests_common STATIC utils.cpp)
+target_link_libraries(tests_common PUBLIC
+    quic CLI11::CLI11 libquic_internal-warnings gnutls::gnutls)
 
-foreach(x speedtest-client speedtest-server dgram-speed-client dgram-speed-server)
-    add_executable(${x} ${x}.cpp)
-    target_link_libraries(${x} PRIVATE quic CLI11::CLI11)
-endforeach()
+# We need hogweed for generating Ed25519 keys (this is already a gnutls dependency, so we shouldn't
+# be adding any new dep by requiring it)
+if(TARGET hogweed)
+    target_link_libraries(tests_common INTERFACE hogweed)
+else()
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(HOGWEED hogweed REQUIRED IMPORTED_TARGET)
+    target_link_libraries(tests_common INTERFACE PkgConfig::HOGWEED)
+endif()
+
+if(LIBQUIC_BUILD_TESTS)
+
+    add_subdirectory(Catch2)
+
+    add_executable(alltests
+        001-handshake.cpp
+        002-send-receive.cpp
+        003-multiclient.cpp
+        004-streams.cpp
+        005-chunked-sender.cpp
+        006-server-send.cpp
+        007-datagrams.cpp
+        008-conn_hooks.cpp
+        009-alpns.cpp
+
+        main.cpp
+    )
+    target_link_libraries(alltests PRIVATE tests_common Catch2::Catch2)
+
+endif()
+
+if(LIBQUIC_BUILD_SPEEDTEST)
+
+    foreach(x speedtest-client speedtest-server dgram-speed-client dgram-speed-server)
+        add_executable(${x} ${x}.cpp)
+        target_link_libraries(${x} PRIVATE tests_common)
+    endforeach()
+
+endif()

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -26,5 +26,8 @@ int main(int argc, char* argv[])
 
     oxen::quic::setup_logging(log_file, log_level);
 
+    oxen::quic::test::defaults::CLIENT_KEYS = oxen::quic::generate_ed25519();
+    oxen::quic::test::defaults::SERVER_KEYS = oxen::quic::generate_ed25519();
+
     return session.run();
 }

--- a/tests/speedtest-server.cpp
+++ b/tests/speedtest-server.cpp
@@ -27,24 +27,6 @@ int main(int argc, char* argv[])
     std::string log_file, log_level;
     add_log_opts(cli, log_file, log_level);
 
-    std::string key{"./serverkey.pem"}, cert{"./servercert.pem"};
-
-    cli.add_option("-c,--certificate", cert, "Path to server certificate to use")
-            ->type_name("FILE")
-            ->capture_default_str()
-            ->check(CLI::ExistingFile);
-    cli.add_option("-k,--key", key, "Path to server key to use")
-            ->type_name("FILE")
-            ->capture_default_str()
-            ->check(CLI::ExistingFile);
-
-    // TODO: make this optional
-    std::string client_cert{"./clientcert.pem"};
-    cli.add_option("-C,--clientcert", key, "Path to client certificate for client authentication")
-            ->type_name("FILE")
-            ->capture_default_str()
-            ->check(CLI::ExistingFile);
-
     bool no_hash = false;
     cli.add_flag(
             "-H,--no-hash",
@@ -69,9 +51,10 @@ int main(int argc, char* argv[])
 
     setup_logging(log_file, log_level);
 
-    Network server_net{};
+    auto [seed, pubkey] = generate_ed25519();
+    auto server_tls = GNUTLSCreds::make_from_ed_keys(seed, pubkey);
 
-    auto server_tls = GNUTLSCreds::make(key, cert, client_cert);
+    Network server_net{};
 
     auto [listen_addr, listen_port] = parse_addr(server_addr, 5500);
     Address server_local{listen_addr, listen_port};
@@ -156,9 +139,30 @@ int main(int argc, char* argv[])
         }
     };
 
-    log::debug(test_cat, "Calling 'server_listen'...");
-    auto _server = server_net.endpoint(server_local);
-    _server->listen(server_tls, stream_opened, stream_data);
+    try
+    {
+        log::debug(test_cat, "Starting up endpoint");
+        auto _server = server_net.endpoint(server_local);
+        _server->listen(server_tls, stream_opened, stream_data);
+    }
+    catch (const std::exception& e)
+    {
+        log::critical(test_cat, "Failed to start server: {}!", e.what());
+        return 1;
+    }
+
+    {
+        // We always want to see this log statement because it contains the pubkey the client needs,
+        // but it feels wrong to force it to a critical statement, so temporarily lower the level to
+        // info to display it.
+        log_level_lowerer enable_info{log::Level::info, test_cat.name};
+        log::info(
+                test_cat,
+                "Listening on {}; client connection args:\n\t{}--remote-pubkey={}",
+                server_local,
+                server_local != Address{"127.0.0.1", 5500} ? "--remote {} "_format(server_local.to_string()) : "",
+                oxenc::to_base64(pubkey));
+    }
 
     for (;;)
         std::this_thread::sleep_for(10min);

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -27,4 +27,77 @@ namespace oxen::quic
         return result;
     }
 
+    void add_log_opts(CLI::App& cli, std::string& file, std::string& level)
+    {
+        file = "stderr";
+        level = "debug";
+
+        cli.add_option("-l,--log-file", file, "Log output filename, or one of stdout/-/stderr/syslog.")
+                ->type_name("FILE")
+                ->capture_default_str();
+
+        cli.add_option("-L,--log-level", level, "Log verbosity level; one of trace, debug, info, warn, error, critical, off")
+                ->type_name("LEVEL")
+                ->capture_default_str()
+                ->check(CLI::IsMember({"trace", "debug", "info", "warn", "error", "critical", "off"}));
+    }
+
+    void setup_logging(std::string out, const std::string& level)
+    {
+        log::Level lvl = log::level_from_string(level);
+
+        constexpr std::array print_vals = {"stdout", "-", "", "stderr", "nocolor", "stdout-nocolor", "stderr-nocolor"};
+        log::Type type;
+        if (std::count(print_vals.begin(), print_vals.end(), out))
+            type = log::Type::Print;
+        else if (out == "syslog")
+            type = log::Type::System;
+        else
+            type = log::Type::File;
+
+        logger_config(out, type, lvl);
+    }
+
+    std::pair<std::string, uint16_t> parse_addr(std::string_view addr, std::optional<uint16_t> default_port)
+    {
+        std::pair<std::string, uint16_t> result;
+        if (auto p = addr.find_last_not_of("0123456789");
+            p != std::string_view::npos && p + 2 <= addr.size() && addr[p] == ':')
+        {
+            if (!parse_int(addr.substr(p + 1), result.second))
+                throw std::invalid_argument{"Invalid address: could not parse port"};
+            addr.remove_suffix(addr.size() - p);
+        }
+        else if (default_port)
+        {
+            result.second = *default_port;
+        }
+        else
+        {
+            throw std::invalid_argument{"Invalid address: no port was specified and there is no default"};
+        }
+
+        bool had_sq_brackets = false;
+        if (!addr.empty() && addr.front() == '[' && addr.back() == ']')
+        {
+            addr.remove_prefix(1);
+            addr.remove_suffix(1);
+            had_sq_brackets = true;
+        }
+
+        if (auto p = addr.find_first_not_of("0123456789."); p != std::string_view::npos)
+        {
+            if (auto q = addr.find_first_not_of("0123456789abcdef:."); q != std::string_view::npos)
+                throw std::invalid_argument{"Invalid address: does not look like IPv4 or IPv6!"};
+            else if (!had_sq_brackets)
+                throw std::invalid_argument{"Invalid address: IPv6 addresses require [...] square brackets"};
+        }
+
+        if (addr.empty())
+            addr = "::";
+
+        result.first = addr;
+        return result;
+    }
+
 }  // namespace oxen::quic

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -5,9 +5,6 @@
 namespace oxen::quic
 {
 
-    std::pair<std::string, std::string> test::defaults::CLIENT_KEYS = generate_ed25519();
-    std::pair<std::string, std::string> test::defaults::SERVER_KEYS = generate_ed25519();
-
     std::pair<std::shared_ptr<GNUTLSCreds>, std::shared_ptr<GNUTLSCreds>> test::defaults::tls_creds_from_ed_keys()
     {
         auto client = GNUTLSCreds::make_from_ed_keys(CLIENT_SEED, CLIENT_PUBKEY);

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -5,6 +5,9 @@
 namespace oxen::quic
 {
 
+    std::pair<std::string, std::string> test::defaults::CLIENT_KEYS = generate_ed25519();
+    std::pair<std::string, std::string> test::defaults::SERVER_KEYS = generate_ed25519();
+
     std::pair<std::shared_ptr<GNUTLSCreds>, std::shared_ptr<GNUTLSCreds>> test::defaults::tls_creds_from_ed_keys()
     {
         auto client = GNUTLSCreds::make_from_ed_keys(CLIENT_SEED, CLIENT_PUBKEY);

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -1,0 +1,30 @@
+#include "utils.hpp"
+
+#include <nettle/eddsa.h>
+
+namespace oxen::quic
+{
+
+    std::pair<std::shared_ptr<GNUTLSCreds>, std::shared_ptr<GNUTLSCreds>> test::defaults::tls_creds_from_ed_keys()
+    {
+        auto client = GNUTLSCreds::make_from_ed_keys(CLIENT_SEED, CLIENT_PUBKEY);
+        auto server = GNUTLSCreds::make_from_ed_keys(SERVER_SEED, SERVER_PUBKEY);
+
+        return std::make_pair(std::move(client), std::move(server));
+    }
+
+    std::pair<std::string, std::string> generate_ed25519()
+    {
+        std::pair<std::string, std::string> result;
+        auto& [seed, pubkey] = result;
+        seed.resize(32);
+        pubkey.resize(32);
+
+        gnutls_rnd(gnutls_rnd_level_t::GNUTLS_RND_KEY, seed.data(), sizeof(seed.size()));
+        ed25519_sha512_public_key(
+                reinterpret_cast<unsigned char*>(pubkey.data()), reinterpret_cast<const unsigned char*>(seed.data()));
+
+        return result;
+    }
+
+}  // namespace oxen::quic

--- a/tests/utils.hpp
+++ b/tests/utils.hpp
@@ -24,10 +24,11 @@ namespace oxen::quic
 
     namespace test::defaults
     {
-        inline const std::string CLIENT_SEED = "468e7ed2cd914ca44568e7189245c7b8e5488404fc88a4019c73b51d9dbc48a5"_hex;
-        inline const std::string CLIENT_PUBKEY = "626136fe40c8860ee5bdc57fd9f15a03ef6777bb9237c18fc4d7ef2aacfe4f88"_hex;
-        inline const std::string SERVER_SEED = "fefbb50cdd4cde3be0ae75042c44ff42b026def4fd6be4fb1dc6e81ea0480c9b"_hex;
-        inline const std::string SERVER_PUBKEY = "d580d5c68937095ea997f6a88f07a86cdd26dfa0d7d268e80ea9bbb5f3ca0304"_hex;
+        extern std::pair<std::string, std::string> CLIENT_KEYS, SERVER_KEYS;
+        inline const std::string& CLIENT_SEED = CLIENT_KEYS.first;
+        inline const std::string& CLIENT_PUBKEY = CLIENT_KEYS.second;
+        inline const std::string& SERVER_SEED = SERVER_KEYS.first;
+        inline const std::string& SERVER_PUBKEY = SERVER_KEYS.second;
 
         std::pair<std::shared_ptr<GNUTLSCreds>, std::shared_ptr<GNUTLSCreds>> tls_creds_from_ed_keys();
     }  // namespace test::defaults

--- a/tests/utils.hpp
+++ b/tests/utils.hpp
@@ -49,36 +49,9 @@ namespace oxen::quic
         return std::nullopt;
     }
 
-    inline void add_log_opts(CLI::App& cli, std::string& file, std::string& level)
-    {
-        file = "stderr";
-        level = "debug";
+    void add_log_opts(CLI::App& cli, std::string& file, std::string& level);
 
-        cli.add_option("-l,--log-file", file, "Log output filename, or one of stdout/-/stderr/syslog.")
-                ->type_name("FILE")
-                ->capture_default_str();
-
-        cli.add_option("-L,--log-level", level, "Log verbosity level; one of trace, debug, info, warn, error, critical, off")
-                ->type_name("LEVEL")
-                ->capture_default_str()
-                ->check(CLI::IsMember({"trace", "debug", "info", "warn", "error", "critical", "off"}));
-    }
-
-    inline void setup_logging(std::string out, const std::string& level)
-    {
-        log::Level lvl = log::level_from_string(level);
-
-        constexpr std::array print_vals = {"stdout", "-", "", "stderr", "nocolor", "stdout-nocolor", "stderr-nocolor"};
-        log::Type type;
-        if (std::count(print_vals.begin(), print_vals.end(), out))
-            type = log::Type::Print;
-        else if (out == "syslog")
-            type = log::Type::System;
-        else
-            type = log::Type::File;
-
-        logger_config(out, type, lvl);
-    }
+    void setup_logging(std::string out, const std::string& level);
 
     /// RAII class that resets the log level for the given category while the object is alive, then
     /// resets it to what it was at construction when the object is destroyed.
@@ -124,48 +97,7 @@ namespace oxen::quic
         return true;
     }
 
-    inline std::pair<std::string, uint16_t> parse_addr(
-            std::string_view addr, std::optional<uint16_t> default_port = std::nullopt)
-    {
-        std::pair<std::string, uint16_t> result;
-        if (auto p = addr.find_last_not_of("0123456789");
-            p != std::string_view::npos && p + 2 <= addr.size() && addr[p] == ':')
-        {
-            if (!parse_int(addr.substr(p + 1), result.second))
-                throw std::invalid_argument{"Invalid address: could not parse port"};
-            addr.remove_suffix(addr.size() - p);
-        }
-        else if (default_port)
-        {
-            result.second = *default_port;
-        }
-        else
-        {
-            throw std::invalid_argument{"Invalid address: no port was specified and there is no default"};
-        }
-
-        bool had_sq_brackets = false;
-        if (!addr.empty() && addr.front() == '[' && addr.back() == ']')
-        {
-            addr.remove_prefix(1);
-            addr.remove_suffix(1);
-            had_sq_brackets = true;
-        }
-
-        if (auto p = addr.find_first_not_of("0123456789."); p != std::string_view::npos)
-        {
-            if (auto q = addr.find_first_not_of("0123456789abcdef:."); q != std::string_view::npos)
-                throw std::invalid_argument{"Invalid address: does not look like IPv4 or IPv6!"};
-            else if (!had_sq_brackets)
-                throw std::invalid_argument{"Invalid address: IPv6 addresses require [...] square brackets"};
-        }
-
-        if (addr.empty())
-            addr = "::";
-
-        result.first = addr;
-        return result;
-    }
+    std::pair<std::string, uint16_t> parse_addr(std::string_view addr, std::optional<uint16_t> default_port = std::nullopt);
 
     template <typename F>
     auto require_future(F& f, std::chrono::milliseconds timeout = 1s)

--- a/tests/utils.hpp
+++ b/tests/utils.hpp
@@ -24,7 +24,7 @@ namespace oxen::quic
 
     namespace test::defaults
     {
-        extern std::pair<std::string, std::string> CLIENT_KEYS, SERVER_KEYS;
+        inline std::pair<std::string, std::string> CLIENT_KEYS, SERVER_KEYS;
         inline const std::string& CLIENT_SEED = CLIENT_KEYS.first;
         inline const std::string& CLIENT_PUBKEY = CLIENT_KEYS.second;
         inline const std::string& SERVER_SEED = SERVER_KEYS.first;


### PR DESCRIPTION
- speedtests were still using the old key/cert file approach, which doesn't currently work.
- the speedtest servers now generate a random Ed25519 key on startup and spit it on in a log statement to be used with the client; this depends on hogweed, but we *already* implicitly have hogweed as a dependency via gnutls.
- split up tests/CMakeLists.txt so that we can choose to build/not build the tests and/or speedtests separately.
- De-inlined test common code into a single tiny static lib that both tests & speedtests use.
- speedtest servers: catch a listen exception -- commonly a failure the bind -- and log about it nicely (then exit) rather than letting the uncaught exception kill the program.