### PR TITLE
Stream/connection thread-safety and lifetime fixes

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -78,7 +78,7 @@ local generic_build(jobs, build_type, lto, werror, cmake_extra, local_mirror, te
         + (if tests then [
              'cd build',
              '../utils/gen-certs.sh',
-             (if gdb then '../utils/ci/drone-gdb.sh ' else '') + './tests/alltests --log-level debug --no-ipv6 --colour-mode ansi',
+             (if gdb then '../utils/ci/drone-gdb.sh ' else '') + './tests/alltests --success --log-level debug --no-ipv6 --colour-mode ansi',
              'cd ..',
            ] else []);
 

--- a/include/oxen/quic/btstream.hpp
+++ b/include/oxen/quic/btstream.hpp
@@ -235,12 +235,6 @@ namespace oxen::quic
 
         void respond(int64_t rid, bstring_view body, bool error = false);
 
-        void check_timeouts() override;
-
-        void receive(bstring_view data) override;
-
-        void closed(uint64_t app_code) override;
-
         /// Registers an individual endpoint to be recognized by this BTRequestStream object.  Can be
         /// called multiple times to set up multiple commands.  See also register_generic_handler.
         void register_handler(std::string endpoint, std::function<void(message)>);
@@ -252,11 +246,14 @@ namespace oxen::quic
         /// exception if the endpoint in this message should be considered not found.
         void register_generic_handler(std::function<void(message)> request_handler);
 
-        const Address& local() const { return conn.local(); }
+        size_t num_pending() const;
 
-        const Address& remote() const { return conn.remote(); }
+      protected:
+        void check_timeouts() override;
 
-        size_t num_pending() const { return user_buffers.size(); }
+        void receive(bstring_view data) override;
+
+        void closed(uint64_t app_code) override;
 
       private:
         // Optional constructor argument: stream close callback
@@ -283,5 +280,7 @@ namespace oxen::quic
         std::string encode_response(int64_t rid, bstring_view body, bool error);
 
         size_t parse_length(std::string_view req);
+
+        size_t num_pending_impl() const { return user_buffers.size(); }
     };
 }  // namespace oxen::quic

--- a/include/oxen/quic/connection.hpp
+++ b/include/oxen/quic/connection.hpp
@@ -145,24 +145,75 @@ namespace oxen::quic
             send_datagram(view, std::move(keep_alive));
         }
 
-        virtual void set_close_quietly() = 0;
         virtual void send_datagram(bstring_view data, std::shared_ptr<void> keep_alive = nullptr) = 0;
-        virtual size_t num_streams_active() const = 0;
-        virtual size_t num_streams_pending() const = 0;
-        virtual uint64_t get_max_streams() const = 0;
-        virtual uint64_t get_streams_available() const = 0;
-        virtual size_t get_max_datagram_size() const = 0;
+
+        virtual Endpoint& endpoint() = 0;
+        virtual const Endpoint& endpoint() const = 0;
+
+        virtual void set_close_quietly() = 0;
+
         virtual bool datagrams_enabled() const = 0;
         virtual bool packet_splitting_enabled() const = 0;
         virtual const ConnectionID& reference_id() const = 0;
-        virtual const Address& local() const = 0;
-        virtual const Address& remote() const = 0;
         virtual bool is_validated() const = 0;
         virtual Direction direction() const = 0;
         virtual ustring_view remote_key() const = 0;
         virtual bool is_inbound() const = 0;
         virtual bool is_outbound() const = 0;
         virtual std::string direction_str() = 0;
+
+        // Non-virtual base class wrappers for the virtual methods of the same name with _impl
+        // appended (e.g.  path_impl); these versions in the base class wrap the _impl call in a
+        // call_get to return the value synchronously.  Generally external application code should
+        // use this, and internal quic code (already in the event loop thread) should use the _impl
+        // ones directly.
+
+        /// Returns the number of streams that are currently open
+        size_t num_streams_active();
+
+        /// Returns the number of streams that have been created but are not yet active on the
+        /// connection; they will become active once the connection negotiates an increase to the
+        /// maximum number of streams, *or* when an existing stream closes, opening a stream slot on
+        /// the connection.
+        size_t num_streams_pending();
+
+        /// Returns the maximum number of active streams that the connection currently allows.
+        uint64_t get_max_streams();
+
+        /// Returns the number of new streams that may still be activated on this connection.
+        uint64_t get_streams_available();
+
+        /// Returns a copy of the current Path in use by this connection.
+        Path path();
+
+        /// Returns a copy of the local address of the path in use by this connection.  (If you want
+        /// both local and remote then prefer to call `path()` once instead of local() and remote()
+        /// separately).
+        Address local();
+
+        /// Returns a copy of the remote address of the path in use by this connection.  (If you
+        /// want both local and remote then prefer to call `path()` once instead of local() and
+        /// remote() separately).
+        Address remote();
+
+        /// Returns the maximum datagram size accepted by this connection.  This depends on the
+        /// negotiated QUIC connection and can change over time, but will generally be somewhere in
+        /// the 1150-1450 range when not using datagram splitting on the connection, or double that
+        /// with datagram splitting enabled.
+        size_t get_max_datagram_size();
+
+        /// Obtains the current max datagram size *if* it has changed since the last time this
+        /// method was called (or if this method has never been called), otherwise returns nullopt.
+        /// This is designed to allow classes to react to changes in the maximum datagram size, if
+        /// needed, by periodically polling this and updating as needed when the value changes.
+        /// When there have not been changes then calling this is cheap (just an atomic bool
+        /// access); a trip to the event loop thread is necessary to retrieve the value when
+        /// changed, but changes are relatively infrequent.
+        ///
+        /// This feature is for non-standard/exotic uses: if you don't care about changes to the
+        /// size (for example, if you use splitting and know the size will always be sufficient)
+        /// then you can safely never worry about this function.
+        virtual std::optional<size_t> max_datagram_size_changed() = 0;
 
         // WIP functions: these are meant to expose specific aspects of the internal state of connection
         // and the datagram IO object for debugging and application (user) utilization.
