### PR TITLE
Windows fixes (and various other bits)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -45,7 +45,7 @@ SpacesInAngles: 'false'
 SpacesInContainerLiterals: 'false'
 SpacesInParentheses: 'false'
 SpacesInSquareBrackets: 'false'
-Standard: c++17
+Standard: c++20
 UseTab: Never
 SortIncludes: true
 ColumnLimit: 125
@@ -53,6 +53,9 @@ IndentWidth: 4
 AccessModifierOffset: -2
 ConstructorInitializerIndentWidth: 8
 ContinuationIndentWidth: 8
+QualifierAlignment: Left
+
+RemoveSemicolon: true
 
 # treat pointers and reference declarations as if part of the type
 DerivePointerAlignment: false

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -171,8 +171,18 @@ local windows_cross_pipeline(name,
         '-DLIBQUIC_BUILD_TESTS=' + (if tests then 'ON ' else 'OFF ') +
         ci_dep_mirror(local_mirror),
         'make -j' + jobs + ' VERBOSE=1',
-        //'wine-stable tests/alltests.exe --log-level debug --colour-mode ansi', // doesn't work yet :(
       ] + extra_cmds,
+    },
+    {
+      name: 'tests (via wine)',
+      image: image,
+      pull: 'always',
+      [if allow_fail then 'failure']: 'ignore',
+      environment: { WINEDEBUG: '-all' },
+      commands: [
+        'cd build/tests',
+        'wine-stable alltests.exe --success -T --log-level debug --colour-mode ansi --no-ipv6',
+      ],
     },
   ],
 };
@@ -310,7 +320,7 @@ local mac_builder(name,
   debian_pipeline('Debian stable (armhf)', docker_base + 'debian-stable/arm32v7', arch='arm64', jobs=4),
 
   // Windows builds (x64)
-  windows_cross_pipeline('Windows (amd64)', docker_base + 'debian-win32-cross'),
+  windows_cross_pipeline('Windows (x64)', docker_base + 'debian-win32-cross'),
 
   // Macos builds:
   mac_builder('macOS (Release, ARM)', arch='arm64'),

--- a/include/oxen/quic/datagram.hpp
+++ b/include/oxen/quic/datagram.hpp
@@ -148,7 +148,7 @@ namespace oxen::quic
 
         std::optional<bstring> to_buffer(bstring_view data, uint16_t dgid);
 
-        int datagrams_stored() const { return recv_buffer.datagrams_stored(); };
+        int datagrams_stored() const { return recv_buffer.datagrams_stored(); }
 
         int64_t stream_id() const override;
 

--- a/include/oxen/quic/formattable.hpp
+++ b/include/oxen/quic/formattable.hpp
@@ -2,18 +2,22 @@
 
 #include <string_view>
 
+// GCC before 10 requires a "bool" keyword in concept; this CONCEPT_COMPAT is empty by default, but
+// expands to bool if under such a GCC.
+#if (!(defined(__clang__)) && defined(__GNUC__) && __GNUC__ < 10)
+#define CONCEPT_COMPAT bool
+#else
+#define CONCEPT_COMPAT
+#endif
+
 namespace oxen::quic
 {
     // Types can opt-in to being fmt-formattable by ensuring they have a ::to_string() method defined
     template <typename T>
-    concept
-#if (!(defined(__clang__)) && defined(__GNUC__) && __GNUC__ < 10)
-            bool
-#endif
-                    ToStringFormattable = requires(T a)
-    {
+    concept CONCEPT_COMPAT ToStringFormattable = requires(T a) {
         {
             a.to_string()
-            } -> std::convertible_to<std::string_view>;
+        } -> std::convertible_to<std::string_view>;
     };
+
 }  // namespace oxen::quic

--- a/include/oxen/quic/gnutls_crypto.hpp
+++ b/include/oxen/quic/gnutls_crypto.hpp
@@ -313,7 +313,7 @@ namespace oxen::quic
 
         ~GNUTLSSession();
 
-        void* get_session() override { return session; };
+        void* get_session() override { return session; }
 
         void* get_anti_replay() const override { return anti_replay; }
 

--- a/include/oxen/quic/ip.hpp
+++ b/include/oxen/quic/ip.hpp
@@ -21,9 +21,12 @@ namespace oxen::quic
 
         const std::string to_string() const;
 
-        explicit operator const in_addr&() const { return reinterpret_cast<const in_addr&>(addr); }
-
-        explicit operator const uint32_t&() const { return reinterpret_cast<const uint32_t&>(addr); }
+        explicit operator in_addr() const
+        {
+            in_addr a;
+            a.s_addr = addr;
+            return a;
+        }
 
         constexpr bool operator==(const ipv4& a) const { return addr == a.addr; }
 

--- a/include/oxen/quic/utils.hpp
+++ b/include/oxen/quic/utils.hpp
@@ -57,11 +57,12 @@ namespace oxen::quic
     using ustring_view = std::basic_string_view<unsigned char>;
     using stream_buffer = std::deque<std::pair<bstring_view, std::shared_ptr<void>>>;
 
-    inline constexpr bool IN_HELL =
 #ifdef _WIN32
-            true;
+    inline constexpr bool IN_HELL = true;
+    extern const bool EMULATING_HELL;  // True if compiled for windows but running under WINE
 #else
-            false;
+    inline constexpr bool IN_HELL = false;
+    inline constexpr bool EMULATING_HELL = false;
 #endif
 
     struct ngtcp2_error_code_t final

--- a/src/datagram.cpp
+++ b/src/datagram.cpp
@@ -42,7 +42,7 @@ namespace oxen::quic
     void DatagramIO::set_fin(bool)
     {
         log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
-    };
+    }
     size_t DatagramIO::unsent_impl() const
     {
         log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
@@ -60,7 +60,7 @@ namespace oxen::quic
     void DatagramIO::wrote(size_t)
     {
         log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
-    };
+    }
     std::vector<ngtcp2_vec> DatagramIO::pending()
     {
         log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -40,6 +40,14 @@ namespace oxen::quic
         running.store(true);
     }
 
+    static std::vector<std::string_view> get_ev_methods()
+    {
+        std::vector<std::string_view> ev_methods_avail;
+        for (const char** methods = event_get_supported_methods(); methods && *methods; methods++)
+            ev_methods_avail.emplace_back(*methods);
+        return ev_methods_avail;
+    }
+
     Loop::Loop()
     {
         log::trace(log_cat, "Beginning loop context creation with new ev loop thread");
@@ -68,9 +76,7 @@ namespace oxen::quic
 #endif
         }
 
