### PR TITLE
Incorrect pubkey length crash

### DIFF
--- a/include/oxen/quic/types.hpp
+++ b/include/oxen/quic/types.hpp
@@ -76,7 +76,7 @@ namespace oxen::quic
                         nullptr);
                 if (buf[0])
                     return buf.data();
-                return "Unknown error {}"_format(error_code);
+                return "Unknown error "s.append(std::to_string(error_code));
             }
 #endif
             if (is_ngtcp2)

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -154,8 +154,9 @@ namespace oxen::quic
         // We have to do this in two passes rather than just closing as we go because
         // `_close_connection` can remove from `conns`, invalidating our implicit iterator.
         std::vector<Connection*> close_me;
+
         for (const auto& c : conns)
-            if (!d || *d == c.second->direction())
+            if (c.second && (!d || *d == c.second->direction()))
                 close_me.push_back(c.second.get());
         for (auto* c : close_me)
             _close_connection(*c, io_error{0}, "NO_ERROR");

--- a/src/gnutls_creds.cpp
+++ b/src/gnutls_creds.cpp
@@ -4,7 +4,6 @@
 
 namespace oxen::quic
 {
-
     const std::string translate_key_format(gnutls_x509_crt_fmt_t crt)
     {
         if (crt == GNUTLS_X509_FMT_DER)

--- a/tests/001-handshake.cpp
+++ b/tests/001-handshake.cpp
@@ -159,6 +159,17 @@ namespace oxen::quic::test
                 CHECK(client_error == 1000);
             };
 
+            SECTION("Incorrect pubkey length")
+            {
+                auto client_endpoint = test_net.endpoint(client_local);
+
+                auto short_key = defaults::SERVER_PUBKEY.substr(0, 31);
+
+                RemoteAddress bad_client_remote{short_key, "127.0.0.1"s, server_endpoint->local().port()};
+
+                REQUIRE_THROWS(client_endpoint->connect(bad_client_remote, client_tls));
+            }
+
             SECTION("No pubkey in remote")
             {
                 // If uncommented, this line will not compile! Remote addresses must pass a remote pubkey to be


### PR DESCRIPTION
- When initiating an outbound connection, passing an ed25519 pubkey of incorrect length will result in an exception being thrown and the endpoint shutting down/closing all connections, as designed
- As not designed, the endpoint will see the ConnectionID mapped to a nullptr (as the connection object failed to be created) and will segfault on bad memory access
- 001 test case added for incorrect keylenths
- Thanks @mpretty-cyro for the catch!