@@ -174,6 +225,19 @@ namespace oxen::quic
 
         virtual ~connection_interface();
 
+      protected:
+        // Unsynchronized access methods suitable only for internal use in contexts where we know we
+        // are already inside the event loop thread.  The public APIs for these (without _impl)
+        // wraps these in a call_get to make them thread-safe.
+        virtual size_t num_streams_active_impl() const = 0;
+        virtual size_t num_streams_pending_impl() const = 0;
+        virtual uint64_t get_max_streams_impl() const = 0;
+        virtual uint64_t get_streams_available_impl() const = 0;
+        virtual const Path& path_impl() const = 0;
+        virtual const Address& local_impl() const { return path_impl().local; }
+        virtual const Address& remote_impl() const { return path_impl().remote; }
+        // Returns 0 if datagrams are not available
+        virtual size_t get_max_datagram_size_impl() = 0;
     };
 
     class Connection : public connection_interface
@@ -224,8 +288,8 @@ namespace oxen::quic
 
         Direction direction() const override { return dir; }
 
-        size_t num_streams_active() const override { return _streams.size(); }
-        size_t num_streams_pending() const override { return pending_streams.size(); }
+        size_t num_streams_active_impl() const override { return _streams.size(); }
+        size_t num_streams_pending_impl() const override { return pending_streams.size(); }
 
         void halt_events();
         bool is_closing() const { return closing; }
@@ -238,20 +302,23 @@ namespace oxen::quic
         bool is_inbound() const override { return not is_outbound(); }
         std::string direction_str() override { return is_inbound() ? "SERVER"s : "CLIENT"s; }
 
-        const Path& path() { return _path; }
-        const Address& local() const override { return _path.local; }
-        const Address& remote() const override { return _path.remote; }
+        const Path& path_impl() const override { return _path; }
+        const Address& local_impl() const override { return _path.local; }
+        const Address& remote_impl() const override { return _path.remote; }
 
-        Endpoint& endpoint() { return _endpoint; }
-        const Endpoint& endpoint() const { return _endpoint; }
+        Endpoint& endpoint() override { return _endpoint; }
+        const Endpoint& endpoint() const override { return _endpoint; }
 
         ustring_view selected_alpn() const override;
 
-        uint64_t get_streams_available() const override;
-        size_t get_max_datagram_size() const override;
-        uint64_t get_max_streams() const override { return _max_streams; }
+        uint64_t get_streams_available_impl() const override;
+        size_t get_max_datagram_size_impl() override;
+        uint64_t get_max_streams_impl() const override { return _max_streams; }
+
         bool datagrams_enabled() const override { return _datagrams_enabled; }
         bool packet_splitting_enabled() const override { return _packet_splitting; }
+
+        std::optional<size_t> max_datagram_size_changed() override;
 
         // public debug functions; to be removed with friend test fixture class
         int last_cleared() const override;
@@ -294,6 +361,13 @@ namespace oxen::quic
 
         bool closing_quietly() const { return _close_quietly; }
 
+        // Called when the endpoint drops its shared pointer to this Connection, to have this
+        // Connection clear itself from all of its streams and then drop the streams.  (This is a
+        // sort of pseudo-destruction to leave the involved objects as empty shells since there
+        // might be shared pointers in application space that keep the connection and/or stream
+        // alive after it gets dropped from libquic internal structures).
+        void drop_streams();
+
       private:
         // private Constructor (publicly construct via `make_conn` instead, so that we can properly
         // set up the shared_from_this shenanigans).
@@ -328,10 +402,11 @@ namespace oxen::quic
         const uint64_t _max_streams{DEFAULT_MAX_BIDI_STREAMS};
         const bool _datagrams_enabled{false};
         const bool _packet_splitting{false};
+        size_t _last_max_dgram_size{0};
+        std::atomic<bool> _max_dgram_size_changed{true};
 
         std::atomic<bool> _close_quietly{false};