-        std::vector<std::string_view> ev_methods_avail;
-        for (const char** methods = event_get_supported_methods(); *methods != nullptr; methods++)
-            ev_methods_avail.emplace_back(*methods);
+        static std::vector<std::string_view> ev_methods_avail = get_ev_methods();
         log::debug(
                 log_cat,
                 "Starting libevent {}; available backends: {}",

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -122,8 +122,7 @@ namespace oxen::quic
         log::info(log_cat, "Loop shutdown complete");
 
 #ifdef _WIN32
-        if (loop_thread)
-            WSACleanup();
+        WSACleanup();
 #endif
     }
 
@@ -149,11 +148,6 @@ namespace oxen::quic
             loop_thread->join();
 
         log::info(log_cat, "Loop shutdown complete");
-
-#ifdef _WIN32
-        if (loop_thread)
-            WSACleanup();
-#endif
     }
 
     void Loop::setup_job_waker()

--- a/src/udp.cpp
+++ b/src/udp.cpp
@@ -195,7 +195,7 @@ namespace oxen::quic
                             sock_,
                             sockopt_proto,
                             addr.is_ipv6() ? IPV6_RECVPKTINFO :
-#ifdef IP_RECVDSTADDR
+#if defined(IP_RECVDSTADDR) && !defined(_WIN32)
                                            IP_RECVDSTADDR,
 #else
                                            IP_PKTINFO,
@@ -761,7 +761,7 @@ namespace oxen::quic
             }
 
             // extract the destination address into path.local
-#ifdef IP_RECVDSTADDR
+#if defined(IP_RECVDSTADDR) && !defined(_WIN32)
             else if (cmsg->cmsg_type == IP_RECVDSTADDR)
                 path.local.set_addr(reinterpret_cast<const struct in_addr*>(QUIC_CMSG_DATA(cmsg)));
 #else

--- a/src/udp.cpp
+++ b/src/udp.cpp
@@ -47,9 +47,11 @@ namespace oxen::quic
 #ifdef _WIN32
     static_assert(std::is_same_v<UDPSocket::socket_t, SOCKET>);
     constexpr int QUIC_IPV4_ECN = IP_ECN;
+    constexpr int QUIC_IPV6_ECN = IPV6_ECN;
     constexpr uint8_t QUIC_ECN_MASK = 0xff;
 #else
     constexpr uint8_t QUIC_ECN_MASK = IPTOS_ECN_MASK;
+    constexpr int QUIC_IPV6_ECN = IPV6_TCLASS;
     constexpr int QUIC_IPV4_ECN =
 #if defined(__APPLE__)  // Apple got --><-- this close to getting it right but then got it wrong
             IP_RECVTOS;
@@ -172,6 +174,9 @@ namespace oxen::quic
                         &sockopt_on,
                         sizeof(sockopt_on)),
                 "enable ecn");
+#else
+        // Not supported before Windows 11 (and not in mingw)
+        // check_rv(WSASetRecvIPEcn(sock_, 1), "enable ecn");
 #endif
 
 #ifdef __APPLE__
@@ -190,6 +195,7 @@ namespace oxen::quic
 
         // Enable destination address info in the packet info:
         if (!broken_os)
+        {
             check_rv(
                     setsockopt(
                             sock_,
@@ -203,6 +209,17 @@ namespace oxen::quic
                             sockopt_on_ptr,
                             sockopt_onoff_size),
                     "enable dest addr info");
+
+#ifdef _WIN32
+            // On windows dual stack sockets we have to set IP_PKTINFO in addition to IPV6_PKTINFO
+            // to ensure we get dest addr for IPv4-mapped-IPv6 addresses.  (Don't do this under
+            // wine, though, because it completely breaks the socket under wine.)
+            if (!EMULATING_HELL && addr.is_ipv6() && addr.dual_stack)
+                check_rv(
+                        setsockopt(sock_, IPPROTO_IP, IP_PKTINFO, sockopt_on_ptr, sockopt_onoff_size),
+                        "enable ipv4 dest addr info");
+#endif
+        }
 
         // Bind!
         check_rv(bind(sock_, addr, addr.socklen()), "bind");
@@ -462,9 +479,22 @@ namespace oxen::quic
         auto* next_buf = const_cast<char*>(reinterpret_cast<const char*>(buf));
         int rv = 0;
         size_t sent = 0;
-        sockaddr* dest_sa = const_cast<Address&>(path.remote);
 
         const bool set_source_addr = bound_.is_any_addr() && !path.local.is_any_addr();
