### PR TITLE
Make oxen/quic/version.hpp header less annoying

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,13 +88,12 @@ add_library(libquic_external INTERFACE)
 # compilation, but not for potential external targets that depend on us.
 add_library(libquic_internal INTERFACE)
 
-configure_file(include/oxen/quic/version.hpp.in include/oxen/quic/version.hpp @ONLY)
 configure_file(liboxenquic.pc.in liboxenquic.pc @ONLY)
 
 include(cmake/check_for_std_filesystem.cmake)
 target_link_libraries(libquic_external INTERFACE filesystem)
 
-target_include_directories(libquic_external INTERFACE include ${CMAKE_CURRENT_BINARY_DIR}/include/oxen)
+target_include_directories(libquic_external INTERFACE include)
 target_include_directories(libquic_internal INTERFACE include/oxen/quic)
 
 set(warning_flags -Wall -Wextra -Wno-unknown-pragmas -Wno-unused-function -Werror=vla)

--- a/include/oxen/quic/version.hpp
+++ b/include/oxen/quic/version.hpp
@@ -1,0 +1,7 @@
+#pragma once
+#include <array>
+
+namespace oxen::quic
+{
+    extern std::array<int, 3> VERSION;
+}

--- a/include/oxen/quic/version.hpp.in
+++ b/include/oxen/quic/version.hpp.in
@@ -1,6 +1,0 @@
-#pragma once
-#include <array>
-
-namespace oxen::quic {
-    constexpr std::array<int, 3> VERSION = {@PROJECT_VERSION_MAJOR@, @PROJECT_VERSION_MINOR@, @PROJECT_VERSION_PATCH@};
-}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,7 @@
 set(libquic_send_allowed "gso, sendmmsg, sendmsg")
 
+configure_file(version.cpp.in version.cpp @ONLY)
+
 add_library(quic
     address.cpp
     btstream.cpp
@@ -16,6 +18,7 @@ add_library(quic
     stream.cpp
     udp.cpp
     utils.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/version.cpp
 )
 
 target_link_libraries(quic

--- a/src/version.cpp.in
+++ b/src/version.cpp.in
@@ -1,0 +1,5 @@
+#include <oxen/quic/version.hpp>
+
+namespace oxen::quic {
+    std::array<int, 3> VERSION{@PROJECT_VERSION_MAJOR@, @PROJECT_VERSION_MINOR@, @PROJECT_VERSION_PATCH@};
+}


### PR DESCRIPTION
This makes the version value part of the library instead of part of the header, because having it in the header makes it annoying to work with quic as a submodule in an application -- the "quic/version.hpp" include in quic.hpp isn't found because of the cmake-time generation.

This does the generation in a .cpp file instead; we lose constexpr-ness, but that doesn't seem like a big deal.