### PR TITLE
Make bt request stream timeouts work

### DIFF
--- a/include/quic/btstream.hpp
+++ b/include/quic/btstream.hpp
@@ -218,7 +218,7 @@ namespace oxen::quic
 
         void respond(int64_t rid, bstring_view body, bool error = false);
 
-        void check_timeouts();
+        void check_timeouts() override;
 
         void receive(bstring_view data) override;
 

--- a/include/quic/connection.hpp
+++ b/include/quic/connection.hpp
@@ -417,6 +417,10 @@ namespace oxen::quic
         // returns number of currently pending streams for use in test cases
         size_t num_pending() const { return pending_streams.size(); }
 
+        // Called (from Endpoint) to trigger any required stream timeouts.  Should not be called
+        // externally.
+        void check_stream_timeouts();
+
 #ifndef NDEBUG
         ~Connection() override;
 #endif

--- a/include/quic/stream.hpp
+++ b/include/quic/stream.hpp
@@ -85,6 +85,11 @@ namespace oxen::quic
         // becomes ready.  The default does nothing.
         virtual void on_ready() {}
 
+        /// Called periodically to check if anything needs to be timed out.  The default does
+        /// nothing, but subclasses can override to not do nothing if it's not the case that nothing
+        /// ain't not good enough isn't false.
+        virtual void check_timeouts() {}
+
         void send_impl(bstring_view data, std::shared_ptr<void> keep_alive = nullptr) override;
 
       private:

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -1351,6 +1351,15 @@ namespace oxen::quic
         return conn;
     }
 
+    void Connection::check_stream_timeouts()
+    {
+        for (const auto* s : {&streams, &stream_queue})
+            for (const auto& [id, stream] : *s)
+                stream->check_timeouts();
+        for (const auto& s : pending_streams)
+            s->check_timeouts();
+    }
+
 #ifndef NDEBUG
 
     connection_interface::~connection_interface()

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -549,6 +549,10 @@ namespace oxen::quic
             }
             it = draining.erase(it);
         }
+
+        // Propagate the timeout check to connections, to be propagated to streams
+        for (auto& [cid, conn] : conns)
+            conn->check_stream_timeouts();
     }
 
     Connection* Endpoint::get_conn(const ConnectionID& id)


### PR DESCRIPTION
BTRequestStream::check_timeouts was't being called; this wires it up via the existing Endpoint interval, and makes it generic (so other custom Stream types could use it as well).

Also fixes an issue in the `message` constructor for a timeout, which doesn't have a body, but was throwing as a result.