+
+#ifdef _WIN32
+        // On Windows, when using a dual-stack socket, IPv4 destinations must always be
+        // passed as IPv4-mapped-IPv6
+        std::optional<Address> mapped_remote;
+        if (bound_.is_ipv6() && path.remote.is_ipv4())
+            mapped_remote = path.remote.mapped_ipv4_as_ipv6();
+        const auto& remote = mapped_remote ? *mapped_remote : path.remote;
+#else
+        const auto& remote = path.remote;
+#endif
+
+        sockaddr* dest_sa = const_cast<Address&>(remote);
+
         const bool source_ipv4 = path.local.is_ipv4();
         union
         {
@@ -528,7 +558,7 @@ namespace oxen::quic
             hdr.msg_iov = &iov;
             hdr.msg_iovlen = 1;
             hdr.msg_name = dest_sa;
-            hdr.msg_namelen = path.remote.socklen();
+            hdr.msg_namelen = remote.socklen();
             hdr.msg_control = control.data();
             hdr.msg_controllen = control.size();
 
@@ -617,7 +647,7 @@ namespace oxen::quic
             hdr.msg_iov = &iovs[i];
             hdr.msg_iovlen = 1;
             hdr.msg_name = dest_sa;
-            hdr.msg_namelen = path.remote.socklen();
+            hdr.msg_namelen = remote.socklen();
 
             auto& control = controls[i];
             hdr.msg_control = control.data();
@@ -654,14 +684,14 @@ namespace oxen::quic
         hdr.lpBuffers = &iov;
         hdr.dwBufferCount = 1;
         hdr.name = dest_sa;
-        hdr.namelen = path.remote.socklen();
+        hdr.namelen = remote.socklen();
 #else
         msghdr hdr{};
         iovec iov;
         hdr.msg_iov = &iov;
         hdr.msg_iovlen = 1;
         hdr.msg_name = dest_sa;
-        hdr.msg_namelen = path.remote.socklen();
+        hdr.msg_namelen = remote.socklen();
 #endif
 
         alignas(cmsghdr) std::array<char, CMSG_SPACE(sizeof(int)) + CMSG_SPACE(sizeof(in6_pktinfo))> control{};
@@ -675,7 +705,8 @@ namespace oxen::quic
         hdr_msg_controllen = control.size();
 
         auto* cm = CMSG_FIRSTHDR(&hdr);
-        size_t actual_size = set_ecn_cmsg(cm, ecn, source_ipv4);
+
+        size_t actual_size = set_ecn_cmsg(cm, ecn, remote.is_ipv4() || remote.is_ipv4_mapped_ipv6());
 
         if (set_source_addr)
         {
@@ -739,37 +770,36 @@ namespace oxen::quic
     {
         assert(path.remote.is_ipv4() || path.remote.is_ipv6());
 
-        const int ecn_type = path.remote.is_ipv4() ? QUIC_IPV4_ECN : IPV6_TCLASS;
-        ;
-
         for (auto cmsg = CMSG_FIRSTHDR(&hdr); cmsg; cmsg = CMSG_NXTHDR(&hdr, cmsg))
         {
-            if (cmsg->cmsg_level != (path.remote.is_ipv4() ? IPPROTO_IP : IPPROTO_IPV6) || cmsg->cmsg_len == 0)
+            if (cmsg->cmsg_len == 0)
                 continue;
 
-            // ECN flag:
-            if (cmsg->cmsg_type == ecn_type)
+            if (cmsg->cmsg_level == IPPROTO_IP)
             {
-                if (path.remote.is_ipv4())
+                if (cmsg->cmsg_type == QUIC_IPV4_ECN)
                     pkt_info.ecn = *reinterpret_cast<uint8_t*>(QUIC_CMSG_DATA(cmsg)) & QUIC_ECN_MASK;
-                else
+
+#if defined(IP_RECVDSTADDR) && !defined(_WIN32)
+                if (cmsg->cmsg_type == IP_RECVDSTADDR)
+                    path.local.set_addr(reinterpret_cast<const struct in_addr*>(QUIC_CMSG_DATA(cmsg)));
+#else
+                if (cmsg->cmsg_type == IP_PKTINFO)
+                    path.local.set_addr(&reinterpret_cast<const struct in_pktinfo*>(QUIC_CMSG_DATA(cmsg))->ipi_addr);
+#endif
+            }
+            else if (cmsg->cmsg_level == IPPROTO_IPV6)
+            {
+                if (cmsg->cmsg_type == QUIC_IPV6_ECN)
                 {
                     int tclass;
                     std::memcpy(&tclass, QUIC_CMSG_DATA(cmsg), sizeof(int));
                     pkt_info.ecn = static_cast<uint8_t>(tclass & QUIC_ECN_MASK);
                 }
-            }
 
-            // extract the destination address into path.local
-#if defined(IP_RECVDSTADDR) && !defined(_WIN32)
-            else if (cmsg->cmsg_type == IP_RECVDSTADDR)
-                path.local.set_addr(reinterpret_cast<const struct in_addr*>(QUIC_CMSG_DATA(cmsg)));
-#else
-            else if (cmsg->cmsg_type == IP_PKTINFO)
-                path.local.set_addr(&reinterpret_cast<const struct in_pktinfo*>(QUIC_CMSG_DATA(cmsg))->ipi_addr);
-#endif
-            else if (cmsg->cmsg_type == IPV6_PKTINFO)
-                path.local.set_addr(&reinterpret_cast<const struct in6_pktinfo*>(QUIC_CMSG_DATA(cmsg))->ipi6_addr);
+                if (cmsg->cmsg_type == IPV6_PKTINFO)
+                    path.local.set_addr(&reinterpret_cast<const struct in6_pktinfo*>(QUIC_CMSG_DATA(cmsg))->ipi6_addr);
+            }
         }
         log::trace(log_cat, "incoming packet path is {}", path);
     }

--- a/src/udp.cpp
+++ b/src/udp.cpp
@@ -619,8 +619,8 @@ namespace oxen::quic
 
 #ifdef _WIN32
         // Microsoft renames everything but uses the same structure just to be obtuse:
-        WSABUF iov;
         WSAMSG hdr{};
+        WSABUF iov;
         hdr.lpBuffers = &iov;
         hdr.dwBufferCount = 1;
         hdr.name = dest_sa;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -10,6 +10,10 @@
 #include "connection.hpp"
 #include "internal.hpp"
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 namespace oxen::quic
 {
     void logger_config(std::string out, log::Type type, log::Level reset)
@@ -85,5 +89,14 @@ namespace oxen::quic
         result.first = addr;
         return result;
     }
+
+#ifdef _WIN32
+    static bool running_under_wine_impl()
+    {
+        auto ntdll = GetModuleHandle("ntdll.dll");
+        return ntdll && GetProcAddress(ntdll, "wine_get_version");
+    }
+    const bool EMULATING_HELL = running_under_wine_impl();
+#endif
 
 }  // namespace oxen::quic

--- a/tests/001-handshake.cpp
+++ b/tests/001-handshake.cpp
@@ -456,17 +456,19 @@ namespace oxen::quic::test
     TEST_CASE("001 - Non-default path local address", "[001][handshake][path][local][nondefault]")
     {
         // This test is very similar to the above, but uses a connection to 127.0.0.2 instead of
-        // 127.0.0.1 (which generally doesn't work on Windows/macOS, even though the entire
-        // 127.0.0.1/8 range is supposed to be localhost).
+        // 127.0.0.1 (which generally doesn't work on macOS, even though the entire 127.0.0.1/8
+        // range is supposed to be localhost).
         //
         // Unlike the above, here the client connects to 127.0.0.2 and so, if the server sends back
         // packets without properly setting the source address, those packets will come from
         // 127.0.0.1, not .2, and the client will drop them as coming from an unknown path and thus
         // the connection to the server will fail.
 
-#if defined(__APPLE__) || defined(_WIN32)
-        SKIP("This test requires 127.0.0.2, which doesn't work on Apple/Windows");
+#if defined(__APPLE__)
+        SKIP("This test requires 127.0.0.2, which doesn't work on Apple");
 #endif
+        if (EMULATING_HELL)
+            SKIP("This test requires 127.0.0.2, which doesn't work under WINE");
 
         Path client_path, server_path;
         auto client_established = callback_waiter{[&](connection_interface& ci) { client_path = ci.path(); }};

--- a/tests/001-handshake.cpp
+++ b/tests/001-handshake.cpp
@@ -29,6 +29,8 @@ namespace oxen::quic::test
             Address ipv6_localhost{"::1", 123};
             Address localnet_ipv6{"fdab:1234:5::1", 123};
             Address public_ipv6{"2345::1", 45678};
+            Address any_ipv6{"::", 12345};
+            Address any_ipv4{"0.0.0.0", 12345};
 
             CHECK(empty_addr.is_set());
             CHECK_THROWS(Address{"127.001", 4400});
@@ -37,9 +39,20 @@ namespace oxen::quic::test
             CHECK(good_addr.is_set());
 
             CHECK(empty_addr.is_any_addr());
+#ifndef OXEN_QUIC_ADDRESS_NO_DUAL_STACK
+            CHECK(empty_addr.is_ipv6());
+            CHECK_FALSE(empty_addr.is_ipv4());
+            CHECK(empty_addr.dual_stack);
+#else
+            CHECK_FALSE(empty_addr.is_ipv6());
+            CHECK(empty_addr.is_ipv4());
+            CHECK_FALSE(empty_addr.dual_stack);
+#endif
             CHECK(empty_addr.is_any_port());
             CHECK_FALSE(empty_addr.is_addressable());
             CHECK_FALSE(empty_addr.is_loopback());
+            CHECK_FALSE(any_ipv6.dual_stack);
+            CHECK_FALSE(any_ipv4.dual_stack);
 
             CHECK(empty_addr == empty_addr2);
 

--- a/tests/001-handshake.cpp
+++ b/tests/001-handshake.cpp
@@ -122,7 +122,6 @@ namespace oxen::quic::test
             CHECK((ipv6(0x2001, 0xdb8, 0xffff) / 32).contains(ipv6(0x2001, 0xdb8)));
         }
 
