### PR TITLE
Fix potential crash in close_connection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ if(CCACHE_PROGRAM)
 endif()
 
 project(libquic
-    VERSION 1.0.0
+    VERSION 1.0.1
     DESCRIPTION "Modular QUIC library for stream and connection management"
     LANGUAGES ${LANGS})
 

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -245,8 +245,9 @@ namespace oxen::quic
     {
         if (!msg)
             msg = ec.strerror();
-        call_soon([this, &conn, ec = std::move(ec), msg = std::move(*msg)]() mutable {
-            _close_connection(conn, std::move(ec), std::move(msg));
+        call_soon([this, connid = conn.reference_id(), ec = std::move(ec), msg = std::move(*msg)]() mutable {
+            if (auto it = conns.find(connid); it != conns.end() && it->second)
+                _close_connection(*it->second, std::move(ec), std::move(msg));
         });
     }
 


### PR DESCRIPTION
If the connection has been destroyed between the time close_connection is called and the `call_soon`ed `_close_connection` happens then the conn will be a dangling reference.

This fixes it by using a reference id, doing a lookup in the call_soon and doing nothing if the lookup doesn't find a connection.