-        std::atomic<bool> _congested{false};
-        bool _is_validated{false};
+        std::atomic<bool> _is_validated{false};
 
         ustring remote_pubkey;
 
@@ -418,6 +493,7 @@ namespace oxen::quic
         int stream_ack(int64_t id, size_t size);
         int stream_receive(int64_t id, bstring_view data, bool fin);
         void stream_closed(int64_t id, uint64_t app_code);
+        void close_all_streams();
         void check_pending_streams(uint64_t available);
         int recv_datagram(bstring_view data, bool fin);
         int ack_datagram(uint64_t dgram_id);

--- a/include/oxen/quic/error.hpp
+++ b/include/oxen/quic/error.hpp
@@ -13,8 +13,9 @@ namespace oxen::quic
     // application error codes, without going so big that we need 64-bit encoding.
     inline constexpr uint64_t ERROR_BASE = 777'000'000;
 
-    // Error code we send to a stream close callback if the stream's connection expires
-    inline constexpr uint64_t STREAM_ERROR_CONNECTION_EXPIRED = ERROR_BASE + 1;
+    // Error code we pass to a stream close callback if the stream is closed because the connection
+    // is closing.
+    inline constexpr uint64_t STREAM_ERROR_CONNECTION_CLOSED = ERROR_BASE + 1;
 
     // Application error code we close with if the stream data handle throws
     inline constexpr uint64_t STREAM_ERROR_EXCEPTION = ERROR_BASE + 100;
@@ -56,8 +57,8 @@ namespace oxen::quic
                 return "Error - stream exception"s;
             case BPARSER_ERROR_EXCEPTION:
                 return "Error - bt request stream exception"s;
-            case STREAM_ERROR_CONNECTION_EXPIRED:
-                return "Error - stream connection expired"s;
+            case STREAM_ERROR_CONNECTION_CLOSED:
+                return "Error - stream connection closed"s;
             case CONN_WRITE_CLOSE_FAIL:
                 return "Error - Failed to write connection close"s;
             case CONN_SEND_CLOSE_FAIL:

--- a/include/oxen/quic/iochannel.hpp
+++ b/include/oxen/quic/iochannel.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "connection_ids.hpp"
 #include "messages.hpp"
 #include "utils.hpp"
 
@@ -12,16 +13,13 @@ namespace oxen::quic
     class IOChannel
     {
       protected:
-        IOChannel(Connection& c, Endpoint& e) : conn{c}, endpoint{e}
-        {
-            log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
-        }
+        IOChannel(Connection& c, Endpoint& e);
 
       public:
         virtual ~IOChannel() { log::trace(log_cat, "{} called", __PRETTY_FUNCTION__); };
 
-        Connection& conn;
         Endpoint& endpoint;
+        const ConnectionID reference_id;
 
         // no copy, no move. always hold in a shared pointer
         IOChannel(const IOChannel&) = delete;
@@ -30,17 +28,22 @@ namespace oxen::quic
         IOChannel& operator=(IOChannel&&) = delete;
 
         virtual bool is_stream() const = 0;
-        virtual bool is_empty() const = 0;
         virtual std::shared_ptr<Stream> get_stream() = 0;
-        virtual std::vector<ngtcp2_vec> pending() = 0;
-        virtual prepared_datagram pending_datagram(bool) = 0;
         virtual int64_t stream_id() const = 0;
-        virtual bool is_closing() const = 0;
-        virtual bool sent_fin() const = 0;
-        virtual void set_fin(bool) = 0;
-        virtual size_t unsent() const = 0;
-        virtual void wrote(size_t) = 0;
-        virtual bool has_unsent() const = 0;
+
+        // These public methods are intended for access from anywhere and invoke a call_get to
+        // synchronously get their value.  (Subclasses provide implementations by overriding the
+        // protected _impl versions of these methods).
+        bool is_empty() const;
+        size_t unsent() const;
+        bool has_unsent() const;
+        bool is_closing() const;
+
+        // These are call_get-proxied to return the value from the Connection object.  They throw if
+        // the Connection object no longer exists.
+        Path path() const;
+        Address local() const;
+        Address remote() const;
 
         template <typename CharType, std::enable_if_t<sizeof(CharType) == 1, int> = 0>
         void send(std::basic_string_view<CharType> data, std::shared_ptr<void> keep_alive = nullptr)
@@ -63,9 +66,58 @@ namespace oxen::quic
         }
 
       protected:
+        friend class Connection;
+        friend struct rotating_buffer;
+
+        Connection* _conn;
+
         // This is the (single) send implementation that implementing classes must provide; other
         // calls to send are converted into calls to this.
         virtual void send_impl(bstring_view, std::shared_ptr<void> keep_alive) = 0;