-#ifndef _WIN32
         SECTION("IPv4 Addresses", "[ipv4][constructors][ipaddr]")
         {
             uint32_t v4_n;                      // network order ipv4 addr
@@ -131,7 +130,12 @@ namespace oxen::quic::test
 
             REQUIRE(inet_pton(AF_INET, v4_h.c_str(), &v4_n));
 
-            in_addr v4_inaddr{v4_n};
+            in_addr v4_inaddr;
+#ifndef _WIN32
+            v4_inaddr.s_addr = v4_n;
+#else
+            v4_inaddr.S_un.S_addr = v4_n;
+#endif
 
             ipv4 v4_net_order{v4_n};
             ipv4 v4_private{v4_h};
@@ -162,7 +166,7 @@ namespace oxen::quic::test
             CHECK(v4_from_ipv4.to_string() == v4_full);
             CHECK(v4_from_ipv4_n.to_string() == v4_full);
         }
-#endif
+
         SECTION("IPv6 Addresses", "[ipv6][constructors][ipaddr]")
         {
             auto weird = "::ffff:192.0.2.1"s;

--- a/tests/001-handshake.cpp
+++ b/tests/001-handshake.cpp
@@ -16,7 +16,7 @@ namespace oxen::quic::test
             auto [client_tls, server_tls] = defaults::tls_creds_from_ed_keys();
             REQUIRE_NOTHROW(GNUTLSCreds::make_from_ed_keys(defaults::CLIENT_SEED, defaults::CLIENT_PUBKEY));
             REQUIRE_THROWS(GNUTLSCreds::make_from_ed_keys(""s, ""s));
-        };
+        }
 
         SECTION("Address objects")
         {
@@ -104,7 +104,7 @@ namespace oxen::quic::test
             CHECK_FALSE(public_ipv6.is_any_port());
             CHECK(public_ipv6.is_addressable());
             CHECK_FALSE(public_ipv6.is_loopback());
-        };
+        }
 
         SECTION("IP Address Ranges", "[range][operators][ipaddr]")
         {
@@ -161,7 +161,7 @@ namespace oxen::quic::test
 
             CHECK(v4_from_ipv4.to_string() == v4_full);
             CHECK(v4_from_ipv4_n.to_string() == v4_full);
-        };
+        }
 #endif
         SECTION("IPv6 Addresses", "[ipv6][constructors][ipaddr]")
         {
@@ -205,8 +205,8 @@ namespace oxen::quic::test
             auto ep = test_net.endpoint(default_addr);
             // Note: kernel chooses a random port after being passed default addr
             CHECK_FALSE(ep->local().to_string() == default_addr.to_string());
-        };
-    };
+        }
+    }
 
     TEST_CASE("001 - Handshaking: Incorrect pubkeys", "[001][client][incorrect][pubkeys]")
     {
@@ -353,7 +353,7 @@ namespace oxen::quic::test
         CHECK(server_ci->is_validated());
         CHECK(server_ci->remote_key() == ustring{reinterpret_cast<const unsigned char*>(defaults::CLIENT_PUBKEY.data()),
                                                  defaults::CLIENT_PUBKEY.length()});
-    };
+    }
 
     TEST_CASE("001 - Handshaking: Types - IPv6", "[001][ipv6]")
     {
@@ -380,7 +380,7 @@ namespace oxen::quic::test
         CHECK_NOTHROW(client_endpoint->connect(client_remote, client_tls));
         CHECK(client_established.wait());
         CHECK(server_established.wait());
-    };
+    }
 
     TEST_CASE("001 - Handshaking: Execution", "[001][handshake][tls][execute]")
     {
@@ -405,7 +405,7 @@ namespace oxen::quic::test
         CHECK(client_established.wait());
         CHECK(server_established.wait());
         CHECK(client_ci->is_validated());
-    };
+    }
 
     TEST_CASE("001 - multi-listen failure", "[001][dumb][listen][protection]")
     {
@@ -447,7 +447,7 @@ namespace oxen::quic::test
         // But server should see the address the client connected to, even though it's listening on
         // the any address:
         CHECK(server_path.local.host() == "127.0.0.1");
-    };
+    }
 
     TEST_CASE("001 - Non-default path local address", "[001][handshake][path][local][nondefault]")
     {
@@ -488,7 +488,7 @@ namespace oxen::quic::test
 
         CHECK(client_path.local.host() == "0.0.0.0");
         CHECK(server_path.local.host() == "127.0.0.2");
-    };
+    }
 
     TEST_CASE("001 - Handshaking: Defer", "[001][defer][quietclose]")
     {
@@ -579,7 +579,7 @@ namespace oxen::quic::test
 
             require_future(f, 5s);
             CHECK(f.get());  // Deferred check for ci.reference_id() != server_ci->reference_id()
-        };
+        }
 
         SECTION("Override connection level callback", "[override][closehook][connection]")
         {
@@ -605,7 +605,7 @@ namespace oxen::quic::test
             client_endpoint->close_conns();
 
             CHECK_FALSE(server_closed_conn_level.is_ready());
-        };
+        }
 
         // This test is inherently racy (by design), but leads to rare data race conditions during
         // destruction; this hacky sleep is here to try to resolve it by adding just a tiny extra
