### PR TITLE
Fix close hooks on pending streams not firing on connection fail

### DIFF
--- a/include/oxen/quic/connection.hpp
+++ b/include/oxen/quic/connection.hpp
@@ -492,6 +492,7 @@ namespace oxen::quic
         int stream_opened(int64_t id);
         int stream_ack(int64_t id, size_t size);
         int stream_receive(int64_t id, bstring_view data, bool fin);
+        void stream_execute_close(Stream& s, uint64_t app_code);
         void stream_closed(int64_t id, uint64_t app_code);
         void close_all_streams();
         void check_pending_streams(uint64_t available);

--- a/include/oxen/quic/stream.hpp
+++ b/include/oxen/quic/stream.hpp
@@ -78,6 +78,7 @@ namespace oxen::quic
         {
             if (close_callback)
                 close_callback(*this, app_code);
+            _conn = nullptr;
         }
 
         // Called immediately after set_ready so that a subclass can do thing as soon as the stream


### PR DESCRIPTION
We were on closing all the *active* streams on a connection failure, but that means BTRequestStream on *pending* streams would never get called.

This fixes it to execute hooks on *all* streams.