### PR TITLE
Remove fmt and oxen logging from headers

### DIFF
--- a/include/oxen/quic.hpp
+++ b/include/oxen/quic.hpp
@@ -7,8 +7,10 @@
 #include "quic/crypto.hpp"
 #include "quic/datagram.hpp"
 #include "quic/endpoint.hpp"
+// #include "quic/format.hpp"  // Not included by default as it depends on fmt
 #include "quic/error.hpp"
 #include "quic/format.hpp"
+#include "quic/formattable.hpp"
 #include "quic/gnutls_crypto.hpp"
 #include "quic/messages.hpp"
 #include "quic/network.hpp"

--- a/include/oxen/quic/address.hpp
+++ b/include/oxen/quic/address.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "format.hpp"
+#include "formattable.hpp"
 #include "utils.hpp"
 
 namespace oxen::quic

--- a/include/oxen/quic/btstream.hpp
+++ b/include/oxen/quic/btstream.hpp
@@ -6,8 +6,6 @@
 
 namespace oxen::quic
 {
-    inline auto bp_cat = oxen::log::Cat("bparser");
-
     using time_point = std::chrono::steady_clock::time_point;
 
     // timeout is used for sent requests awaiting responses
@@ -218,8 +216,6 @@ namespace oxen::quic
         template <typename... Opt>
         void command(std::string ep, bstring_view body, Opt&&... opts)
         {
-            log::trace(bp_cat, "{} called", __PRETTY_FUNCTION__);
-
             auto rid = next_rid++;
             auto req = std::make_shared<sent_request>(*this, encode_command(ep, rid, body), rid, std::forward<Opt>(opts)...);
 
@@ -260,19 +256,11 @@ namespace oxen::quic
 
       private:
         // Optional constructor argument: stream close callback
-        void handle_bp_opt(std::function<void(Stream&, uint64_t)> close_cb)
-        {
-            log::debug(bp_cat, "Bparser set user-provided close callback!");
-            close_callback = std::move(close_cb);
-        }
+        void handle_bp_opt(std::function<void(Stream&, uint64_t)> close_cb);
 
         // Optional constructor argument: generic request handler.  Providing it in the constructor
         // is equivalent to calling register_command_fallback() with the lambda.
-        void handle_bp_opt(std::function<void(message m)> request_handler)
-        {
-            log::debug(bp_cat, "Bparser set generic request handler");
-            generic_handler = std::move(request_handler);
-        }
+        void handle_bp_opt(std::function<void(message m)> request_handler);
 
         void handle_input(message msg);
 

--- a/include/oxen/quic/connection.hpp
+++ b/include/oxen/quic/connection.hpp
@@ -103,7 +103,8 @@ namespace oxen::quic
             {
                 if (auto st = std::dynamic_pointer_cast<StreamT>(std::move(s)))
                     return st;
-                throw std::invalid_argument{"Stream ID {} is not an instance of the requested Stream subclass"_format(id)};
+                throw std::invalid_argument{
+                        "Stream ID " + std::to_string(id) + " is not an instance of the requested Stream subclass"};
             }
             else
                 return s;
@@ -118,7 +119,7 @@ namespace oxen::quic
         {
             if (auto s = maybe_stream<StreamT>(id))
                 return s;
-            throw std::out_of_range{"Could not find a stream with ID {}"_format(id)};
+            throw std::out_of_range{"Could not find a stream with ID " + std::to_string(id)};
         }
 
         template <

--- a/include/oxen/quic/connection_ids.hpp
+++ b/include/oxen/quic/connection_ids.hpp
@@ -7,6 +7,7 @@ extern "C"
 #include <gnutls/crypto.h>
 }
 
+#include "formattable.hpp"
 #include "types.hpp"
 #include "utils.hpp"
 
@@ -36,7 +37,7 @@ namespace oxen::quic
 
         explicit operator const uint64_t&() const { return id; }
 
-        std::string to_string() const { return "< RID:{} >"_format(id); }
+        std::string to_string() const;
     };
     template <>
     constexpr inline bool IsToStringFormattable<ConnectionID> = true;