@@ -618,7 +618,7 @@ namespace oxen::quic::test
             // The pubkeys definitely should not be the same
             CHECK(oxenc::to_hex(incoming) != oxenc::to_hex(local));
         }
-    };
+    }
 
     TEST_CASE("001 - Idle timeout", "[001][idle][timeout]")
     {

--- a/tests/002-send-receive.cpp
+++ b/tests/002-send-receive.cpp
@@ -44,7 +44,7 @@ namespace oxen::quic::test
         REQUIRE_NOTHROW(client_stream->send(good_msg));
 
         require_future(d_future);
-    };
+    }
 
     TEST_CASE("002 - Simple client to server transmission", "[002][simple][bidirectional]")
     {
@@ -96,7 +96,7 @@ namespace oxen::quic::test
         REQUIRE_NOTHROW(client_stream->send(good_msg));
 
         require_future(d_futures[1]);
-    };
+    }
 
     TEST_CASE("002 - Simple client to server transmission", "[002][simple][2x2]")
     {
@@ -145,7 +145,7 @@ namespace oxen::quic::test
         server_b_stream->send(good_msg);
 
         require_future(d_futures[1]);
-    };
+    }
 
     TEST_CASE("002 - Client to server transmission, larger string ownership", "[002][simple][larger][ownership]")
     {
@@ -228,7 +228,7 @@ namespace oxen::quic::test
             CHECK(good == tests);
             CHECK(bad == 0);
         }
-    };
+    }
 
     TEST_CASE("002 - BParser Testing", "[002][bparser]")
     {
@@ -357,7 +357,8 @@ namespace oxen::quic::test
                 if (m.body() == "hello")
                     m.respond("goodbye");
                 else if (m.body() == "I need a reply crypto-soon")
-                {}  // <-- Crypto-soon, defined.
+                {
+                }  // <-- Crypto-soon, defined.
                 else if (m.body() == "I hate you")
                     m.respond("lol", true);
             };

--- a/tests/003-multiclient.cpp
+++ b/tests/003-multiclient.cpp
@@ -26,8 +26,8 @@ namespace oxen::quic::test
             auto client_c = test_net.endpoint(default_addr);
 
             REQUIRE_FALSE(client_a == client_c);
-        };
-    };
+        }
+    }
 
     TEST_CASE("003 - Multi-client to server transmission: Execution", "[003][multi-client][execute]")
     {
@@ -112,5 +112,5 @@ namespace oxen::quic::test
         async_thread_b.join();
         async_thread_a.join();
         REQUIRE(data_check == 4);
-    };
+    }
 }  // namespace oxen::quic::test

--- a/tests/003-multiclient.cpp
+++ b/tests/003-multiclient.cpp
@@ -20,8 +20,7 @@ namespace oxen::quic::test
             auto client_a = test_net.endpoint(default_addr);
 
             REQUIRE_THROWS(
-                    client_b = test_net.endpoint(
-                            RemoteAddress{defaults::SERVER_PUBKEY, "127.0.0.1"s, client_a->local().port()}));
+                    client_b = test_net.endpoint(RemoteAddress{defaults::SERVER_PUBKEY, "", client_a->local().port()}));
 
             auto client_c = test_net.endpoint(default_addr);
 

--- a/tests/004-streams.cpp
+++ b/tests/004-streams.cpp
@@ -564,7 +564,7 @@ namespace oxen::quic::test
         auto d = client_ci->open_stream();
 
         // On slower setups, a small amount of time is needed to finish initializing all the streams
-        std::this_thread::sleep_for(5ms);
+        std::this_thread::sleep_for(25ms);
 
         CHECK(client_ci->get_stream(0) == a);
         CHECK(client_ci->get_stream(4) == b);

--- a/tests/004-streams.cpp
+++ b/tests/004-streams.cpp
@@ -34,7 +34,7 @@ namespace oxen::quic::test
 
         REQUIRE(client_established.wait());
         REQUIRE(conn_interface->get_max_streams() == max_streams.stream_count);
-    };
+    }
 
     TEST_CASE("004 - Multiple pending streams: streams available", "[004][streams][pending][config]")
     {
@@ -68,7 +68,7 @@ namespace oxen::quic::test
 
         require_future(data_future);
         REQUIRE(conn_interface->get_streams_available() == max_streams.stream_count - 1);
-    };
+    }
 
     TEST_CASE("004 - Multiple pending streams: different remote settings", "[004][streams][pending][config]")
     {
@@ -122,7 +122,7 @@ namespace oxen::quic::test
         REQUIRE(server_ci->get_streams_available() == client_config.stream_count);
         REQUIRE(client_ci->get_streams_available() == server_config.stream_count - 1);
         REQUIRE(server_ci->get_max_streams() == server_config.stream_count);
-    };
+    }
 
     TEST_CASE("004 - Multiple pending streams: Execution", "[004][streams][pending][execute]")
     {
@@ -227,7 +227,7 @@ namespace oxen::quic::test
         require_future(f);
 
         REQUIRE(data_check == n_recvs);
-    };
+    }
 
     struct ClientStream : public Stream
     {
@@ -305,7 +305,7 @@ namespace oxen::quic::test
 
         require_future(cs_f);
         require_future(sc_f);
-    };
+    }
 
     TEST_CASE("004 - Subclassing quic::stream, custom to custom", "[004][customstream][subclass]")
     {
@@ -341,7 +341,7 @@ namespace oxen::quic::test
         REQUIRE_NOTHROW(client_stream->send(msg));
 
         require_future(server_future);
-    };
+    }
 
     struct CustomStream : public Stream
     {
@@ -541,7 +541,7 @@ namespace oxen::quic::test
         REQUIRE(server_closed.wait());
 
         CHECK(expected_server_stream_ctor_count == server_stream_ctor_count.load());
-    };
+    }
 
     TEST_CASE("004 - subclass retrieval", "[004][customstream][get_stream]")
     {
@@ -699,7 +699,7 @@ namespace oxen::quic::test
 
         client_ci->close_connection();
         REQUIRE(server_closed.wait());
-    };
+    }
 
     TEST_CASE("004 - BTRequestStream, server stream extraction", "[004][server][extraction]")
     {
@@ -774,7 +774,7 @@ namespace oxen::quic::test
 
         server_extracted->command("test_endpoint"s, "hi"s);
         REQUIRE(client_handler.wait());
-    };
+    }
 
     TEST_CASE("004 - BTRequestStream, server extracts queued streams", "[004][server][queue]")
     {
@@ -824,7 +824,7 @@ namespace oxen::quic::test
 
         server_bt->command("test_endpoint"s, "hi"s);
         REQUIRE(client_handler.wait());
-    };
+    }
 
     TEST_CASE("004 - BTRequestStream, send queue functionality", "[004][sendqueue]")
     {
@@ -898,7 +898,7 @@ namespace oxen::quic::test
         REQUIRE(client_established.wait());
         REQUIRE(server_established.wait());
         REQUIRE(client_handler.wait());
-    };
+    }
 
     TEST_CASE("004 - Stream/connection lifetime handling", "[004][streams][lifetime]")
     {
@@ -961,7 +961,7 @@ namespace oxen::quic::test
 
         // Connection has gone away, but we still have the pointer; this call should do nothing:
         stream->send("But wait, there's more!"s);
-    };
+    }
 
     TEST_CASE("004 - Connection closed during stream callback", "[004][streams][closing]")
     {

--- a/tests/005-chunked-sender.cpp
+++ b/tests/005-chunked-sender.cpp
@@ -109,5 +109,5 @@ namespace oxen::quic::test
                     "HELLO![CHUNK-1][CHUNK-2][CHUNK-3][Chunk-4][Chunk-5][Chunk-6][chunk-7][chunk-8][chunk-9][chunk-10]"
                     "Goodbye.");
         }
