### PR TITLE
CI (dropping deb10/ub18) cleanups

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -77,7 +77,6 @@ local generic_build(jobs, build_type, lto, werror, cmake_extra, local_mirror, te
         ]
         + (if tests then [
              'cd build',
-             '../utils/gen-certs.sh',
              (if gdb then '../utils/ci/drone-gdb.sh ' else '') + './tests/alltests --success --log-level debug --no-ipv6 --colour-mode ansi',
              'cd ..',
            ] else []);
@@ -283,6 +282,7 @@ local mac_builder(name,
       ],
     }],
   },
+
   // Various debian builds
   debian_pipeline('Debian sid (amd64)', docker_base + 'debian-sid'),
   debian_pipeline('Debian sid/Debug (amd64)', docker_base + 'debian-sid', build_type='Debug'),
@@ -297,17 +297,11 @@ local mac_builder(name,
   debian_pipeline('Debian testing (i386)', docker_base + 'debian-testing/i386'),
   debian_pipeline('Debian 12 static', docker_base + 'debian-bookworm', cmake_extra='-DBUILD_STATIC_DEPS=ON', deps=['g++']),
   debian_pipeline('Debian 12 bookworm (i386)', docker_base + 'debian-bookworm/i386'),
-  debian_pipeline('Debian 11 bullseye (amd64)', docker_base + 'debian-bullseye', deps=default_deps_old, extra_setup=local_gnutls() + debian_backports('bullseye', ['cmake'])),
-  debian_pipeline('Debian 10 buster (amd64)', docker_base + 'debian-buster', deps=default_deps_old, extra_setup=kitware_repo('bionic') + local_gnutls()),
-  debian_pipeline('Debian 10 static Debug', docker_base + 'debian-buster', build_type='Debug', cmake_extra='-DBUILD_STATIC_DEPS=ON', deps=['g++'], extra_setup=kitware_repo('bionic')),
+  debian_pipeline('Debian 11 bullseye (amd64)', docker_base + 'debian-bullseye', deps=['g++'], extra_setup=local_gnutls() + debian_backports('bullseye', ['cmake'])),
+  debian_pipeline('Debian 11 static Debug', docker_base + 'debian-bullseye', build_type='Debug', cmake_extra='-DBUILD_STATIC_DEPS=ON', deps=default_deps_old, extra_setup=debian_backports('bullseye', ['cmake'])),
   debian_pipeline('Ubuntu latest (amd64)', docker_base + 'ubuntu-rolling'),
   debian_pipeline('Ubuntu 22.04 jammy (amd64)', docker_base + 'ubuntu-jammy'),
-  debian_pipeline('Ubuntu 20.04 focal (amd64)', docker_base + 'ubuntu-focal', deps=default_deps_old, extra_setup=kitware_repo('focal') + local_gnutls()),
-  debian_pipeline('Ubuntu 18.04 bionic (amd64)',
-                  docker_base + 'ubuntu-bionic',
-                  deps=['g++-8'] + default_deps_old_base,
-                  extra_setup=kitware_repo('bionic') + local_gnutls(),
-                  cmake_extra='-DCMAKE_C_COMPILER=gcc-8 -DCMAKE_CXX_COMPILER=g++-8'),
+  debian_pipeline('Ubuntu 20.04 focal (amd64)', docker_base + 'ubuntu-focal', deps=['g++-10'] + default_deps_old, extra_setup=kitware_repo('focal') + local_gnutls(), cmake_extra='-DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10'),
 
   // ARM builds (ARM64 and armhf)
   debian_pipeline('Debian sid (ARM64)', docker_base + 'debian-sid', arch='arm64', jobs=4),

--- a/include/oxen/quic/formattable.hpp
+++ b/include/oxen/quic/formattable.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string_view>
+
 namespace oxen::quic
 {
     // Types can opt-in to being fmt-formattable by ensuring they have a ::to_string() method defined
@@ -10,6 +12,8 @@ namespace oxen::quic
 #endif
                     ToStringFormattable = requires(T a)
     {
-        a.to_string();
+        {
+            a.to_string()
+            } -> std::convertible_to<std::string_view>;
     };
 }  // namespace oxen::quic

--- a/include/oxen/quic/gnutls_crypto.hpp
+++ b/include/oxen/quic/gnutls_crypto.hpp
@@ -260,8 +260,6 @@ namespace oxen::quic
         friend class GNUTLSSession;
 
       private:
-        GNUTLSCreds(std::string local_key, std::string local_cert, std::string remote_cert, std::string ca_arg);
-
         // Construct from raw Ed25519 keys
         GNUTLSCreds(std::string ed_seed, std::string ed_pubkey);
 
@@ -282,9 +280,6 @@ namespace oxen::quic
         void load_keys(x509_loader& seed, x509_loader& pk);
 
         void set_key_verify_callback(key_verify_callback cb) { key_verify = std::move(cb); }
-
-        static std::shared_ptr<GNUTLSCreds> make(
-                std::string remote_key, std::string remote_cert, std::string local_cert = "", std::string ca_arg = "");
 
         static std::shared_ptr<GNUTLSCreds> make_from_ed_keys(std::string seed, std::string pubkey);
 

--- a/readme.md
+++ b/readme.md
@@ -50,8 +50,5 @@ Unit tests use [Catch2](https://github.com/catchorg/Catch2) as a formal unit-tes
 tests are built by default as part of the standard CMake build logic (unless being built as a
 subdirectory of another CMake project) and can be invoked through the `build/tests/alltests` binary.
 
-Tests require tls certificates to run; suitable certificates can be created by running the
-`../utils/gen-certs.sh` script from the `build` directory.
-
 Building the tests also build `./tests/speedtest-client` and `./tests/speedtest-server` which can be
 used to test network performance of libquic streams.


### PR DESCRIPTION
- string-formattable concept now requires convertible_to string_view
- dropped debian-10 and ubuntu-18 like its hot
- removed deprecated gnutls_creds constructor and utilization of cert gen script