@@ -71,10 +72,7 @@ namespace oxen::quic
             return cid;
         }
 
-        std::string to_string() const
-        {
-            return "{:02x}"_format(fmt::join(std::begin(data), std::begin(data) + datalen, ""));
-        }
+        std::string to_string() const;
     };
     template <>
     constexpr inline bool IsToStringFormattable<quic_cid> = true;

--- a/include/oxen/quic/connection_ids.hpp
+++ b/include/oxen/quic/connection_ids.hpp
@@ -64,13 +64,7 @@ namespace oxen::quic
 
         inline bool operator!=(const quic_cid& other) const { return !(*this == other); }
 
-        static quic_cid random()
-        {
-            quic_cid cid;
-            cid.datalen = static_cast<size_t>(NGTCP2_MAX_CIDLEN);
-            gnutls_rnd(GNUTLS_RND_RANDOM, cid.data, cid.datalen);
-            return cid;
-        }
+        static quic_cid random();
 
         std::string to_string() const;
     };

--- a/include/oxen/quic/context.hpp
+++ b/include/oxen/quic/context.hpp
@@ -49,20 +49,16 @@ namespace oxen::quic
         template <typename... Opt>
         IOContext(Direction d, Opt&&... opts) : dir{d}
         {
-            log::trace(log_cat, "Making IO session context");
             // parse all options
             ((void)handle_ioctx_opt(std::forward<Opt>(opts)), ...);
-
-            if (tls_creds == nullptr)
-                throw std::runtime_error{"Session IOContext requires some form of TLS credentials to operate"};
-
-            log::debug(
-                    log_cat, "{} IO context created successfully", (dir == Direction::OUTBOUND) ? "Outbound"s : "Inbound"s);
+            _init();
         }
 
         ~IOContext() = default;
 
       private:
+        void _init();
+
         void handle_ioctx_opt(std::shared_ptr<TLSCreds> tls);
         void handle_ioctx_opt(opt::max_streams ms);
         void handle_ioctx_opt(opt::keep_alive ka);

--- a/include/oxen/quic/datagram.hpp
+++ b/include/oxen/quic/datagram.hpp
@@ -149,17 +149,9 @@ namespace oxen::quic
 
         int datagrams_stored() const { return recv_buffer.datagrams_stored(); };
 
-        int64_t stream_id() const override
-        {
-            log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
-            return std::numeric_limits<int64_t>::min();
-        }
+        int64_t stream_id() const override;
 
-        std::shared_ptr<Stream> get_stream() override
-        {
-            log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
-            return nullptr;
-        }
+        std::shared_ptr<Stream> get_stream() override;
 
       private:
         const bool _packet_splitting{false};
@@ -169,34 +161,13 @@ namespace oxen::quic
 
         void send_impl(bstring_view data, std::shared_ptr<void> keep_alive) override;
 
-        bool is_closing_impl() const override
-        {
-            log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
-            return false;
-        }
-        bool sent_fin() const override
-        {
-            log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
-            return false;
-        }
-        void set_fin(bool) override { log::trace(log_cat, "{} called", __PRETTY_FUNCTION__); };
-        size_t unsent_impl() const override
-        {
-            log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
-            size_t sum{0};
-            if (send_buffer.empty())
-                return sum;
-            for (const auto& entry : send_buffer.buf)
-                sum += entry.size();
-            return sum;
-        }
-        bool has_unsent_impl() const override { return not is_empty_impl(); }
-        void wrote(size_t) override { log::trace(log_cat, "{} called", __PRETTY_FUNCTION__); };
-        std::vector<ngtcp2_vec> pending() override
-        {
-            log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
-            return {};
-        }
+        bool is_closing_impl() const override;
+        bool sent_fin() const override;
+        void set_fin(bool) override;
+        size_t unsent_impl() const override;
+        bool has_unsent_impl() const override;
+        void wrote(size_t) override;
+        std::vector<ngtcp2_vec> pending() override;
     };
 
 }  // namespace oxen::quic