-    };
+    }
 }  // namespace oxen::quic::test

--- a/tests/006-server-send.cpp
+++ b/tests/006-server-send.cpp
@@ -62,7 +62,7 @@ namespace oxen::quic::test
         require_future(client_future);
         require_future(server_future);
         REQUIRE(data_check == 2);
-    };
+    }
 
     TEST_CASE("006 - Server streams: Remote initiation, server send", "[006][server][streams][send][execute]")
     {
@@ -174,5 +174,5 @@ namespace oxen::quic::test
 
         require_future(server_futures[2]);
         REQUIRE(data_check == 4);
-    };
+    }
 }  // namespace oxen::quic::test

--- a/tests/007-datagrams.cpp
+++ b/tests/007-datagrams.cpp
@@ -60,7 +60,7 @@ namespace oxen::quic::test
         REQUIRE(bufsize_ep->packet_splitting_enabled());
         REQUIRE(bufsize_ep->splitting_policy() == Splitting::ACTIVE);
         REQUIRE(bufsize_ep->datagram_bufsize() == bsize);
-    };
+    }
 
     TEST_CASE("007 - Datagram support: Query param info from datagram-disabled endpoint", "[007][datagrams][types]")
     {
@@ -86,7 +86,7 @@ namespace oxen::quic::test
         REQUIRE_FALSE(conn_interface->packet_splitting_enabled());
         REQUIRE_FALSE(conn_interface->packet_splitting_enabled());
         REQUIRE(conn_interface->get_max_datagram_size() == 0);
-    };
+    }
 
     TEST_CASE("007 - Datagram support: Query param info from default datagram-enabled endpoint", "[007][datagrams][types]")
     {
@@ -116,7 +116,7 @@ namespace oxen::quic::test
 
         std::this_thread::sleep_for(5ms);
         REQUIRE(conn_interface->get_max_datagram_size() < MAX_PMTUD_UDP_PAYLOAD);
-    };
+    }
 
     TEST_CASE("007 - Datagram support: Query params from split-datagram enabled endpoint", "[007][datagrams][types]")
     {
@@ -144,7 +144,7 @@ namespace oxen::quic::test
 
         std::this_thread::sleep_for(5ms);
         REQUIRE(conn_interface->get_max_datagram_size() < MAX_GREEDY_PMTUD_UDP_PAYLOAD);
-    };
+    }
 
     TEST_CASE("007 - Datagram support: Execute, No Splitting Policy", "[007][datagrams][execute][nosplit]")
     {
@@ -192,8 +192,8 @@ namespace oxen::quic::test
             conn_interface->send_datagram(msg);
 
             require_future(data_future);
-        };
-    };
+        }
+    }
 
     TEST_CASE("007 - Datagram support: Execute, Packet Splitting Enabled", "[007][datagrams][execute][split][simple]")
     {
@@ -270,8 +270,8 @@ namespace oxen::quic::test
 
             require_future(data_future);
             CHECK(data_counter == 2);
-        };
-    };
+        }
+    }
 
     TEST_CASE(
             "007 - Datagram support: Rotating Buffer, Clearing Buffer", "[007][datagrams][execute][split][rotating][clear]")
@@ -354,8 +354,8 @@ namespace oxen::quic::test
             auto server_ci = server_endpoint->get_all_conns(Direction::INBOUND).front();
 
             REQUIRE(server_ci->last_cleared() == 0);
-        };
-    };
+        }
+    }
 
     TEST_CASE(
             "007 - Datagram support: Rotating Buffer, Mixed Datagrams", "[007][datagrams][execute][split][rotating][mixed]")
@@ -440,8 +440,8 @@ namespace oxen::quic::test
                 require_future(f);
 
             REQUIRE(data_counter == int(n));