+
+        virtual std::vector<ngtcp2_vec> pending() = 0;
+        virtual prepared_datagram pending_datagram(bool) = 0;
+        virtual bool sent_fin() const = 0;
+        virtual void set_fin(bool) = 0;
+        virtual void wrote(size_t) = 0;
+
+        // Does the actual implementation: these methods may only be called internally, from code
+        // already inside the event loop thread.  (The public non-_impl versions of these methods
+        // are simply wrappers that use call_get to invoke these _impl versions).
+        virtual bool is_empty_impl() const = 0;
+        virtual size_t unsent_impl() const = 0;
+        virtual bool has_unsent_impl() const = 0;
+        virtual bool is_closing_impl() const = 0;
+
+        // Wraps an IOChannel (or derived type) accessor member function pointer in a call_get for
+        // synchronous access that always returns by value (even if the member function returns by
+        // reference).
+        template <
+                typename Class,
+                typename T,
+                typename Ret = remove_cvref_t<T>,
+                typename EP = std::enable_if_t<std::is_base_of_v<IOChannel, Class>, Endpoint>>
+        Ret call_get_accessor(T (Class::*getter)() const) const
+        {
+            return static_cast<EP&>(endpoint).call_get(
+                    [this, &getter]() -> Ret { return (static_cast<const Class*>(this)->*getter)(); });
+        }
+
+        // Wraps a Connection accessor member function pointer in a call_get for synchronous access
+        // that always returns by value (even if the member function returns by reference) through
+        // the IOChannel's connection pointer.  Throws if the Connection doesn't exist anymore.
+        template <typename T, typename Ret = remove_cvref_t<T>, typename EP = Endpoint>
+        Ret call_get_accessor(T (Connection::*getter)() const) const
+        {
+            // This do-nothing static cast to force deferred instantiation until later on (when the
+            // Endpoint class will be available).  Otherwise this won't compile because Endpoint
+            // is only forward declared here.
+            return static_cast<EP&>(endpoint).call_get([this, &getter]() -> Ret {
+                if (!_conn)
+                    throw std::runtime_error{"Connection has gone away"};
+                return (_conn->*getter)();
+            });
+        }
     };
 
 }  // namespace oxen::quic

