### PR TITLE
Log level tweaks

### DIFF
--- a/include/oxen/quic/datagram.hpp
+++ b/include/oxen/quic/datagram.hpp
@@ -151,13 +151,13 @@ namespace oxen::quic
 
         int64_t stream_id() const override
         {
-            log::debug(log_cat, "{} called", __PRETTY_FUNCTION__);
+            log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
             return std::numeric_limits<int64_t>::min();
         }
 
         std::shared_ptr<Stream> get_stream() override
         {
-            log::debug(log_cat, "{} called", __PRETTY_FUNCTION__);
+            log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
             return nullptr;
         }
 
@@ -171,18 +171,18 @@ namespace oxen::quic
 
         bool is_closing_impl() const override
         {
-            log::debug(log_cat, "{} called", __PRETTY_FUNCTION__);
+            log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
             return false;
         }
         bool sent_fin() const override
         {
-            log::debug(log_cat, "{} called", __PRETTY_FUNCTION__);
+            log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
             return false;
         }
-        void set_fin(bool) override { log::debug(log_cat, "{} called", __PRETTY_FUNCTION__); };
+        void set_fin(bool) override { log::trace(log_cat, "{} called", __PRETTY_FUNCTION__); };
         size_t unsent_impl() const override
         {
-            log::debug(log_cat, "{} called", __PRETTY_FUNCTION__);
+            log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
             size_t sum{0};
             if (send_buffer.empty())
                 return sum;
@@ -194,7 +194,7 @@ namespace oxen::quic
         void wrote(size_t) override { log::trace(log_cat, "{} called", __PRETTY_FUNCTION__); };
         std::vector<ngtcp2_vec> pending() override
         {
-            log::warning(log_cat, "{} called", __PRETTY_FUNCTION__);
+            log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
             return {};
         }
     };

--- a/include/oxen/quic/stream.hpp
+++ b/include/oxen/quic/stream.hpp
@@ -231,7 +231,7 @@ namespace oxen::quic
 
         prepared_datagram pending_datagram(bool) override
         {
-            log::warning(log_cat, "{} called", __PRETTY_FUNCTION__);
+            log::warning(log_cat, "{} called, but this is a stream object!", __PRETTY_FUNCTION__);
             throw std::runtime_error{"Stream objects should not be queried for pending datagrams!"};
         }
 

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -1666,7 +1666,7 @@ namespace oxen::quic
 
         event_add(packet_retransmit_timer.get(), nullptr);
 
-        log::info(log_cat, "Successfully created new {} connection object", d_str);
+        log::info(log_cat, "Successfully created new {} connection object {}", d_str, _ref_id);
     }
 
     std::shared_ptr<Connection> Connection::make_conn(

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -373,16 +373,16 @@ namespace oxen::quic
             Moreover, decoding and setting 0RTT transport parameters must be handled in connection creation. Both that
             location and the required callbacks are comment-blocked in the relevant location.
         */
-        if (not tls_session->get_early_data_accepted())
-        {
-            log::info(log_cat, "Early data was rejected by server!");
+        // if (not tls_session->get_early_data_accepted())
+        //{
+        // log::info(log_cat, "Early data was rejected by server!");
 
-            // if (auto rv = ngtcp2_conn_tls_early_data_rejected(conn.get()); rv != 0)
-            // {
-            //     log::error(log_cat, "ngtcp2_conn_tls_early_data_rejected: {}", ngtcp2_strerror(rv));
-            //     return -1;
-            // }
-        }
+        // if (auto rv = ngtcp2_conn_tls_early_data_rejected(conn.get()); rv != 0)
+        // {
+        //     log::error(log_cat, "ngtcp2_conn_tls_early_data_rejected: {}", ngtcp2_strerror(rv));
+        //     return -1;
+        // }
+        //}
 
         // ustring data;
         // data.resize(256);

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -445,7 +445,7 @@ namespace oxen::quic
             }
         }
 
-        log::warning(log_cat, "Could not find connection associated with {}", ccid);
+        log::debug(log_cat, "Could not find connection associated with {}", ccid);
 
         return nullptr;
     }

--- a/src/gnutls_session.cpp
+++ b/src/gnutls_session.cpp
@@ -65,7 +65,7 @@ namespace oxen::quic
 
     GNUTLSSession::~GNUTLSSession()
     {
-        log::info(log_cat, "Entered {}", __PRETTY_FUNCTION__);
+        log::trace(log_cat, "Entered {}", __PRETTY_FUNCTION__);
 
         if (not is_client)
             gnutls_anti_replay_deinit(anti_replay);
@@ -242,6 +242,7 @@ namespace oxen::quic
         if (auto rv = gnutls_alpn_get_selected_protocol(session, &proto); rv < 0)
         {
             auto err = fmt::format("{} called, but ALPN negotiation incomplete.", __PRETTY_FUNCTION__);
+            log::error(log_cat, "{}", err);
             throw std::logic_error(err);
         }
 

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -152,7 +152,7 @@ namespace oxen::quic
 
     void Network::close_immediate()
     {
-        log::debug(log_cat, "{} called", __PRETTY_FUNCTION__);
+        log::info(log_cat, "{} called", __PRETTY_FUNCTION__);
 
         if (loop_thread)
             event_base_loopbreak(ev_loop.get());


### PR DESCRIPTION
- Lowered various "... called" logs to trace level (so that there's no log system invocation in release builds on various common methods)
- Lowered "could not find connection" warning to debug, because this gets called on every new connection resulting in lots of spurious log warnings.
- Added the reference id into the "great success" connection construction info log.
- Raised network close_immediate log to `info`, to match the log level in close_gracefully.
- Added an error log just before we throw in the ALPN-bad-call path.