--- a/include/oxen/quic/endpoint.hpp
+++ b/include/oxen/quic/endpoint.hpp
@@ -74,10 +74,8 @@ namespace oxen::quic
 
                 // initialize client context and client tls context simultaneously
                 inbound_ctx = std::make_shared<IOContext>(Direction::INBOUND, std::forward<Opt>(opts)...);
-                _set_context_globals(inbound_ctx);
-                _accepting_inbound = true;
-
-                log::debug(log_cat, "Inbound context ready for incoming connections");
+                // Call the private version for remaining (untemplated) setup:
+                _listen();
             });
         }
 
@@ -226,6 +224,9 @@ namespace oxen::quic
         const std::shared_ptr<event_base>& get_loop() { return net.loop(); }
 
         const std::unique_ptr<UDPSocket>& get_socket() { return socket; }
+
+        // Does the non-templated bit of `listen()`
+        void _listen();
 
         void handle_ep_opt(opt::enable_datagrams dc);
         void handle_ep_opt(opt::outbound_alpns alpns);

--- a/include/oxen/quic/error.hpp
+++ b/include/oxen/quic/error.hpp
@@ -33,7 +33,9 @@ namespace oxen::quic
       public:
         uint64_t code;
 
-        explicit application_stream_error(uint64_t errcode) : code{errcode}, _what{"application error {}"_format(errcode)} {}
+        explicit application_stream_error(uint64_t errcode) :
+                code{errcode}, _what{"application error " + std::to_string(errcode)}
+        {}
         const char* what() const noexcept override { return _what.c_str(); }
 
       private:
@@ -72,7 +74,7 @@ namespace oxen::quic
             case CONN_IDLE_CLOSED:
                 return "Connection closed by idle timeout"s;
             default:
-                return "Application error code {}"_format(e);
+                return "Application error code " + std::to_string(e);
         }
     }
 
@@ -95,12 +97,7 @@ namespace oxen::quic
 
         int ngtcp2_code() const { return static_cast<int>(_code); }
 
-        uint64_t ngtcp2() const
-        {
-            if (not is_ngtcp2)
-                log::warning(log_cat, "Error code {} is not an ngtcp2 error code", _code);
-            return _code;
-        }
+        uint64_t ngtcp2() const;
 
         std::string strerror() const { return is_ngtcp2 ? ngtcp2_strerror(static_cast<int>(_code)) : quic_strerror(_code); }
     };

--- a/include/oxen/quic/format.hpp
+++ b/include/oxen/quic/format.hpp
@@ -1,17 +1,18 @@
 #pragma once
 
-#include <fmt/core.h>
+// Optional header for formattable quic types; this header is not included automatically by any
+// other quic header and must be included explicitly if wanted.  Using this header requires fmt be
+// available (which is true in libquic itself, but may not be when libquic is installed as a
+// library).
+
+#include <fmt/format.h>
 
 #include <iostream>