--- a/include/oxen/quic/messages.hpp
+++ b/include/oxen/quic/messages.hpp
@@ -108,7 +108,7 @@ namespace oxen::quic
     struct rotating_buffer
     {
         int row{0}, col{0}, last_cleared{-1};
-        DatagramIO& d;
+        DatagramIO& datagram;
         const int bufsize;
         const int rowsize;
         // tracks the number of partial datagrams held in each buffer bucket

--- a/include/oxen/quic/network.hpp
+++ b/include/oxen/quic/network.hpp
@@ -132,7 +132,13 @@ namespace oxen::quic
             call_soon([&f, &prom] {
                 try
                 {
-                    prom.set_value(f());
+                    if constexpr (!std::is_void_v<Ret>)
+                        prom.set_value(f());
+                    else
+                    {
+                        f();
+                        prom.set_value();
+                    }
                 }
                 catch (...)
                 {

--- a/include/oxen/quic/stream.hpp
+++ b/include/oxen/quic/stream.hpp
@@ -47,9 +47,9 @@ namespace oxen::quic
       public:
         ~Stream() override;
 
-        bool available() const { return !(_is_closing || is_shutdown || _sent_fin); }
+        bool available() const { return !(_is_closing || _is_shutdown || _sent_fin); }
         bool is_stream() const override { return true; }
-        bool is_ready() const { return ready; }
+        bool is_ready() const { return _ready; }
         bool is_empty() const override { return user_buffers.empty(); }
         int64_t stream_id() const override { return _stream_id; }
         const ConnectionID& reference_id() const;
@@ -97,11 +97,11 @@ namespace oxen::quic
       private:
         std::vector<ngtcp2_vec> pending() override;
 
-        size_t unacked_size{0};
+        size_t _unacked_size{0};
         bool _is_closing{false};
-        bool is_shutdown{false};
+        bool _is_shutdown{false};
         bool _sent_fin{false};
-        bool ready{false};
+        bool _ready{false};
         int64_t _stream_id;
 
         const Connection& get_conn() const { return conn; }
@@ -112,7 +112,7 @@ namespace oxen::quic
 
         void acknowledge(size_t bytes);
 
-        inline size_t size() const
+        size_t size() const
         {
             size_t sum{0};
             if (user_buffers.empty())
@@ -122,9 +122,9 @@ namespace oxen::quic
             return sum;
         }
 
-        inline size_t unacked() const { return unacked_size; }
+        size_t unacked() const { return _unacked_size; }
 
-        inline size_t unsent() const override
+        size_t unsent() const override
         {
             log::trace(log_cat, "size={}, unacked={}", size(), unacked());
             return size() - unacked();
@@ -266,10 +266,10 @@ namespace oxen::quic
             chunk_sender<T>::make(simultaneous, *this, std::move(next_chunk), std::move(done));
         }
 
-        inline void set_ready()
+        void set_ready()
         {
             log::trace(log_cat, "Setting stream ready");
-            ready = true;
+            _ready = true;
             on_ready();
         }
     };

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(quic
     format.cpp
     gnutls_creds.cpp
     gnutls_session.cpp
+    iochannel.cpp
     messages.cpp
     network.cpp
     stream.cpp

--- a/src/btstream.cpp
+++ b/src/btstream.cpp
@@ -14,7 +14,7 @@ namespace oxen::quic
     }
 
     message::message(BTRequestStream& bp, bstring req, bool is_timeout) :
-            data{std::move(req)}, return_sender{bp.weak_from_this()}, _rid{bp.reference_id()}, timed_out{is_timeout}
+            data{std::move(req)}, return_sender{bp.weak_from_this()}, _rid{bp.reference_id}, timed_out{is_timeout}
     {
         if (!is_timeout)
         {
@@ -288,4 +288,10 @@ namespace oxen::quic
 
         return pos + 1;
     }
+
+    size_t BTRequestStream::num_pending() const
+    {
+        return call_get_accessor(&BTRequestStream::num_pending_impl);
+    }
+
 }  // namespace oxen::quic

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -642,7 +642,7 @@ namespace oxen::quic
             else
                 stream = construct_stream(nullptr);
 
-            assert(!stream->ready);
+            assert(!stream->_ready);
             stream->_stream_id = next_incoming_stream_id;
             next_incoming_stream_id += 4;
 
@@ -668,12 +668,12 @@ namespace oxen::quic
             else
                 stream = construct_stream(make_stream);
 
-            assert(!stream->ready);
+            assert(!stream->_ready);
 
             if (int rv = ngtcp2_conn_open_bidi_stream(conn.get(), &stream->_stream_id, stream.get()); rv != 0)
             {
                 log::warning(log_cat, "Stream not ready [Code: {}]; adding to pending streams list", ngtcp2_strerror(rv));
-                assert(!stream->ready);
+                assert(!stream->_ready);
                 pending_streams.push_back(std::move(stream));
                 return pending_streams.back();
             }
@@ -1140,7 +1140,7 @@ namespace oxen::quic
 
         auto& stream = *it->second;
         const bool was_closing = stream._is_closing;
-        stream._is_closing = stream.is_shutdown = true;
+        stream._is_closing = stream._is_shutdown = true;
 
         if (!was_closing)
         {

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -758,16 +758,12 @@ namespace oxen::quic
         log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
         assert(n_packets > 0 && n_packets <= MAX_BATCH);
 
-#ifndef NDEBUG
-        if (test_suite.datagram_flip_flop_enabled)
+        if (debug_datagram_flip_flop_enabled)
         {
-            test_suite.datagram_flip_flip_counter += n_packets;
-            log::debug(
-                    log_cat,
-                    "enable_datagram_flip_flop_test is true; sent packet count: {}",
-                    test_suite.datagram_flip_flip_counter.load());
+            debug_datagram_counter += n_packets;
+            log::debug(log_cat, "enable_datagram_flip_flop_test is true; sent packet count: {}", debug_datagram_counter);
         }
-#endif
+
         auto rv = endpoint().send_packets(_path.remote, send_buffer.data(), send_buffer_size.data(), send_ecn, n_packets);
 
         if (rv.blocked())
@@ -1614,12 +1610,6 @@ namespace oxen::quic
 
         event_add(packet_retransmit_timer.get(), nullptr);
 
-#ifndef NDEBUG
-        test_suite.datagram_drop_enabled = false;
-        test_suite.datagram_flip_flop_enabled = false;
-        test_suite.datagram_drop_counter = 0;
-        test_suite.datagram_flip_flip_counter = 0;
-#endif
         log::info(log_cat, "Successfully created new {} connection object", d_str);
     }
 
@@ -1658,18 +1648,15 @@ namespace oxen::quic
             s->check_timeouts();
     }
 
-#ifndef NDEBUG
 
     connection_interface::~connection_interface()
     {
-        log::debug(log_cat, "connection_interface @{} destroyed", (void*)this);
+        log::trace(log_cat, "connection_interface @{} destroyed", (void*)this);
     }
 
     Connection::~Connection()
     {
-        log::debug(log_cat, "Connection @{} destroyed", (void*)this);
+        log::trace(log_cat, "Connection @{} destroyed", (void*)this);
     }
-
-#endif
 
 }  // namespace oxen::quic

--- a/src/datagram.cpp
+++ b/src/datagram.cpp
@@ -11,17 +11,12 @@ namespace oxen::quic
             dgram_data_cb{std::move(data_cb)},
             rbufsize{endpoint._rbufsize},
             recv_buffer{*this},
-            _packet_splitting(conn.packet_splitting_enabled())
+            _packet_splitting(_conn->packet_splitting_enabled())
     {
         log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
     }
 
-    dgram_interface::dgram_interface(Connection& c) : ci{c} {}
-
-    const ConnectionID& dgram_interface::reference_id() const
-    {
-        return ci.reference_id();
-    }
+    dgram_interface::dgram_interface(Connection& c) : ci{c}, reference_id{ci.reference_id()} {}
 
     std::shared_ptr<connection_interface> dgram_interface::get_conn_interface()
     {
@@ -35,32 +30,40 @@ namespace oxen::quic
 
     void DatagramIO::send_impl(bstring_view data, std::shared_ptr<void> keep_alive)
     {
-        // check this first and once; already considers policy when returning
-        const auto max_size = conn.get_max_datagram_size();
-
-        // we use >= instead of > for that just-in-case 1-byte cushion
-        if (data.size() > max_size)
-        {
-            log::warning(
-                    log_cat,
-                    "Data of length {} cannot be sent with {} datagrams of max size {}",
-                    data.size(),
-                    _packet_splitting ? "unsplit" : "split",
-                    max_size);
-            throw std::invalid_argument{"Data too large to send as datagram with current policy"};
-        }
-
         // if packet_splitting is lazy OR packet_splitting is off, send as "normal" datagram
-        endpoint.call([this, data, keep_alive, max_size]() {
+        endpoint.call([this, data, keep_alive = std::move(keep_alive)]() {
+            if (!_conn)
+            {
+                log::warning(log_cat, "Unable to send datagram: connection has gone away");
+                return;
+            }
+
+            // check this first and once; already considers policy when returning
+            const auto max_size = _conn->get_max_datagram_size_impl();
+
+            // we use >= instead of > for that just-in-case 1-byte cushion
+            if (data.size() > max_size)
+            {
+                log::warning(
+                        log_cat,
+                        "Data of length {} cannot be sent with {} datagrams of max size {}",
+                        data.size(),
+                        _packet_splitting ? "unsplit" : "split",
+                        max_size);
+                // Ideally we would throw, but because we're inside a `call` and are probably
+                // running after the `send_impl` call returned, all we can really do is warn and
+                // drop.
+                return;
+            }
+
             log::trace(
                     log_cat,
                     "Connection ({}) sending {} datagram: {}",
-                    conn.reference_id(),
+                    _conn->reference_id(),
                     _packet_splitting ? "split" : "whole",
                     buffer_printer{data});
 
-            auto half_size = max_size / 2;
-            bool split = _packet_splitting && data.size() > half_size;
+            bool split = _packet_splitting && data.size() > max_size / 2;
 
             auto dgram_id = _next_dgram_counter << 2;
             if (split)
@@ -69,7 +72,7 @@ namespace oxen::quic
 
             send_buffer.emplace(data, dgram_id, std::move(keep_alive), split ? dgram::OVERSIZED : dgram::STANDARD, max_size);
 
-            conn.packet_io_ready();
+            _conn->packet_io_ready();
         });
     }
 

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -231,6 +231,8 @@ namespace oxen::quic
     {
         if (not conn.closing_quietly())
         {
+            conn.close_all_streams();
+
             // prioritize connection level callback over endpoint level
             if (conn.conn_closed_cb)
             {
@@ -325,6 +327,8 @@ namespace oxen::quic
     {
         const auto& rid = conn.reference_id();
 
+        conn.halt_events();
+
         log::debug(log_cat, "Deleting associated CIDs for connection ({})", rid);
 
         if (conn.is_inbound())
@@ -341,6 +345,8 @@ namespace oxen::quic
             dissociate_cid(&*itr, conn);
             itr = cids.erase(itr);
         }
+
+        conn.drop_streams();
 
         conns.erase(rid);
         log::debug(log_cat, "Deleted connection ({})", rid);

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -316,8 +316,8 @@ namespace oxen::quic
                         "Error: failed to send close packet [{}]; removing connection ({})",
                         rv.str_error(),
                         conn.reference_id());
-                delete_connection(conn);
             }
+            delete_connection(conn);
         });
     }
 
@@ -778,6 +778,8 @@ namespace oxen::quic
                 send_or_queue_packet(p, std::move(buf), ecn, std::move(cb));
             });
         }
