### PR TITLE
BT stream request queue

### DIFF
--- a/include/quic/btstream.hpp
+++ b/include/quic/btstream.hpp
@@ -230,6 +230,8 @@ namespace oxen::quic
 
         const Address& remote() const { return conn.remote(); }
 
+        size_t num_pending() const { return user_buffers.size(); }
+
       private:
         void handle_bp_opt(std::function<void(Stream&, uint64_t)> close_cb)
         {

--- a/include/quic/connection.hpp
+++ b/include/quic/connection.hpp
@@ -175,7 +175,8 @@ namespace oxen::quic
         }
 
         virtual void send_datagram(bstring_view data, std::shared_ptr<void> keep_alive = nullptr) = 0;
-        virtual size_t active_streams() const = 0;
+        virtual size_t num_streams_active() const = 0;
+        virtual size_t num_streams_pending() const = 0;
         virtual uint64_t get_max_streams() const = 0;
         virtual uint64_t get_streams_available() const = 0;
         virtual size_t get_max_datagram_size() const = 0;
@@ -250,7 +251,8 @@ namespace oxen::quic
 
         Direction direction() const override { return dir; }
 
-        size_t active_streams() const override { return streams.size(); }
+        size_t num_streams_active() const override { return _streams.size(); }
+        size_t num_streams_pending() const override { return pending_streams.size(); }
 
         void halt_events();
         bool is_closing() const { return closing; }
@@ -366,8 +368,8 @@ namespace oxen::quic
         std::shared_ptr<Stream> get_stream_impl(int64_t id) override;
 
         // holds a mapping of active streams
-        std::map<int64_t, std::shared_ptr<Stream>> streams;
-        std::map<int64_t, std::shared_ptr<Stream>> stream_queue;
+        std::map<int64_t, std::shared_ptr<Stream>> _streams;
+        std::map<int64_t, std::shared_ptr<Stream>> _stream_queue;
 
         int64_t next_incoming_stream_id = is_outbound() ? 1 : 0;
 

--- a/include/quic/datagram.hpp
+++ b/include/quic/datagram.hpp
@@ -72,7 +72,6 @@ namespace oxen::quic
         virtual bool is_empty() const = 0;
         virtual std::shared_ptr<Stream> get_stream() = 0;
         virtual std::vector<ngtcp2_vec> pending() = 0;
-        virtual size_t num_pending() const = 0;
         virtual prepared_datagram pending_datagram(bool) = 0;
         virtual int64_t stream_id() const = 0;
         virtual bool is_closing() const = 0;
@@ -194,8 +193,6 @@ namespace oxen::quic
         buffer_que send_buffer;
 
         bool is_empty() const override { return send_buffer.empty(); }
-
-        size_t num_pending() const override { return send_buffer.size(); }
 
         prepared_datagram pending_datagram(bool r) override;
 

--- a/include/quic/datagram.hpp
+++ b/include/quic/datagram.hpp
@@ -72,6 +72,7 @@ namespace oxen::quic
         virtual bool is_empty() const = 0;
         virtual std::shared_ptr<Stream> get_stream() = 0;
         virtual std::vector<ngtcp2_vec> pending() = 0;
+        virtual size_t num_pending() const = 0;
         virtual prepared_datagram pending_datagram(bool) = 0;
         virtual int64_t stream_id() const = 0;
         virtual bool is_closing() const = 0;
@@ -193,6 +194,8 @@ namespace oxen::quic
         buffer_que send_buffer;
 
         bool is_empty() const override { return send_buffer.empty(); }
+
+        size_t num_pending() const override { return send_buffer.size(); }
 
         prepared_datagram pending_datagram(bool r) override;
 

--- a/include/quic/stream.hpp
+++ b/include/quic/stream.hpp
@@ -49,7 +49,6 @@ namespace oxen::quic
         bool is_stream() const override { return true; }
         bool is_ready() const { return ready; }
         bool is_empty() const override { return user_buffers.empty(); }
-        size_t num_pending() const override { return user_buffers.size(); }
         int64_t stream_id() const override { return _stream_id; }
         const ConnectionID& conn_id() const;
         bool has_unsent() const override { return not is_empty(); }
@@ -81,7 +80,7 @@ namespace oxen::quic
         }
 
         // Called immediately after set_ready so that a subclass can do thing as soon as the stream
-        // becomes ready. \The default does nothing.
+        // becomes ready. The default does nothing.
         virtual void on_ready() {}
 
         /// Called periodically to check if anything needs to be timed out.  The default does
@@ -91,9 +90,9 @@ namespace oxen::quic
 
         void send_impl(bstring_view data, std::shared_ptr<void> keep_alive = nullptr) override;
 
-      private:
         stream_buffer user_buffers;
 
+      private:
         std::vector<ngtcp2_vec> pending() override;
 
         size_t unacked_size{0};

--- a/include/quic/stream.hpp
+++ b/include/quic/stream.hpp
@@ -47,12 +47,12 @@ namespace oxen::quic
 
         bool available() const { return !(_is_closing || is_shutdown || _sent_fin); }
         bool is_stream() const override { return true; }
-
+        bool is_ready() const { return ready; }
+        bool is_empty() const override { return user_buffers.empty(); }
+        size_t num_pending() const override { return user_buffers.size(); }
         int64_t stream_id() const override { return _stream_id; }
         const ConnectionID& conn_id() const;
-
         bool has_unsent() const override { return not is_empty(); }
-
         bool is_closing() const override { return _is_closing; }
         bool sent_fin() const override { return _sent_fin; }
         void set_fin(bool v) override { _sent_fin = v; }
@@ -62,7 +62,6 @@ namespace oxen::quic
         void close(uint64_t app_err_code = 0);
 
         void set_stream_data_cb(stream_data_callback cb) { data_callback = std::move(cb); }
-
         void set_stream_close_cb(stream_close_callback cb) { close_callback = std::move(cb); }
 
         stream_data_callback data_callback;
@@ -82,7 +81,7 @@ namespace oxen::quic
         }
 
         // Called immediately after set_ready so that a subclass can do thing as soon as the stream
-        // becomes ready.  The default does nothing.
+        // becomes ready. \The default does nothing.
         virtual void on_ready() {}
 
         /// Called periodically to check if anything needs to be timed out.  The default does
@@ -105,8 +104,6 @@ namespace oxen::quic
         int64_t _stream_id;
 
         const Connection& get_conn() const { return conn; }
-
-        bool is_empty() const override { return user_buffers.empty(); }
 
         void wrote(size_t bytes) override;
 

--- a/tests/utils.hpp
+++ b/tests/utils.hpp
@@ -22,6 +22,9 @@ namespace oxen::quic
 
     using namespace oxenc::literals;
 
+    inline const std::string TEST_ENDPOINT = "test_endpoint"s;
+    inline const std::string TEST_BODY = "test_body"s;
+
     namespace test::defaults
     {
         inline std::pair<std::string, std::string> CLIENT_KEYS, SERVER_KEYS;


### PR DESCRIPTION
- no substantial changes to the internal code are necessary; a few methods to return queue size are added
- new test case in 004 displaying the ability of outbound streams to have send queues, supplanting the need for any in the application layer