### PR TITLE
Allow individual handshake timeouts on connections

### DIFF
--- a/include/oxen/quic/connection.hpp
+++ b/include/oxen/quic/connection.hpp
@@ -262,6 +262,8 @@ namespace oxen::quic
         //          will select the first in the client's list it also supports, so the user
         //          should list them in decreasing priority. If the user does not specify alpns,
         //          the default will be set
+        //      default_handshake_timeout: the default timeout for handshaking for the endpoint
+        //          (individual connections might have this overridden via connect option).
         //      remote_pk: optional parameter used by clients to verify the pubkey of the remote
         //          endpoint during handshake negotiation. For servers, omit this parameter or
         //          pass std::nullopt
@@ -274,7 +276,7 @@ namespace oxen::quic
                 const Path& path,
                 std::shared_ptr<IOContext> ctx,
                 const std::vector<ustring>& alpns,
-                std::chrono::nanoseconds handshake_timeout,
+                std::chrono::nanoseconds default_handshake_timeout,
                 std::optional<ustring> remote_pk = std::nullopt,
                 ngtcp2_pkt_hd* hdr = nullptr,
                 std::optional<ngtcp2_token_type> token_type = std::nullopt,
@@ -379,7 +381,7 @@ namespace oxen::quic
                 const Path& path,
                 std::shared_ptr<IOContext> ctx,
                 const std::vector<ustring>& alpns,
-                std::chrono::nanoseconds handshake_timeout,
+                std::chrono::nanoseconds default_handshake_timeout,
                 std::optional<ustring> remote_pk = std::nullopt,
                 ngtcp2_pkt_hd* hdr = nullptr,
                 std::optional<ngtcp2_token_type> token_type = std::nullopt,

--- a/include/oxen/quic/context.hpp
+++ b/include/oxen/quic/context.hpp
@@ -19,6 +19,8 @@ namespace oxen::quic
         uint64_t max_streams{0};
         // keep alive timeout
         std::chrono::milliseconds keep_alive{0ms};
+        // handshake timeout; <= 0 means no timeout; nullopt means use endpoint's default.
+        std::optional<std::chrono::nanoseconds> handshake_timeout{std::nullopt};
         // idle timeout
         std::chrono::milliseconds idle_timeout{DEFAULT_IDLE_TIMEOUT};
         // datagram support
@@ -65,6 +67,7 @@ namespace oxen::quic
         void handle_ioctx_opt(opt::max_streams ms);
         void handle_ioctx_opt(opt::keep_alive ka);
         void handle_ioctx_opt(opt::idle_timeout ito);
+        void handle_ioctx_opt(opt::handshake_timeout hto);
         void handle_ioctx_opt(stream_data_callback func);
         void handle_ioctx_opt(stream_open_callback func);
         void handle_ioctx_opt(stream_close_callback func);

--- a/include/oxen/quic/utils.hpp
+++ b/include/oxen/quic/utils.hpp
@@ -113,7 +113,7 @@ namespace oxen::quic
 
     inline constexpr uint64_t DEFAULT_MAX_BIDI_STREAMS = 32;
 
-    inline constexpr std::chrono::seconds DEFAULT_HANDSHAKE_TIMEOUT = 5s;
+    inline constexpr std::chrono::seconds DEFAULT_HANDSHAKE_TIMEOUT = 10s;
     inline constexpr std::chrono::seconds DEFAULT_IDLE_TIMEOUT = 30s;
 
     // NGTCP2 sets the path_pmtud_payload to 1200 on connection creation, then discovers upwards

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -27,6 +27,12 @@ namespace oxen::quic
         log::trace(log_cat, "User passed connection idle_timeout config value: {}", config.idle_timeout.count());
     }
 