-#include <oxen/log.hpp>
-#include <oxen/log/format.hpp>
+
+#include "formattable.hpp"
 
 namespace oxen::quic
 {
-    // Types can opt-in to being formatting via .to_string() by specializing this to true
-    template <typename T>
-    constexpr bool IsToStringFormattable = false;
-
     struct buffer_printer
     {
         std::basic_string_view<std::byte> buf;

--- a/include/oxen/quic/formattable.hpp
+++ b/include/oxen/quic/formattable.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace oxen::quic
+{
+
+    // Types can opt-in to being fmt-formattable (by calling the .to_string() method when formatted)
+    // by specializing this to true and the oxen/quic/format.hpp header.
+    template <typename T>
+    constexpr bool IsToStringFormattable = false;
+
+}  // namespace oxen::quic

--- a/include/oxen/quic/gnutls_crypto.hpp
+++ b/include/oxen/quic/gnutls_crypto.hpp
@@ -13,47 +13,17 @@ namespace oxen::quic
 {
     class Connection;
 
-    inline const std::string translate_key_format(gnutls_x509_crt_fmt_t crt)
-    {
-        if (crt == GNUTLS_X509_FMT_DER)
-            return "<< DER >>";
-        if (crt == GNUTLS_X509_FMT_PEM)
-            return "<< PEM >>";
+    const std::string translate_key_format(gnutls_x509_crt_fmt_t crt);
 
-        return "<< UNKNOWN >>";
-    }
+    const std::string translate_cert_type(gnutls_certificate_type_t type);
 
-    inline const std::string translate_cert_type(gnutls_certificate_type_t type)
-    {
-        auto t = static_cast<int>(type);
-
-        switch (t)
-        {
-            case 1:
-                return "<< X509 Cert >>";
-            case 2:
-                return "<< OpenPGP Cert >>";
-            case 3:
-                return "<< Raw PK Cert >>";
-            case 0:
-            default:
-                return "<< Unknown Type >>";
-        }
-    }
-
-    inline const std::string get_cert_type(gnutls_session_t session, gnutls_ctype_target_t type)
-    {
-        return translate_cert_type(gnutls_certificate_type_get2(session, type));
-    }
+    const std::string get_cert_type(gnutls_session_t session, gnutls_ctype_target_t type);
 
     extern "C"
     {
         int cert_verify_callback_gnutls(gnutls_session_t g_session);
 
-        inline void gnutls_log(int level, const char* str)
-        {
-            log::debug(log_cat, "GNUTLS Log (level {}): {}", level, str);
-        }
+        void gnutls_log(int level, const char* str);
 
         struct gnutls_log_setter
         {

--- a/include/oxen/quic/iochannel.hpp
+++ b/include/oxen/quic/iochannel.hpp
@@ -16,7 +16,7 @@ namespace oxen::quic
         IOChannel(Connection& c, Endpoint& e);
 
       public:
-        virtual ~IOChannel() { log::trace(log_cat, "{} called", __PRETTY_FUNCTION__); };
+        virtual ~IOChannel() = default;
 
         Endpoint& endpoint;
         const ConnectionID reference_id;

--- a/include/oxen/quic/opt.hpp
+++ b/include/oxen/quic/opt.hpp
@@ -118,7 +118,8 @@ namespace oxen::quic::opt
         explicit static_secret(ustring s) : secret{std::move(s)}
         {
             if (secret.size() < SECRET_MIN_SIZE)
-                throw std::invalid_argument{"opt::static_secret requires data of at least {} bytes"_format(SECRET_MIN_SIZE)};
+                throw std::invalid_argument{
+                        "opt::static_secret requires data of at least " + std::to_string(SECRET_MIN_SIZE) + "bytes"};
         }
     };
 

--- a/include/oxen/quic/utils.hpp
+++ b/include/oxen/quic/utils.hpp
@@ -200,11 +200,7 @@ namespace oxen::quic
 
     struct event_deleter final
     {
-        void operator()(::event* e) const
-        {
-            if (e)
-                ::event_free(e);
-        }
+        void operator()(::event* e) const;
     };
     using event_ptr = std::unique_ptr<::event, event_deleter>;
 

--- a/include/oxen/quic/utils.hpp
+++ b/include/oxen/quic/utils.hpp
@@ -2,8 +2,6 @@
 
 #include <type_traits>
 
-#include "format.hpp"
-
 extern "C"
 {
 #ifdef _WIN32
@@ -41,8 +39,6 @@ extern "C"
 
 namespace oxen::quic
 {
-    inline auto log_cat = oxen::log::Cat("quic");
-
     class connection_interface;
 
     // called when a connection's handshake completes
@@ -54,13 +50,11 @@ namespace oxen::quic
     using connection_closed_callback = std::function<void(connection_interface& conn, uint64_t ec)>;
 
     using namespace std::literals;
-    using namespace oxen::log::literals;
     using bstring = std::basic_string<std::byte>;
     using ustring = std::basic_string<unsigned char>;
     using bstring_view = std::basic_string_view<std::byte>;
     using ustring_view = std::basic_string_view<unsigned char>;
     using stream_buffer = std::deque<std::pair<bstring_view, std::shared_ptr<void>>>;
-    namespace log = oxen::log;
 
     constexpr bool IN_HELL =
 #ifdef _WIN32
@@ -186,8 +180,6 @@ namespace oxen::quic
     {
         return suffix.size() <= str.size() && str.substr(str.size() - suffix.size()) == suffix;
     }
-
-    void logger_config(std::string out = "stderr", log::Type type = log::Type::Print, log::Level reset = log::Level::trace);
 
     std::chrono::steady_clock::time_point get_time();
     std::chrono::nanoseconds get_timestamp();

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,9 +6,11 @@ add_library(quic
     address.cpp
     btstream.cpp
     connection.cpp
+    connection_ids.cpp
     context.cpp
     datagram.cpp
     endpoint.cpp
+    error.cpp
     format.cpp
     gnutls_creds.cpp
     gnutls_session.cpp

--- a/src/address.cpp
+++ b/src/address.cpp
@@ -2,6 +2,8 @@
 
 #include <oxenc/endian.h>
 
+#include "internal.hpp"
+
 namespace oxen::quic
 {
     Address::Address(const std::string& addr, uint16_t port)

--- a/src/btstream.cpp
+++ b/src/btstream.cpp
@@ -2,8 +2,12 @@
 
 #include <stdexcept>
 
+#include "internal.hpp"
+
 namespace oxen::quic
 {
+
+    inline auto bp_cat = oxen::log::Cat("bparser");
 
     static std::pair<std::ptrdiff_t, std::size_t> get_location(bstring& data, std::string_view substr)
     {
@@ -42,6 +46,16 @@ namespace oxen::quic
             log::warning(bp_cat, "BTRequestStream unable to send response: stream has gone away");
     }
 
+    void BTRequestStream::handle_bp_opt(std::function<void(Stream&, uint64_t)> close_cb)
+    {
+        log::debug(bp_cat, "Bparser set user-provided close callback!");
+        close_callback = std::move(close_cb);
+    }
+    void BTRequestStream::handle_bp_opt(std::function<void(message m)> request_handler)
+    {
+        log::debug(bp_cat, "Bparser set generic request handler");
+        generic_handler = std::move(request_handler);
+    }
     void BTRequestStream::respond(int64_t rid, bstring_view body, bool error)
     {
         log::trace(bp_cat, "{} called", __PRETTY_FUNCTION__);

--- a/src/connection_ids.cpp
+++ b/src/connection_ids.cpp
@@ -18,4 +18,12 @@ namespace oxen::quic
         return oxenc::to_hex(data, data + datalen);
     }
 
+    quic_cid quic_cid::random()
+    {
+        quic_cid cid;
+        cid.datalen = static_cast<size_t>(NGTCP2_MAX_CIDLEN);
+        gnutls_rnd(GNUTLS_RND_RANDOM, cid.data, cid.datalen);
+        return cid;
+    }
+
 }  // namespace oxen::quic

--- a/src/connection_ids.cpp
+++ b/src/connection_ids.cpp
@@ -1,0 +1,21 @@
+#include "connection_ids.hpp"
+
+#include <oxenc/hex.h>
+
+#include "format.hpp"
+#include "internal.hpp"
+
+namespace oxen::quic
+{
+
+    std::string ConnectionID::to_string() const
+    {
+        return "< RID:{} >"_format(id);
+    }
+
+    std::string quic_cid::to_string() const
+    {
+        return oxenc::to_hex(data, data + datalen);
+    }
+
+}  // namespace oxen::quic

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -1,9 +1,18 @@
 #include "context.hpp"
 
 #include "connection.hpp"
+#include "internal.hpp"
 
 namespace oxen::quic
 {
+    void IOContext::_init()
+    {
+        if (tls_creds == nullptr)
+            throw std::runtime_error{"Session IOContext requires some form of TLS credentials to operate"};
+
+        log::debug(log_cat, "{} IO context created successfully", (dir == Direction::OUTBOUND) ? "Outbound"s : "Inbound"s);
+    }
+
     void IOContext::handle_ioctx_opt(std::shared_ptr<TLSCreds> tls)
     {
         tls_creds = std::move(tls);

--- a/src/datagram.cpp
+++ b/src/datagram.cpp
@@ -2,6 +2,7 @@
 
 #include "connection.hpp"
 #include "endpoint.hpp"
+#include "internal.hpp"
 
 namespace oxen::quic
 {
@@ -14,6 +15,56 @@ namespace oxen::quic
             _packet_splitting(_conn->packet_splitting_enabled())
     {
         log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
+    }
+
+    int64_t DatagramIO::stream_id() const
+    {
+        log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
+        return std::numeric_limits<int64_t>::min();
+    }
+
+    std::shared_ptr<Stream> DatagramIO::get_stream()
+    {
+        log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
+        return nullptr;
+    }
+
+    bool DatagramIO::is_closing_impl() const
+    {
+        log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
+        return false;
+    }
+    bool DatagramIO::sent_fin() const
+    {
+        log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
+        return false;
+    }
+    void DatagramIO::set_fin(bool)
+    {
+        log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
+    };
+    size_t DatagramIO::unsent_impl() const
+    {
+        log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
+        size_t sum{0};
+        if (send_buffer.empty())
+            return sum;
+        for (const auto& entry : send_buffer.buf)
+            sum += entry.size();
+        return sum;
+    }
+    bool DatagramIO::has_unsent_impl() const
+    {
+        return not is_empty_impl();
+    }
+    void DatagramIO::wrote(size_t)
+    {
+        log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
+    };
+    std::vector<ngtcp2_vec> DatagramIO::pending()
+    {
+        log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
+        return {};
     }
 
     dgram_interface::dgram_interface(Connection& c) : ci{c}, reference_id{ci.reference_id()} {}

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -109,6 +109,14 @@ namespace oxen::quic
         event_add(expiry_timer.get(), &exp_interval);
     }
 
+    void Endpoint::_listen()
+    {
+        _set_context_globals(inbound_ctx);
+        _accepting_inbound = true;
+
+        log::debug(log_cat, "Inbound context ready for incoming connections");
+    }
+
     void Endpoint::_set_context_globals(std::shared_ptr<IOContext>& ctx)
     {
         ctx->config.datagram_support = _datagrams;

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -1,0 +1,15 @@
+#include "error.hpp"
+
+#include "internal.hpp"
+
+namespace oxen::quic
+{
+
+    uint64_t io_error::ngtcp2() const
+    {
+        if (not is_ngtcp2)
+            log::warning(log_cat, "Error code {} is not an ngtcp2 error code", _code);
+        return _code;
+    }
+
+}  // namespace oxen::quic

--- a/src/gnutls_session.cpp
+++ b/src/gnutls_session.cpp
@@ -1,6 +1,7 @@
 #include "connection.hpp"
 #include "endpoint.hpp"
 #include "gnutls_crypto.hpp"
+#include "internal.hpp"
 
 namespace oxen::quic
 {

--- a/src/internal.hpp
+++ b/src/internal.hpp
@@ -1,11 +1,22 @@
 #pragma once
 
 #include <cstddef>
+#include <oxen/log.hpp>
+#include <oxen/log/format.hpp>
 
+#include "format.hpp"
 #include "utils.hpp"
 
 namespace oxen::quic
 {
+
+    inline auto log_cat = oxen::log::Cat("quic");
+
+    namespace log = oxen::log;
+
+    using namespace log::literals;
+
+    void logger_config(std::string out = "stderr", log::Type type = log::Type::Print, log::Level reset = log::Level::trace);
 
     inline constexpr size_t MAX_BATCH =
 #if defined(OXEN_LIBQUIC_UDP_SENDMMSG) || defined(OXEN_LIBQUIC_UDP_GSO)

--- a/src/iochannel.cpp
+++ b/src/iochannel.cpp
@@ -1,6 +1,7 @@
 #include "iochannel.hpp"
 
 #include "endpoint.hpp"
+#include "internal.hpp"
 
 namespace oxen::quic
 {

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -3,6 +3,7 @@
 #include "connection.hpp"
 #include "datagram.hpp"
 #include "endpoint.hpp"
+#include "internal.hpp"
 
 namespace oxen::quic
 {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -37,4 +37,11 @@ namespace oxen::quic
         std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) { return std::tolower(c); });
         return s;
     }
+
+    void event_deleter::operator()(::event* e) const
+    {
+        if (e)
+            ::event_free(e);
+    }
+
 }  // namespace oxen::quic

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -8,6 +8,7 @@
 #include <string>
 
 #include "connection.hpp"
+#include "internal.hpp"
 
 namespace oxen::quic
 {

--- a/tests/004-streams.cpp
+++ b/tests/004-streams.cpp
@@ -407,13 +407,13 @@ namespace oxen::quic::test
         SECTION("Stream logic using queue_incoming_stream in connection open callback")
         {
             auto server_open_all_cb = callback_waiter{[&](connection_interface& ci) {
-                log::info(bp_cat, "Server queuing Custom Stream A!");
+                log::info(test_cat, "Server queuing Custom Stream A!");
                 server_a = ci.queue_incoming_stream<CustomStreamA>(std::move(sp1));
-                log::info(bp_cat, "Server queuing Custom Stream B!");
+                log::info(test_cat, "Server queuing Custom Stream B!");
                 server_b = ci.queue_incoming_stream<CustomStreamB>(std::move(sp2));
-                log::info(bp_cat, "Server queuing Custom Stream C!");
+                log::info(test_cat, "Server queuing Custom Stream C!");
                 server_c = ci.queue_incoming_stream<CustomStreamC>(std::move(sp3));
-                log::info(bp_cat, "Server queuing default stream D");
+                log::info(test_cat, "Server queuing default stream D");
                 server_d = ci.queue_incoming_stream();
             }};
 
@@ -443,13 +443,13 @@ namespace oxen::quic::test
                     switch (*id)
                     {
                         case 0:
-                            log::info(bp_cat, "Server opening Custom Stream A!");
+                            log::info(test_cat, "Server opening Custom Stream A!");
                             return e.make_shared<CustomStreamA>(c, e, std::move(sp1));
                         case 4:
-                            log::info(bp_cat, "Server opening Custom Stream B!");
+                            log::info(test_cat, "Server opening Custom Stream B!");
                             return e.make_shared<CustomStreamB>(c, e, std::move(sp2));
                         case 8:
-                            log::info(bp_cat, "Server opening Custom Stream C!");
+                            log::info(test_cat, "Server opening Custom Stream C!");
                             return e.make_shared<CustomStreamC>(c, e, std::move(sp3));
                     }
                 }
@@ -479,26 +479,26 @@ namespace oxen::quic::test
                     [&](Connection& c, Endpoint& e, std::optional<int64_t> id) -> std::shared_ptr<Stream> {
                 server_stream_ctor_count++;
 
-                log::trace(bp_cat, "Server stream constructor given ID:{}", id.value_or(11111));
+                log::trace(test_cat, "Server stream constructor given ID:{}", id.value_or(11111));
 
                 if (id)
                 {
                     switch (*id)
                     {
                         case 4:
-                            log::info(bp_cat, "Server opening Custom Stream B!");
+                            log::info(test_cat, "Server opening Custom Stream B!");
                             return e.make_shared<CustomStreamB>(c, e, std::move(sp2));
                         case 8:
-                            log::info(bp_cat, "Server opening Custom Stream C!");
+                            log::info(test_cat, "Server opening Custom Stream C!");
                             return e.make_shared<CustomStreamC>(c, e, std::move(sp3));
                     }
                 }
-                log::info(bp_cat, "Server returning nullptr!");
+                log::info(test_cat, "Server returning nullptr!");
                 return nullptr;
             };
 
             auto server_open_cb = callback_waiter{[&](connection_interface& ci) {
-                log::info(bp_cat, "Server queuing Custom Stream A!");
+                log::info(test_cat, "Server queuing Custom Stream A!");
                 server_a = ci.queue_incoming_stream<CustomStreamA>(std::move(sp1));
             }};
 
@@ -514,19 +514,19 @@ namespace oxen::quic::test
             REQUIRE(server_open_cb.wait());
         }
 
-        log::info(bp_cat, "Client opening Custom Stream A!");
+        log::info(test_cat, "Client opening Custom Stream A!");
         client_a = client_ci->open_stream<CustomStreamA>(std::move(cp1));
         REQUIRE_NOTHROW(client_a->send("Stream A!"_bs));
         require_future(sf1);
         CHECK(sf1.get() == "Stream A!");
 
-        log::info(bp_cat, "Client opening Custom Stream B!");
+        log::info(test_cat, "Client opening Custom Stream B!");
         client_b = client_ci->open_stream<CustomStreamB>(std::move(cp2));
         REQUIRE_NOTHROW(client_b->send("Stream B!"_bs));
         require_future(sf2);
         CHECK(sf2.get() == "Stream B!");
 
-        log::info(bp_cat, "Client opening Custom Stream C!");
+        log::info(test_cat, "Client opening Custom Stream C!");
         client_c = client_ci->open_stream<CustomStreamC>(std::move(cp3));
         REQUIRE_NOTHROW(client_c->send("Stream C!"_bs));
         require_future(sf3);
@@ -640,10 +640,10 @@ namespace oxen::quic::test
             switch (count)
             {
                 case 1:
-                    log::info(bp_cat, "Server opening Custom Stream A!");
+                    log::info(test_cat, "Server opening Custom Stream A!");
                     return e.make_shared<CustomStreamA>(c, e, std::move(cp1));
                 case 2:
-                    log::info(bp_cat, "Server opening Custom Stream C!");
+                    log::info(test_cat, "Server opening Custom Stream C!");
                     return e.make_shared<CustomStreamC>(c, e, std::move(cp3));
             }
             return nullptr;
@@ -729,14 +729,14 @@ namespace oxen::quic::test
             {
                 if (*id == 0)
                 {
-                    log::trace(bp_cat, "Server constructing BTRequestStream!");
+                    log::trace(test_cat, "Server constructing BTRequestStream!");
                     server_extracted = e.make_shared<BTRequestStream>(c, e);
                     server_extracted->register_handler("test_endpoint"s, server_handler);
                     return server_extracted;
                 }
                 else
                 {
-                    log::trace(bp_cat, "Server constructing default bullshit!");
+                    log::trace(test_cat, "Server constructing default bullshit!");
                     return e.make_shared<Stream>(c, e);
                 }
             }

--- a/tests/utils.hpp
+++ b/tests/utils.hpp
@@ -1,24 +1,32 @@
 #pragma once
 
+#include <oxenc/base64.h>
+
 #include <CLI/CLI.hpp>
 #include <CLI/Error.hpp>
 #include <charconv>
 #include <future>
 #include <optional>
 #include <oxen/log.hpp>
+#include <oxen/log/format.hpp>
 #include <oxen/quic/endpoint.hpp>
+#include <oxen/quic/format.hpp>
 #include <oxen/quic/gnutls_crypto.hpp>
 #include <oxen/quic/network.hpp>
 #include <oxen/quic/utils.hpp>
 #include <string>
 
-#include "oxenc/base64.h"
-
 namespace oxen::quic
 {
     extern bool disable_ipv6, disable_rotating_buffer;
 
-    inline auto test_cat = oxen::log::Cat("test");
+    namespace log = oxen::log;
+    using namespace log::literals;
+    inline auto test_cat = log::Cat("test");
+
+    // Borrowing these from src/internal.hpp:
+    void logger_config(std::string out = "stderr", log::Type type = log::Type::Print, log::Level reset = log::Level::trace);
+    inline auto log_cat = log::Cat("quic");
 
     using namespace oxenc::literals;
 


### PR DESCRIPTION
Having them in headers breaks packaging because it means we would have to build packages for both oxen-logging, spdlog, and fmt, which is a nuissance.

This PR changes the code so that we only use fmt/spdlog/oxen-logging internal (in src/ and test/) but *don't* use or require it from any headers.

There is a tiny bit of fmt-dependent code left in quic/format.hpp, but this is now not included by default and is an optional include an application with fmt available can include to be able to format quic types.

For the most part this just moves logs into the cpp and changes a few formatted strings to work via stl functions, but a few trace logs got dropped because they seemed unimportant enough to move into the cpp file.