### PR TITLE
BTRequestStream: generic handler & exception catching

### DIFF
--- a/include/quic/btstream.hpp
+++ b/include/quic/btstream.hpp
@@ -245,6 +245,12 @@ namespace oxen::quic
         /// commands that are not created via `register_command` calls.
         void register_command(std::string endpoint, std::function<void(message)>);
 
+        /// Registered (or replaces) the fallback command handler that is invoked if the requested
+        /// endpoint does not match any endpoint set up with `register_command`.  If no individual
+        /// `register_command` endpoints are set up at all then this becomes the single callback to
+        /// invoke for all incoming commands.
+        void register_command_fallback(std::function<void(message)> request_handler);
+
         const Address& local() const { return conn.local(); }
 
         const Address& remote() const { return conn.remote(); }
@@ -257,10 +263,9 @@ namespace oxen::quic
             close_callback = std::move(close_cb);
         }
 
-        // Optional constructor argument: generic request handler.  If set, this is invoked for all
-        // incoming requests to endpoints that do not have a `register_command`.  (And so if
-        // `register_command` is not used at all, this can handle all endpoint).
-        void handle_bp_opt(std::function<void(oxen::quic::message m)> request_handler)
+        // Optional constructor argument: generic request handler.  Providing it in the constructor
+        // is equivalent to calling register_command_fallback() with the lambda.
+        void handle_bp_opt(std::function<void(message m)> request_handler)
         {
             log::debug(bp_cat, "Bparser set generic request handler");
             generic_handler = std::move(request_handler);

--- a/include/quic/btstream.hpp
+++ b/include/quic/btstream.hpp
@@ -239,17 +239,16 @@ namespace oxen::quic
 
         void closed(uint64_t app_code) override;
 
-        /// Registers an individual command to be recognized by this BTRequestStream object.  Can be
-        /// called multiple times to set up multiple commands.  As an alternative (or supplement)
-        /// you can also specify a single handler during construction to be called for any invoked
-        /// commands that are not created via `register_command` calls.
-        void register_command(std::string endpoint, std::function<void(message)>);
+        /// Registers an individual endpoint to be recognized by this BTRequestStream object.  Can be
+        /// called multiple times to set up multiple commands.  See also register_generic_handler.
+        void register_handler(std::string endpoint, std::function<void(message)>);
 
-        /// Registered (or replaces) the fallback command handler that is invoked if the requested
-        /// endpoint does not match any endpoint set up with `register_command`.  If no individual
-        /// `register_command` endpoints are set up at all then this becomes the single callback to
-        /// invoke for all incoming commands.
-        void register_command_fallback(std::function<void(message)> request_handler);
+        /// Registered (or replaces) the generic handler that is invoked if the requested endpoint
+        /// does not match any endpoint set up with `register_handler`.  If no individual
+        /// `register_handler` endpoints are set up at all then this becomes the single callback to
+        /// invoke for all incoming commands.  This handler should throw a `no_such_endpoint`
+        /// exception if the endpoint in this message should be considered not found.
+        void register_generic_handler(std::function<void(message)> request_handler);
 
         const Address& local() const { return conn.local(); }
 

--- a/include/quic/btstream.hpp
+++ b/include/quic/btstream.hpp
@@ -61,8 +61,8 @@ namespace oxen::quic
         inline static constexpr auto TYPE_ERROR = "E"sv;
         inline static constexpr auto TYPE_COMMAND = "C"sv;
 
-        void respond(bstring_view body, bool error = false);
-        void respond(std::string_view body, bool error = false) { respond(convert_sv<std::byte>(body), error); }
+        void respond(bstring_view body, bool error = false) const;
+        void respond(std::string_view body, bool error = false) const { respond(convert_sv<std::byte>(body), error); }
 
         const bool timed_out{false};
         bool is_error() const { return type() == TYPE_ERROR; }

--- a/include/quic/btstream.hpp
+++ b/include/quic/btstream.hpp
@@ -22,6 +22,16 @@ namespace oxen::quic
 
     class BTRequestStream;
 
+    // Exception type to throw from a handler to have a method-not-found error returned as a
+    // response to the message.  The `what()` value is not actually used: we send back a string that
+    // includes the requested method name in the error.  The main use of this exception is when
+    // using a generic handler to use the exact same error behaviour as if `register_command` were
+    // being used and the command didn't exist, but individual handlers could use it as well.
+    class no_such_endpoint : public std::exception
+    {
+        const char* what() const noexcept override { return "endpoint does not exist"; }
+    };
+
     struct message
     {
         friend class BTRequestStream;
@@ -47,11 +57,15 @@ namespace oxen::quic
         message(BTRequestStream& bp, bstring req, bool is_timeout = false);
 
       public:
+        inline static constexpr auto TYPE_REPLY = "R"sv;
+        inline static constexpr auto TYPE_ERROR = "E"sv;
+        inline static constexpr auto TYPE_COMMAND = "C"sv;
+
         void respond(bstring_view body, bool error = false);
         void respond(std::string_view body, bool error = false) { respond(convert_sv<std::byte>(body), error); }
 
         const bool timed_out{false};
-        bool is_error() const { return type() == "E"sv; }
+        bool is_error() const { return type() == TYPE_ERROR; }
 
         //  To be used to determine if the message was a result of an error or timeout; equivalent
         //  to checking that both .timed_out and .is_error() are false.
@@ -159,6 +173,7 @@ namespace oxen::quic
         std::deque<std::shared_ptr<sent_request>> sent_reqs;
 
         std::unordered_map<std::string, std::function<void(message)>> func_map;
+        std::function<void(message)> generic_handler;
 
         bstring buf;
         std::string size_buf;
@@ -224,6 +239,10 @@ namespace oxen::quic
 
         void closed(uint64_t app_code) override;
 
+        /// Registers an individual command to be recognized by this BTRequestStream object.  Can be
+        /// called multiple times to set up multiple commands.  As an alternative (or supplement)
+        /// you can also specify a single handler during construction to be called for any invoked
+        /// commands that are not created via `register_command` calls.
         void register_command(std::string endpoint, std::function<void(message)>);
 
         const Address& local() const { return conn.local(); }
@@ -231,10 +250,20 @@ namespace oxen::quic
         const Address& remote() const { return conn.remote(); }
 
       private:
+        // Optional constructor argument: stream close callback
         void handle_bp_opt(std::function<void(Stream&, uint64_t)> close_cb)
         {
             log::debug(bp_cat, "Bparser set user-provided close callback!");
             close_callback = std::move(close_cb);
+        }
+
+        // Optional constructor argument: generic request handler.  If set, this is invoked for all
+        // incoming requests to endpoints that do not have a `register_command`.  (And so if
+        // `register_command` is not used at all, this can handle all endpoint).
+        void handle_bp_opt(std::function<void(oxen::quic::message m)> request_handler)
+        {
+            log::debug(bp_cat, "Bparser set generic request handler");
+            generic_handler = std::move(request_handler);
         }
 
         void handle_input(message msg);

--- a/src/btstream.cpp
+++ b/src/btstream.cpp
@@ -86,13 +86,13 @@ namespace oxen::quic
         close_callback(*this, app_code);
     }
 
-    void BTRequestStream::register_command(std::string ep, std::function<void(message)> func)
+    void BTRequestStream::register_handler(std::string ep, std::function<void(message)> func)
     {
         endpoint.call(
                 [this, ep = std::move(ep), func = std::move(func)]() mutable { func_map[std::move(ep)] = std::move(func); });
     }
 
-    void BTRequestStream::register_command_fallback(std::function<void(message)> request_handler)
+    void BTRequestStream::register_generic_handler(std::function<void(message)> request_handler)
     {
         log::debug(bp_cat, "Bparser set generic request handler");
         endpoint.call([this, func = std::move(request_handler)]() mutable { generic_handler = std::move(func); });
@@ -130,7 +130,7 @@ namespace oxen::quic
         {
             if (!func_map.empty())
             {
-                if (auto itr = func_map.find(msg.endpoint_str()); itr != func_map.end())
+                if (auto itr = func_map.find(ep); itr != func_map.end())
                 {
                     log::debug(bp_cat, "Executing request endpoint {}", msg.endpoint());
                     return itr->second(std::move(msg));

--- a/src/btstream.cpp
+++ b/src/btstream.cpp
@@ -32,7 +32,7 @@ namespace oxen::quic
         }
     }
 
-    void message::respond(bstring_view body, bool error)
+    void message::respond(bstring_view body, bool error) const
     {
         log::trace(bp_cat, "{} called", __PRETTY_FUNCTION__);
 

--- a/tests/002-send-receive.cpp
+++ b/tests/002-send-receive.cpp
@@ -249,7 +249,7 @@ namespace oxen::quic::test
 
             stream_constructor_callback server_constructor = [&](Connection& c, Endpoint& e, std::optional<int64_t>) {
                 auto s = e.make_shared<BTRequestStream>(c, e);
-                s->register_command("test_endpoint"s, server_bp_cb);
+                s->register_handler("test_endpoint"s, server_bp_cb);
                 return s;
             };
 
@@ -288,7 +288,7 @@ namespace oxen::quic::test
 
             stream_constructor_callback server_constructor = [&](Connection& c, Endpoint& e, std::optional<int64_t>) {
                 auto s = e.make_shared<BTRequestStream>(c, e);
-                s->register_command("test_endpoint"s, server_bp_cb);
+                s->register_handler("test_endpoint"s, server_bp_cb);
                 return s;
             };
 
@@ -332,7 +332,7 @@ namespace oxen::quic::test
 
             stream_constructor_callback server_constructor = [&](Connection& c, Endpoint& e, std::optional<int64_t>) {
                 auto s = e.make_shared<BTRequestStream>(c, e);
-                s->register_command("test_endpoint"s, server_bp_cb);
+                s->register_handler("test_endpoint"s, server_bp_cb);
                 return s;
             };
 
@@ -391,7 +391,7 @@ namespace oxen::quic::test
 
             stream_constructor_callback server_constructor = [&](Connection& c, Endpoint& e, std::optional<int64_t>) {
                 auto s = e.make_shared<BTRequestStream>(c, e);
-                s->register_command("test"s, server_bp_cb);
+                s->register_handler("test"s, server_bp_cb);
                 return s;
             };
 
@@ -471,7 +471,7 @@ namespace oxen::quic::test
 
         stream_constructor_callback server_constructor = [&](Connection& c, Endpoint& e, std::optional<int64_t>) {
             auto s = e.make_shared<BTRequestStream>(c, e);
-            s->register_command("test_endpoint"s, server_handler);
+            s->register_handler("test_endpoint"s, server_handler);
             return s;
         };
 
@@ -549,7 +549,7 @@ namespace oxen::quic::test
 
             stream_constructor_callback server_constructor = [&](Connection& c, Endpoint& e, std::optional<int64_t>) {
                 auto s = e.make_shared<BTRequestStream>(c, e);
-                s->register_command("test_endpoint"s, server_handler);
+                s->register_handler("test_endpoint"s, server_handler);
                 return s;
             };
 
@@ -590,7 +590,7 @@ namespace oxen::quic::test
 
             stream_constructor_callback server_constructor = [&](Connection& c, Endpoint& e, std::optional<int64_t>) {
                 auto s = e.make_shared<BTRequestStream>(c, e);
-                s->register_command("test_endpoint"s, server_handler);
+                s->register_handler("test_endpoint"s, server_handler);
                 return s;
             };
 
@@ -655,17 +655,17 @@ namespace oxen::quic::test
         {
             server_conn_est = [&](connection_interface& c) {
                 auto s = c.queue_incoming_stream<BTRequestStream>(std::move(handler_generic));
-                s->register_command("ep1"s, handler1);
-                s->register_command("ep2"s, handler2);
+                s->register_handler("ep1"s, handler1);
+                s->register_handler("ep2"s, handler2);
             };
         }
         SECTION("generic handler via method")
         {
             server_conn_est = [&](connection_interface& c) {
                 auto s = c.queue_incoming_stream<BTRequestStream>();
-                s->register_command("ep1"s, handler1);
-                s->register_command("ep2"s, handler2);
-                s->register_command_fallback(std::move(handler_generic));
+                s->register_handler("ep1"s, handler1);
+                s->register_handler("ep2"s, handler2);
+                s->register_generic_handler(std::move(handler_generic));
             };
         }
 

--- a/tests/004-streams.cpp
+++ b/tests/004-streams.cpp
@@ -705,7 +705,7 @@ namespace oxen::quic::test
 
         auto client_established = callback_waiter{[&](connection_interface& ci) {
             client_extracted = ci.open_stream<BTRequestStream>();
-            client_extracted->register_command("test_endpoint"s, client_handler);
+            client_extracted->register_handler("test_endpoint"s, client_handler);
         }};
 
         stream_constructor_callback server_constructor =
@@ -715,7 +715,7 @@ namespace oxen::quic::test
                 if (*id == 0)
                 {
                     server_extracted = e.make_shared<BTRequestStream>(c, e);
-                    server_extracted->register_command("test_endpoint"s, server_handler);
+                    server_extracted->register_handler("test_endpoint"s, server_handler);
                     return server_extracted;
                 }
                 else
@@ -775,7 +775,7 @@ namespace oxen::quic::test
 
         auto server_established = callback_waiter{[&](connection_interface& ci) {
             server_bt = ci.queue_incoming_stream<BTRequestStream>();
-            server_bt->register_command("test_endpoint"s, server_handler);
+            server_bt->register_handler("test_endpoint"s, server_handler);
         }};
 
         auto client_established = callback_waiter{[&](connection_interface&) {}};
@@ -792,7 +792,7 @@ namespace oxen::quic::test
         REQUIRE(server_established.wait());
 
         client_bt = client_ci->open_stream<BTRequestStream>();
-        client_bt->register_command("test_endpoint"s, client_handler);
+        client_bt->register_handler("test_endpoint"s, client_handler);
         REQUIRE(client_bt->stream_id() == 0);
 
         server_ci = server_endpoint->get_all_conns(Direction::INBOUND).front();


### PR DESCRIPTION
This adds the ability to construct a BTRequestStream with a generic command handler so that if you have a non-trivial set of commands you don't have to incur a potentially large instantiation cost of constructing a bunch of lambda for `register_command` calls that may never be used.  Instead you can now provide a single handler that gets called for any incoming command.

This also adds the ability to throw a new `no_such_endpoint` exception so that such a handler can signal that an endpoint doesn't exist.

Since this necessitated adding an exception handler anyway, this also catches generic exceptions and wraps them with a generic error-producing response function.  Previously an uncaught exception throw from a handler would crash the program.