### PR TITLE
Add configurable idle timeout; change default to 30s

### DIFF
--- a/include/oxen/quic/context.hpp
+++ b/include/oxen/quic/context.hpp
@@ -19,6 +19,8 @@ namespace oxen::quic
         uint64_t max_streams{0};
         // keep alive timeout
         std::chrono::milliseconds keep_alive{0ms};
+        // idle timeout
+        std::chrono::milliseconds idle_timeout{DEFAULT_IDLE_TIMEOUT};
         // datagram support
         bool datagram_support{false};
         // datagram splitting support
@@ -62,6 +64,7 @@ namespace oxen::quic
         void handle_ioctx_opt(std::shared_ptr<TLSCreds> tls);
         void handle_ioctx_opt(opt::max_streams ms);
         void handle_ioctx_opt(opt::keep_alive ka);
+        void handle_ioctx_opt(opt::idle_timeout ito);
         void handle_ioctx_opt(stream_data_callback func);
         void handle_ioctx_opt(stream_open_callback func);
         void handle_ioctx_opt(stream_close_callback func);

--- a/include/oxen/quic/endpoint.hpp
+++ b/include/oxen/quic/endpoint.hpp
@@ -214,7 +214,7 @@ namespace oxen::quic
 
         void close_conns(std::optional<Direction> d = std::nullopt);
 
-        void drop_connection(Connection& conn);
+        void drop_connection(Connection& conn, io_error err);
 
         void close_connection(Connection& conn, io_error ec = io_error{0}, std::optional<std::string> msg = std::nullopt);
 
@@ -280,7 +280,7 @@ namespace oxen::quic
 
         std::vector<ustring> outbound_alpns;
         std::vector<ustring> inbound_alpns;
-        std::chrono::nanoseconds handshake_timeout{5s};
+        std::chrono::nanoseconds handshake_timeout{DEFAULT_HANDSHAKE_TIMEOUT};
 
         std::map<ustring, ustring> anti_replay_db;
 

--- a/include/oxen/quic/error.hpp
+++ b/include/oxen/quic/error.hpp
@@ -44,6 +44,10 @@ namespace oxen::quic
     inline constexpr uint64_t CONN_WRITE_CLOSE_FAIL = ERROR_BASE + 1000;
     // Failed to send connection close:
     inline constexpr uint64_t CONN_SEND_CLOSE_FAIL = ERROR_BASE + 1001;
+    // Failed to write packet
+    inline constexpr uint64_t CONN_SEND_FAIL = ERROR_BASE + 1002;
+    // Connection closing because it reached idle timeout
+    inline constexpr uint64_t CONN_IDLE_CLOSED = ERROR_BASE + 1003;
 
     inline std::string quic_strerror(uint64_t e)
     {
@@ -63,6 +67,10 @@ namespace oxen::quic
                 return "Error - Failed to write connection close"s;
             case CONN_SEND_CLOSE_FAIL:
                 return "Error - Failed to send connection close"s;
+            case CONN_SEND_FAIL:
+                return "Error - Failed to send packet"s;
+            case CONN_IDLE_CLOSED:
+                return "Connection closed by idle timeout"s;
             default:
                 return "Application error code {}"_format(e);
         }

--- a/include/oxen/quic/opt.hpp
+++ b/include/oxen/quic/opt.hpp
@@ -17,11 +17,31 @@ namespace oxen::quic::opt
         explicit max_streams(uint64_t s) : stream_count{s} {}
     };
 
+    // If non-zero, this sets a keep-alive timer for outgoing PINGs on this connection so that a
+    // functioning but idle connection can stay alive indefinitely without hitting the connection's
+    // idle timeout.  Typically in designing a protocol you need only one side to send pings; the
+    // responses to a ping keep the connection in the other direction alive.  This value should
+    // typically be lower than the idle_timeout of both sides of the connection to be effective.
+    //
+    // If this option is not specified or is set to a duration of 0 then outgoing PINGs will not be
+    // sent on the connection.
     struct keep_alive
     {
         std::chrono::milliseconds time{0ms};
         keep_alive() = default;
         explicit keep_alive(std::chrono::milliseconds val) : time{val} {}
+    };
+
+    // Can be used to override the default (30s) maximum idle timeout for a connection.  Note that
+    // this is negotiated during connection establishment, and the lower value advertised by each
+    // side will be used for the connection.  Can be 0 to disable idle timeout entirely, but such an
+    // option has caveats for connections across unknown internet boxes (see comments in RFC 9000,
+    // section 10.1.2).
+    struct idle_timeout
+    {
+        std::chrono::milliseconds timeout{DEFAULT_IDLE_TIMEOUT};
+        idle_timeout() = default;
+        explicit idle_timeout(std::chrono::milliseconds val) : timeout{val} {}
     };
 
     /// This can be initialized a few different ways. Simply passing a default constructed struct