+    void IOContext::handle_ioctx_opt(opt::handshake_timeout hto)
+    {
+        config.handshake_timeout = hto.timeout;
+        log::trace(log_cat, "User passed connection handshake_timeout config value: {}", config.handshake_timeout->count());
+    }
+
     void IOContext::handle_ioctx_opt(stream_data_callback func)
     {
         log::trace(log_cat, "IO context stored stream close callback");

--- a/tests/001-handshake.cpp
+++ b/tests/001-handshake.cpp
@@ -471,4 +471,68 @@ namespace oxen::quic::test
         CHECK(client_conn_closed.wait(500ms));
         CHECK(client_errcode == CONN_IDLE_CLOSED);
     }
+
+    TEST_CASE("001 - Handshake timeout", "[001][handshake][timeout]")
+    {
+        auto net1 = std::make_unique<Network>();
+        Network net2{};
+
+        auto [client_tls, server_tls] = defaults::tls_creds_from_ed_keys();
+
+        Address server_local{};
+        Address client_local{};
+
+        uint64_t client_errcode = 424242;
+
+        callback_waiter client_conn_closed{
+                [&client_errcode](connection_interface&, uint64_t errcode) { client_errcode = errcode; }};
+
+#if 0
+        // This code doesn't work: ngtcp2 (at least as of 1.1.0) apparently considers the client to
+        // be post-handshake by the point the server gets this key (presumably because it doesn't
+        // need anything else from the server), so the handshake established timeout just doesn't
+        // fire on the client and, no matter how long we block the server, the only timeout that
+        // will happen is the idle timeout.
+        server_tls->set_key_verify_callback([](const ustring_view&, const ustring_view&) {
+            // This stalls the entire network object; this is a really terrible thing to do outside
+            // of test code, but will let us simulate a slow handshake.
+            log::critical(log_cat, "key verify sleeping...");
+            std::this_thread::sleep_for(30s);
+            log::critical(log_cat, "key verify done sleeping");
+            return true;
+        });
+#endif
+        // So what we do instead is just shutdown the server's network entirely before even trying
+        // to connect to client.  Unfortunately we don't really have a way to reliably kill the
+        // outgoing client connection mid-handshake, so these tests can only really *half* test that
+        // the handshake argument is being dealt with properly (not ideal, but probably fine since
+        // the Connection code is largely the same in terms of where it deals with the handshake
+        // timeout value).
+
+        std::shared_ptr<Endpoint> client_endpoint;
+        std::shared_ptr<connection_interface> client_ci;
+
+        auto server_endpoint = net1->endpoint(server_local);
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+
+        server_endpoint.reset();
+        net1.reset();  // kill the server
+
+        opt::handshake_timeout timeout{100ms};
+
+        SECTION("Client endpoint handshake timeout")
+        {
+            client_endpoint = net2.endpoint(client_local, client_conn_closed, timeout);
+            client_ci = client_endpoint->connect(client_remote, client_tls);
+        }
+        SECTION("Client connect handshake timeout")
+        {
+            client_endpoint = net2.endpoint(client_local, client_conn_closed);
+            client_ci = client_endpoint->connect(client_remote, client_tls, timeout);
+        }
+        CHECK_FALSE(client_conn_closed.wait(25ms));
+
+        CHECK(client_conn_closed.wait(125ms));
+        CHECK(client_errcode == static_cast<uint64_t>(NGTCP2_ERR_HANDSHAKE_TIMEOUT));
+    }
 }  // namespace oxen::quic::test


### PR DESCRIPTION
This adds support for passing `opt::handshake_timeout` into listen/connect so that you can change the timeout for that connection to something different than the endpoint; the endpoint's value now simply becomes the default for connections that don't override it (similarly to how endpoint vs connection connection close callbacks work).

It also maps 0 (or negative) timeouts to ngtcp2's special "no timeout" value of UINT64_MAX.

I also increased the default handshake timeout to 10s (up from 5s) as it seems possible to me that some feasible, if rare, network latency could result in a legitimate 5s handshake time (e.g. think quic over lokinet over a weak mobile internet connection).