### PR TITLE
BTRequestStream: fire pending callbacks as timeouts when closing

### DIFF
--- a/include/oxen/quic/btstream.hpp
+++ b/include/oxen/quic/btstream.hpp
@@ -53,7 +53,9 @@ namespace oxen::quic
         ConnectionID _rid;
 
         // - `is_timeout` should be true if this is being constructed as a non-response because we
-        //   didn't get any reply from the other side in time.
+        //   didn't get any reply from the other side in time.  This *can* happen earlier than the
+        //   requested timeout in cases where we detect early that the response cannot arrive, such
+        //   as the connection closing.
         message(BTRequestStream& bp, bstring req, bool is_timeout = false);
 
       public:
@@ -250,6 +252,7 @@ namespace oxen::quic
 
       protected:
         void check_timeouts() override;
+        void check_timeouts(std::optional<std::chrono::steady_clock::time_point> now);
 
         void receive(bstring_view data) override;
 


### PR DESCRIPTION
This updates BTRequestStream so that, if the connection (or,
technically, just the stream) closes, we fire off any pending response
callbacks as timeouts.

This is quite useful for application code because, with this change, it
can know that it will get the reply callback fired one way or another
(unless using close_quietly, which explicitly bypasses callbacks).

Without this applications would have to juggle and coordinate calls
across both the close callback and the timeout callbacks to check the
two ways a call could fail.

This also wraps the various callback invocations in `try`s that catch
and log (but otherwise continue) in case application code throws.