-        };
-    };
+        }
+    }
 
     TEST_CASE("007 - Datagram support: Rotating Buffer, Induced Loss", "[007][datagrams][execute][split][rotating][loss]")
     {
@@ -523,8 +523,8 @@ namespace oxen::quic::test
 
             REQUIRE(counter == bufsize);
             REQUIRE(received == successful_msg);
-        };
-    };
+        }
+    }
 
     /*
         Test Note:
@@ -633,6 +633,6 @@ namespace oxen::quic::test
             REQUIRE(data_counter == (int)n);
             auto flip_flop_count = TestHelper::disable_dgram_flip_flop(*conn_interface);
             REQUIRE(flip_flop_count < (int)n);
-        };
-    };
+        }
+    }
 }  // namespace oxen::quic::test

--- a/tests/008-conn_hooks.cpp
+++ b/tests/008-conn_hooks.cpp
@@ -39,7 +39,7 @@ namespace oxen::quic::test
             REQUIRE(server_established.wait());
 
             conn_interface->close_connection(error_code);
-        };
+        }
 
         SECTION("via Endpoint::{connect,listen}(...)")
         {
@@ -55,11 +55,11 @@ namespace oxen::quic::test
             REQUIRE(server_established.wait());
 
             conn_interface->close_connection(error_code);
-        };
+        }
 
         REQUIRE(server_closed.wait());
         REQUIRE(client_closed.wait());
         CHECK(client_error == error_code);
         CHECK(server_error == error_code);
-    };
+    }
 }  // namespace oxen::quic::test

--- a/tests/009-alpns.cpp
+++ b/tests/009-alpns.cpp
@@ -39,7 +39,7 @@ namespace oxen::quic::test
             auto conn = client_endpoint->connect(client_remote, client_tls);
             REQUIRE(client_established.wait());
             REQUIRE(conn->selected_alpn() == "default"_usv);
-        };
+        }
 
         SECTION("No Server ALPNs specified (defaulted)")
         {
@@ -55,7 +55,7 @@ namespace oxen::quic::test
             auto conn = client_endpoint->connect(client_remote, client_tls);
             CHECK(client_closed.wait(2s));
             REQUIRE_FALSE(client_established.is_ready());
-        };
+        }
 
         SECTION("No Client ALPNs specified (defaulted)")
         {
@@ -71,7 +71,7 @@ namespace oxen::quic::test
             auto conn = client_endpoint->connect(client_remote, client_tls);
             CHECK(client_closed.wait(2s));
             REQUIRE_FALSE(client_established.is_ready());
-        };
+        }
 
         SECTION("Client ALPNs not supported")
         {
@@ -88,7 +88,7 @@ namespace oxen::quic::test
             auto conn = client_endpoint->connect(client_remote, client_tls);
             CHECK(client_closed.wait(2s));
             REQUIRE_FALSE(client_established.is_ready());
-        };
+        }
 
         SECTION("Select first ALPN both sides support")
         {
@@ -112,7 +112,7 @@ namespace oxen::quic::test
             auto conn2 = client_endpoint2->connect(client_remote, client_tls);
             REQUIRE(client_established2.wait());
             REQUIRE(conn2->selected_alpn() == "relay"_usv);
-        };
-    };
+        }
+    }
 
 }  // namespace oxen::quic::test

--- a/tests/010-migration.cpp
+++ b/tests/010-migration.cpp
@@ -109,5 +109,5 @@ namespace oxen::quic::test
 
         require_future(conn_future_b);
         CHECK(client_established_b.wait());
-    };
+    }
 }  // namespace oxen::quic::test

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,13 @@ else()
     target_link_libraries(tests_common INTERFACE PkgConfig::HOGWEED)
 endif()
 
+function(extra_linking target)
+    if(WIN32 AND NOT BUILD_SHARED_LIBS)
+        target_link_libraries(${target} PRIVATE -static)
+    endif()
+endfunction()
+
+
 if(LIBQUIC_BUILD_TESTS)
     add_subdirectory(Catch2)
 
@@ -34,6 +41,7 @@ if(LIBQUIC_BUILD_TESTS)
         main.cpp
     )
     target_link_libraries(alltests PRIVATE tests_common Catch2::Catch2)
+    extra_linking(alltests)
 
 endif()
 
@@ -44,6 +52,7 @@ if(LIBQUIC_BUILD_SPEEDTEST)
         add_executable(${x} ${x}.cpp)
         target_link_libraries(${x} PRIVATE tests_common)
         set_target_properties(${x} PROPERTIES OUTPUT_NAME ${LIBQUIC_SPEEDTEST_PREFIX}${x})
+        extra_linking(${x})
     endforeach()
 
     if(LIBQUIC_INSTALL)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,6 +39,7 @@ if(LIBQUIC_BUILD_TESTS)
         010-migration.cpp
 
         main.cpp
+        case_logger.cpp
     )
     target_link_libraries(alltests PRIVATE tests_common Catch2::Catch2)
     extra_linking(alltests)

--- a/tests/case_logger.cpp
+++ b/tests/case_logger.cpp
@@ -1,0 +1,109 @@
+// This file contains a Catch2 listener than add oxen logging statements tracing the entry of cases
+// and sections in the test suite.
+//
+// It runs in its own log level; to activate it, run alltests with `-T`/`--test-tracing`.
+//
+#include <catch2/catch_test_case_info.hpp>
+#include <catch2/reporters/catch_reporter_event_listener.hpp>
+#include <catch2/reporters/catch_reporter_registrars.hpp>
+#include <oxen/log.hpp>
+#include <oxen/log/internal.hpp>
+
+namespace fmt
+{
+    template <>
+    struct formatter<Catch::StringRef, char> : formatter<std::string_view>
+    {
+        template <typename FormatContext>
+        auto format(const Catch::StringRef& val, FormatContext& ctx) const
+        {
+            return formatter<std::string_view>::format({val.data(), val.size()}, ctx);
+        }
+    };
+}  // namespace fmt
+
+namespace oxen::quic::test
+{
+    using namespace Catch;
+
+    static auto cat = log::Cat("testcase");
+
+    static std::string_view sv(const Catch::StringRef& s)
+    {
+        return {s.data(), s.size()};
+    }
+
+    // Bypass the usual log::trace(...) because we want to fake the source location, and want this
+    // even in non-debug builds.
+    template <typename... T>
+    static void test_trace(const Catch::SourceLineInfo& sli, fmt::format_string<T...> fmt, T&&... args)
+    {
+
+        std::string_view filename{sli.file};
+        for (const auto& prefix : oxen::log::detail::source_prefixes)
+        {
+            if (filename.starts_with(prefix))
+            {
+                filename.remove_prefix(prefix.size());
+                if (!filename.empty() && filename[0] == '/')
+                    filename.remove_prefix(1);
+            }
+        }
+        while (filename.starts_with("../"))
+            filename.remove_prefix(3);
+
+        spdlog::source_loc sloc{filename.data(), static_cast<int>(sli.line), /*function name=*/""};
+
+        cat->log(sloc, log::Level::trace, fmt, std::forward<T>(args)...);
+    }
+
+    class CaseLogger : public Catch::EventListenerBase
+    {
+      public:
+        using Catch::EventListenerBase::EventListenerBase;
+
+        static std::string getDescription()
+        {
+            return "Report test cases and section starting/ending events via oxen-logging";
+        }
+
+        void testCaseStarting(const TestCaseInfo& info) override
+        {
+            test_trace(info.lineInfo, "Starting test case {} ({})", info.name, info.tagsAsString());
+        }
+        void testCaseEnded(const TestCaseStats& stats) override
+        {
+            auto& info = *stats.testInfo;
+            test_trace(info.lineInfo, "Finished test case {} ({})", info.name, info.tagsAsString());
+        }
+
+        void testCasePartialStarting(const Catch::TestCaseInfo& info, uint64_t partNumber) override
+        {
+            if (partNumber > 0)
+                test_trace(info.lineInfo, "↪ Starting test case {} pass {}", info.name, partNumber);
+        }
+
+        void testCasePartialEnded(const Catch::TestCaseStats& stats, uint64_t partNumber) override
+        {
+            auto& info = *stats.testInfo;
+            if (partNumber > 0)
+                test_trace(info.lineInfo, "↩ Finished test case {} pass {}", info.name, partNumber);
+        }
+
+        bool first_sect = true;
+        void sectionStarting(const SectionInfo& info) override
+        {
+            if (first_sect)
+                first_sect = false;
+            test_trace(info.lineInfo, "  ↪ Entering section {}", info.name);
+        }
+        void sectionEnded(const SectionStats& stats) override
+        {
+            auto& info = stats.sectionInfo;
+            test_trace(info.lineInfo, "  ↩ Finished section {} in {:.3f}ms", info.name, stats.durationInSeconds * 1000);
+        }
+    };
+
+}  // namespace oxen::quic::test
+
+CATCH_REGISTER_LISTENER(oxen::quic::test::CaseLogger)

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -10,6 +10,7 @@ int main(int argc, char* argv[])
 
     using namespace Catch::Clara;
     std::string log_level = "critical", log_file = "stderr";