+        else if (callback)
+            callback({});
     }
 
     void Endpoint::send_version_negotiation(const ngtcp2_version_cid& vid, const Path& p)

--- a/src/iochannel.cpp
+++ b/src/iochannel.cpp
@@ -1,0 +1,48 @@
+#include "iochannel.hpp"
+
+#include "endpoint.hpp"
+
+namespace oxen::quic
+{
+
+    IOChannel::IOChannel(Connection& c, Endpoint& e) : endpoint{e}, reference_id{c.reference_id()}, _conn{&c}
+    {
+        log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
+    }
+
+    bool IOChannel::is_empty() const
+    {
+        return call_get_accessor(&IOChannel::is_empty_impl);
+    }
+
+    size_t IOChannel::unsent() const
+    {
+        return call_get_accessor(&IOChannel::unsent_impl);
+    }
+
+    bool IOChannel::has_unsent() const
+    {
+        return call_get_accessor(&IOChannel::has_unsent_impl);
+    }
+
+    bool IOChannel::is_closing() const
+    {
+        return call_get_accessor(&IOChannel::is_closing_impl);
+    }
+
+    Path IOChannel::path() const
+    {
+        return call_get_accessor(&Connection::path_impl);
+    }
+
+    Address IOChannel::local() const
+    {
+        return call_get_accessor(&Connection::local_impl);
+    }
+
+    Address IOChannel::remote() const
+    {
+        return call_get_accessor(&Connection::remote_impl);
+    }
+
+}  // namespace oxen::quic

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -2,6 +2,7 @@
 
 #include "connection.hpp"
 #include "datagram.hpp"
