### PR TITLE
Downgrade warning firing on connection timeouts

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -1662,7 +1662,7 @@ namespace oxen::quic
                     auto& self = *static_cast<Connection*>(self_);
                     if (auto rv = ngtcp2_conn_handle_expiry(self, get_timestamp().count()); rv != 0)
                     {
-                        log::warning(
+                        log::debug(
                                 log_cat, "Error: expiry handler invocation returned error code: {}", ngtcp2_strerror(rv));
                         self.endpoint().close_connection(self, io_error{rv});
                         return;

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -1662,8 +1662,7 @@ namespace oxen::quic
                     auto& self = *static_cast<Connection*>(self_);
                     if (auto rv = ngtcp2_conn_handle_expiry(self, get_timestamp().count()); rv != 0)
                     {
-                        log::debug(
-                                log_cat, "Error: expiry handler invocation returned error code: {}", ngtcp2_strerror(rv));
+                        log::debug(log_cat, "Error: expiry handler invocation returned error code: {}", ngtcp2_strerror(rv));
                         self.endpoint().close_connection(self, io_error{rv});
                         return;
                     }


### PR DESCRIPTION
There are way too many of these in storage serever logs in practice just from connection testing to endpoints that aren't currently reachable, and this isn't (necessarily) indicative of a local problem.  This downgrades it to debug; if the application is doing something here that should be warned about then it can warn about it in a close handler.