+    bool test_case_tracing = false;
     oxen::quic::disable_ipv6 = false;
     oxen::quic::disable_rotating_buffer = false;
 
@@ -17,7 +18,8 @@ int main(int argc, char* argv[])
                Opt(log_file, "file")["--log-file"](
                        "oxen-logging log file to output logs to, or one of  or one of stdout/-/stderr/syslog.") |
                Opt(oxen::quic::disable_ipv6)["--no-ipv6"]("disable ipv6 addressing in the test suite") |
-               Opt(oxen::quic::disable_rotating_buffer)["--no-buf"]("disable rotating buffers in the test suite");
+               Opt(oxen::quic::disable_rotating_buffer)["--no-buf"]("disable rotating buffers in the test suite") |
+               Opt(test_case_tracing)["-T"]["--test-tracing"]("enable oxen log tracing of test cases/sections");
 
     session.cli(cli);
 
@@ -25,6 +27,8 @@ int main(int argc, char* argv[])
         return rc;
 
     oxen::quic::setup_logging(log_file, log_level);
+
+    oxen::log::set_level(oxen::log::Cat("testcase"), test_case_tracing ? oxen::log::Level::trace : oxen::log::Level::off);
 
     oxen::quic::test::defaults::CLIENT_KEYS = oxen::quic::generate_ed25519();
     oxen::quic::test::defaults::SERVER_KEYS = oxen::quic::generate_ed25519();

--- a/tests/speedtest-server.cpp
+++ b/tests/speedtest-server.cpp
@@ -159,12 +159,20 @@ int main(int argc, char* argv[])
         // but it feels wrong to force it to a critical statement, so temporarily lower the level to
         // info to display it.
         log_level_lowerer enable_info{log::Level::info, test_cat.name};
+        std::vector<std::string> flags;
+        if (server_local != Address{"127.0.0.1", 5500})
+            flags.push_back("--remote {}"_format(server_local.to_string()));
+        flags.push_back("--remote-pubkey={}"_format(oxenc::to_base64(pubkey)));
+        if (no_hash)
+            flags.push_back(no_checksum ? "-HX" : "-H");
+        else if (no_checksum)
+            flags.push_back("-X");
+
         log::info(
                 test_cat,
-                "Listening on {}; client connection args:\n\t{}--remote-pubkey={}",
+                "Listening on {}; client connection args:\n\t{}",
                 server_local,
-                server_local != Address{"127.0.0.1", 5500} ? "--remote {} "_format(server_local.to_string()) : "",
-                oxenc::to_base64(pubkey));
+                "{}"_format(fmt::join(flags, " ")));
     }
 
     for (;;)

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -137,7 +137,7 @@ namespace oxen::quic
     void add_log_opts(CLI::App& cli, std::string& file, std::string& level)
     {
         file = "stderr";
-        level = "debug";
+        level = "info";
 
         cli.add_option("-l,--log-file", file, "Log output filename, or one of stdout/-/stderr/syslog.")
                 ->type_name("FILE")

--- a/utils/format.sh
+++ b/utils/format.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-CLANG_FORMAT_DESIRED_VERSION=15
+CLANG_FORMAT_DESIRED_VERSION=16
 
 binary=$(command -v clang-format-$CLANG_FORMAT_DESIRED_VERSION 2>/dev/null)
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
This fixes various small issues on Windows to get the test suite working (via wine).

New useful things added here:
- The `alltests` binary now has a `-T` flag that can print a trace of all test case and sections being entered.
- The windows build now runs the test suite under wine.

Fixes:
- If a socket option failed, the program could crash because we weren't checking for Connection shutdown in between socket operations and rescheduling a transmit timer (if such a socket operation failed, it would trigger Connection shutdown, invalidating the retransmit timer pointer).
- `event_get_supported_methods` is not thread safe; we now call it just once (via a static local variable) instead of during each Loop construction to avoid such crash potential.
- Windows binaries were not fully static (they required libstdc++-6.dll and similar, which we don't easily have or want to ship alongside the binaries)
- Dual stack IPv6 was not working on Windows (or anywhere else outside Linux/macOS).  This commit now does it properly so that it is either explicitly enabled or disabled depending on the Address value that we bind.
- IPv4 address tests were broken (and ifdef'd away) on Windows; this includes a Windows-specific hack to get it working.
- WSACleanup() was called during `Loop` destruction, but *also* during `Loop::shutdown`, but WSACleanup calls must be one-to-one with `WSAStartup` calls.  This broken the test suite on Windows because in cases where we have two Network objects, the first one being destroyed could WSACleanup *twice*, which then completely stalled the second one's event loop which would then deadlock.  This fixes it to always unconditionally call it (just once) in the destructor, matching the WSAStartup call in the constructor.
- socket operation failures did not have a log statement: they now have a descriptive error with what failed, the error code, and the error reason.
- Windows IPv4 bound address were failing because Windows defines a `IP_RECVDSTADDR` symbol that it doesn't actually support.  This fixes it to ignore `IP_RECVDSTADDR` on Windows (we need to use `IP_PKTINFO` instead).
- Fixed `ipv4::operator in_addr` compatibility in Windows, where in_addr is non-simple enough that the reinterpret_cast was failing strict aliasing rules.

Random cleanups:
- added a format rule to eliminate unnecessary semicolons
- cleaned up the C++20 formattable concept using a macro instead of an inline ifdef for the `bool` that older GCC needs.  (This is the same macro name that is now being used in Lokinet, which can just drop its own definition once it updates to this oxen-libquic).
- Changed the default speedtest-server/-client log level to info instead of debug.  Debug is pointless as a default because it just bottlenecks the CPU printing log statements when sending huge numbers of packets.
- Fixed mismatched order of declared variables on Windows and non-Windows code paths