+#include "endpoint.hpp"
 
 namespace oxen::quic
 {
@@ -42,7 +43,7 @@ namespace oxen::quic
 #endif
     }
 
-    rotating_buffer::rotating_buffer(DatagramIO& _d) : d{_d}, bufsize{_d.rbufsize}, rowsize{_d.rbufsize / 4}
+    rotating_buffer::rotating_buffer(DatagramIO& d) : datagram{d}, bufsize{d.rbufsize}, rowsize{d.rbufsize / 4}
     {
         for (auto& v : buf)
             v.resize(rowsize);
@@ -51,6 +52,9 @@ namespace oxen::quic
     std::optional<bstring> rotating_buffer::receive(bstring_view data, uint16_t dgid)
     {
         log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
+
+        assert(datagram.endpoint.in_event_loop());
+        assert(datagram._conn);
 
         auto idx = dgid >> 2;
         log::trace(
@@ -70,11 +74,11 @@ namespace oxen::quic
 
         if (b)
         {
-            if (d.conn.test_suite.datagram_drop_enabled)
+            if (datagram._conn->debug_datagram_drop_enabled)
             {
                 log::debug(log_cat, "enable_datagram_drop_test is true, inducing packet loss");
-                d.conn.test_suite.datagram_drop_counter += 1;
-                log::debug(log_cat, "test counter: {}", d.conn.test_suite.datagram_drop_counter.load());
+                datagram._conn->debug_datagram_counter++;
+                log::debug(log_cat, "test counter: {}", datagram._conn->debug_datagram_counter);
                 return std::nullopt;
             }
             else

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -70,7 +70,6 @@ namespace oxen::quic
 
         if (b)
         {
-#ifndef NDEBUG
             if (d.conn.test_suite.datagram_drop_enabled)
             {
                 log::debug(log_cat, "enable_datagram_drop_test is true, inducing packet loss");
@@ -82,7 +81,6 @@ namespace oxen::quic
             {
                 log::debug(log_cat, "enable_datagram_drop_test is false, skipping optional logic");
             }
-#endif
 
             log::trace(
                     log_cat,

--- a/tests/001-handshake.cpp
+++ b/tests/001-handshake.cpp
@@ -350,6 +350,7 @@ namespace oxen::quic::test
                 // The endpoint-level callback will be called for the connection that was initiated by the
                 // client, as the client's pubkey dictates it's connection is to be deferred to. As a result,
                 // the reference ID will be different than that of the connection initiated by the server.
+                std::lock_guard lock{mut};
                 REQUIRE(ci.reference_id() != server_ci->reference_id());
                 p.set_value(true);
             };

--- a/tests/speedtest-server.cpp
+++ b/tests/speedtest-server.cpp
@@ -79,7 +79,7 @@ int main(int argc, char* argv[])
     std::map<ConnectionID, std::map<int64_t, stream_info>> csd;
 
     stream_data_callback stream_data = [&](Stream& s, bstring_view data) {
-        auto& sd = csd[s.conn.reference_id()];
+        auto& sd = csd[s.reference_id];
         auto it = sd.find(s.stream_id());
         if (it == sd.end())
         {

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -63,6 +63,50 @@ namespace oxen::quic
         return ep->get_conn(conn->_source_cid);
     }
 
+    void TestHelper::enable_dgram_drop(connection_interface& ci)
+    {
+        auto& conn = static_cast<Connection&>(ci);
+        conn._endpoint.call_get([&conn] {
+            conn.debug_datagram_flip_flop_enabled = false;
+            conn.debug_datagram_drop_enabled = true;
+            conn.debug_datagram_counter = 0;
+        });
+    }
+    int TestHelper::disable_dgram_drop(connection_interface& ci)
+    {
+        auto& conn = static_cast<Connection&>(ci);
+        return conn._endpoint.call_get([&conn] {
+            conn.debug_datagram_drop_enabled = false;
+            int count = 0;
+            std::swap(count, conn.debug_datagram_counter);
+            return count;
+        });
+    }
+    void TestHelper::enable_dgram_flip_flop(connection_interface& ci)
+    {
+        auto& conn = static_cast<Connection&>(ci);
+        conn._endpoint.call_get([&conn] {
+            conn.debug_datagram_drop_enabled = false;
+            conn.debug_datagram_flip_flop_enabled = true;
+            conn.debug_datagram_counter = 0;
+        });
+    }
+    int TestHelper::disable_dgram_flip_flop(connection_interface& ci)
+    {
+        auto& conn = static_cast<Connection&>(ci);
+        return conn._endpoint.call_get([&conn] {
+            conn.debug_datagram_flip_flop_enabled = false;
+            int count = 0;
+            std::swap(count, conn.debug_datagram_counter);
+            return count;
+        });
+    }
+    int TestHelper::get_dgram_debug_counter(connection_interface& ci)
+    {
+        auto& conn = static_cast<Connection&>(ci);
+        return conn._endpoint.call_get([&conn] { return conn.debug_datagram_counter; });
+    }
+
     std::pair<std::shared_ptr<GNUTLSCreds>, std::shared_ptr<GNUTLSCreds>> test::defaults::tls_creds_from_ed_keys()
     {
         auto client = GNUTLSCreds::make_from_ed_keys(CLIENT_SEED, CLIENT_PUBKEY);

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -107,6 +107,11 @@ namespace oxen::quic
         return conn._endpoint.call_get([&conn] { return conn.debug_datagram_counter; });
     }
 
+    void TestHelper::increment_ref_id(Endpoint& ep, uint64_t by)
+    {
+        ep._next_rid += by;
+    }
+
     std::pair<std::shared_ptr<GNUTLSCreds>, std::shared_ptr<GNUTLSCreds>> test::defaults::tls_creds_from_ed_keys()
     {
         auto client = GNUTLSCreds::make_from_ed_keys(CLIENT_SEED, CLIENT_PUBKEY);

--- a/tests/utils.hpp
+++ b/tests/utils.hpp
@@ -42,6 +42,10 @@ namespace oxen::quic
         static int disable_dgram_flip_flop(connection_interface& conn);
         static int get_dgram_debug_counter(connection_interface& conn);
 
+        // Bumps the connection's next reference id to make it easier to tell which connection is
+        // which in log output.
+        static void increment_ref_id(Endpoint& ep, uint64_t by = 1);
+
         static Connection* get_conn(std::shared_ptr<Endpoint>& ep, std::shared_ptr<connection_interface>& conn);
     };
 
@@ -124,7 +128,7 @@ namespace oxen::quic
     std::pair<std::string, uint16_t> parse_addr(std::string_view addr, std::optional<uint16_t> default_port = std::nullopt);
 
     template <typename F>
-    auto require_future(F& f, std::chrono::milliseconds timeout = 1s)
+    auto require_future(F&& f, std::chrono::milliseconds timeout = 1s)
     {
         REQUIRE(f.wait_for(timeout) == std::future_status::ready);
         return f.get();

--- a/tests/utils.hpp
+++ b/tests/utils.hpp
@@ -36,6 +36,12 @@ namespace oxen::quic
 
         static void set_endpoint_local_addr(Endpoint& ep, Address new_local);
 
+        static void enable_dgram_drop(connection_interface& conn);
+        static int disable_dgram_drop(connection_interface& conn);
+        static void enable_dgram_flip_flop(connection_interface& conn);
+        static int disable_dgram_flip_flop(connection_interface& conn);
+        static int get_dgram_debug_counter(connection_interface& conn);
+
         static Connection* get_conn(std::shared_ptr<Endpoint>& ep, std::shared_ptr<connection_interface>& conn);
     };
 


### PR DESCRIPTION
Fixes various issues in Stream, mostly around thread-safety and lifetime.

This all started in Python bindings when a Stream object could easily outlive its Connection (since we really don't have nicely-defined lifetime control there, because destruction depends on Python garbage collection), which could then segfault if you tried to (for instance) send down it.

This turns out to be not just a Python issue, though, as the same problem could occur (if not exactly easily) if you, for instance, held a Stream in a lambda to send something down it.

This snowballed into fixes for various Stream/Connection values being non-threadsafe.

The first few commits here were separable; see their individual descriptions.

High-level summary of the changes in the Big Commit:
- Various thread-unsafe methods are now made protected, with the old public name now becoming a wrapper than safely accesses (or sets) the appropriate value through a `call_get`.
- Stream and datagram_interface now just have a copy of their Connection's reference_id (so that we don't have to synchronously go to the Connection to get it safely).  This also means it can still be available even if the Connection has gone away.
- max datagram size handling got revamped: we have little choice but to drop (rather than throw an exception when trying to send something too big) because of the necessity of checking the maximum inside the `call`, so this necessitated some changes:
  - we now track the last max datagram size (internally) and flip an atomic<bool> if that max size changes.
  - callers can query the last size, or can check it only if it has changed.  (These aren't necessary, but provided in case an application needs to worry about the specific max datagram size).
- Streams no longer hold a `Connection&`, but instead a `Connection*` that can be nullptr'ed by the owning Connection when the Connection is going away.  Stream's now-call_get wrapped methods properly check that they have a Connection before trying to use it, and failing (or dropping) if the connection has gone away.
- Some paths through Connection shutdown didn't `halt_events()`, and some paths could end up trying to packet_io_ready() after a half_events() and segfault (because the packet_io_trigger was already deleted).  Fixed.
- Streams didn't always have their stream close callback fired.  This fixes it by calling a new `drop_streams()` method during connection close firing.  (Similarly to connection close callbacks, we don't fire them if the connection has been set to close quietly).