--- a/include/oxen/quic/utils.hpp
+++ b/include/oxen/quic/utils.hpp
@@ -113,6 +113,9 @@ namespace oxen::quic
 
     inline constexpr uint64_t DEFAULT_MAX_BIDI_STREAMS = 32;
 
+    inline constexpr std::chrono::seconds DEFAULT_HANDSHAKE_TIMEOUT = 5s;
+    inline constexpr std::chrono::seconds DEFAULT_IDLE_TIMEOUT = 30s;
+
     // NGTCP2 sets the path_pmtud_payload to 1200 on connection creation, then discovers upwards
     // to a theoretical max of 1452. In 'lazy' mode, we take in split packets under the current max
     // pmtud size. In 'greedy' mode, we take in up to double the current pmtud size to split amongst

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -21,6 +21,12 @@ namespace oxen::quic
         log::trace(log_cat, "User passed connection keep_alive config value: {}", config.keep_alive.count());
     }
 
+    void IOContext::handle_ioctx_opt(opt::idle_timeout ito)
+    {
+        config.idle_timeout = ito.timeout;
+        log::trace(log_cat, "User passed connection idle_timeout config value: {}", config.idle_timeout.count());
+    }
+
     void IOContext::handle_ioctx_opt(stream_data_callback func)
     {
         log::trace(log_cat, "IO context stored stream close callback");

--- a/tests/001-handshake.cpp
+++ b/tests/001-handshake.cpp
@@ -417,4 +417,44 @@ namespace oxen::quic::test
         };
     };
 
+    TEST_CASE("001 - Idle timeout", "[001][idle][timeout]")
+    {
+        Network net{};
+
+        auto [client_tls, server_tls] = defaults::tls_creds_from_ed_keys();
+
+        Address server_local{};
+        Address client_local{};
+
+        uint64_t server_errcode = 4242;
+        uint64_t client_errcode = 424242;
+
+        callback_waiter server_conn_closed{
+                [&server_errcode](connection_interface&, uint64_t errcode) { server_errcode = errcode; }};
+        callback_waiter client_conn_closed{
+                [&client_errcode](connection_interface&, uint64_t errcode) { client_errcode = errcode; }};
+
+        auto server_endpoint = net.endpoint(server_local, server_conn_closed);
+        auto client_endpoint = net.endpoint(client_local, client_conn_closed);
+
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+
+        SECTION("Client fast timeout")
+        {
+            server_endpoint->listen(server_tls);
+            auto client_ci = client_endpoint->connect(client_remote, client_tls, opt::idle_timeout{250ms});
+        }
+        SECTION("Server fast timeout")
+        {
+            server_endpoint->listen(server_tls, opt::idle_timeout{250ms});
+            auto client_ci = client_endpoint->connect(client_remote, client_tls);
+        }
+
+        CHECK_FALSE(server_conn_closed.wait(100ms));
+
+        CHECK(server_conn_closed.wait(500ms));
+        CHECK(server_errcode == CONN_IDLE_CLOSED);
+        CHECK(client_conn_closed.wait(500ms));
+        CHECK(client_errcode == CONN_IDLE_CLOSED);
+    }
 }  // namespace oxen::quic::test


### PR DESCRIPTION
Adds an option passable to `connect`/`listen` to specify a max idle timeout for outgoing connection/incoming connections.

This also changes the default to 30s instead of 5min because 5min is long enough that it could cause problems (because internet middle boxes reportedly start dropping things after 30s or so of no activity).  Thus a 30s default seems safer, and code that knows it is safe to go longer can opt-in to larger values.

Also fixes an issue identified by the added test where the close callback was just getting 0 when we land on it via `drop_connection`; it now gets an appropriate error code passed through.