### PR TITLE
No-UDP Endpoints: manual data I/O routing

### DIFF
--- a/include/oxen/quic/address.hpp
+++ b/include/oxen/quic/address.hpp
@@ -380,6 +380,8 @@ namespace oxen::quic
             return &_path;
         }
 
+        Path invert() const { return {remote, local}; }
+
         std::string to_string() const;
     };
 }  // namespace oxen::quic

--- a/include/oxen/quic/endpoint.hpp
+++ b/include/oxen/quic/endpoint.hpp
@@ -378,7 +378,7 @@ namespace oxen::quic
         void send_or_queue_packet(
                 const Path& p, std::vector<std::byte> buf, uint8_t ecn, std::function<void(io_result)> callback = nullptr);
 
-        void send_version_negotiation(const ngtcp2_version_cid& vid, const Path& p);
+        void send_version_negotiation(const ngtcp2_version_cid& vid, Path p);
 
         void check_timeouts();
 

--- a/include/oxen/quic/opt.hpp
+++ b/include/oxen/quic/opt.hpp
@@ -149,7 +149,7 @@ namespace oxen::quic
         // take responsibility for passing packets into the Endpoint via Endpoint::manually_receive_packet(...)
         struct manual_routing
         {
-            using send_handler_t = std::function<void(Path, bstring_view)>;
+            using send_handler_t = std::function<void(const Path&, bstring_view)>;
 
           private:
             friend Endpoint;

--- a/include/oxen/quic/opt.hpp
+++ b/include/oxen/quic/opt.hpp
@@ -6,138 +6,173 @@
 #include "crypto.hpp"
 #include "types.hpp"
 
-namespace oxen::quic::opt
+namespace oxen::quic
 {
-    using namespace std::chrono_literals;
+    class Endpoint;
 
-    struct max_streams
+    namespace opt
     {
-        uint64_t stream_count{DEFAULT_MAX_BIDI_STREAMS};
-        max_streams() = default;
-        explicit max_streams(uint64_t s) : stream_count{s} {}
-    };
+        using namespace std::chrono_literals;
 
-    // If non-zero, this sets a keep-alive timer for outgoing PINGs on this connection so that a
-    // functioning but idle connection can stay alive indefinitely without hitting the connection's
-    // idle timeout.  Typically in designing a protocol you need only one side to send pings; the
-    // responses to a ping keep the connection in the other direction alive.  This value should
-    // typically be lower than the idle_timeout of both sides of the connection to be effective.
-    //
-    // If this option is not specified or is set to a duration of 0 then outgoing PINGs will not be
-    // sent on the connection.
-    struct keep_alive
-    {
-        std::chrono::milliseconds time{0ms};
-        keep_alive() = default;
-        explicit keep_alive(std::chrono::milliseconds val) : time{val} {}
-    };
-
-    // Can be used to override the default (30s) maximum idle timeout for a connection.  Note that
-    // this is negotiated during connection establishment, and the lower value advertised by each
-    // side will be used for the connection.  Can be 0 to disable idle timeout entirely, but such an
-    // option has caveats for connections across unknown internet boxes (see comments in RFC 9000,
-    // section 10.1.2).
-    struct idle_timeout
-    {
-        std::chrono::milliseconds timeout{DEFAULT_IDLE_TIMEOUT};
-        idle_timeout() = default;
-        explicit idle_timeout(std::chrono::milliseconds val) : timeout{val} {}
-    };
-
-    /// This can be initialized a few different ways. Simply passing a default constructed struct
-    /// to Network::Endpoint(...) will enable datagrams without packet-splitting. From there, pass
-    /// `Splitting::ACTIVE` to the constructor to enable packet-splitting.
-    ///
-    /// The size of the rotating datagram buffer can also be specified as a second parameter to the
-    /// constructor. Buffer size is subdivided amongst 4 equally sized buffer rows, so the bufsize
-    /// must be perfectly divisible by 4
-    ///
-    /// In some use cases, the user may want the receive data as a string view or a string literal.
-    /// The default is string literal; setting
-    ///
-    /// The max size of a transmittable datagram can be queried directly from connection_interface::
-    /// get_max_datagram_size(). At connection initialization, ngtcp2 will default this value to 1200.
-    /// The actual value is negotiated upwards via path discovery, reaching a theoretical maximum of
-    /// NGTCP2_MAX_PMTUD_UDP_PAYLOAD_SIZE (1452), or near it, per datagram. Please note that enabling
-    /// datagram splitting will double whatever value is returned.
-    ///
-    /// Note: this setting CANNOT be changed for an endpoint after creation, it must be
-    /// destroyed and re-initialized with the desired settings.
-    struct enable_datagrams
-    {
-        bool split_packets{false};
-        Splitting mode{Splitting::NONE};
-        // Note: this is the size of the entire buffer, divided amongst 4 rows
-        int bufsize{4096};
-
-        enable_datagrams() = default;
-        explicit enable_datagrams(bool e) = delete;
-        explicit enable_datagrams(Splitting m) : split_packets{true}, mode{m} {}
-        explicit enable_datagrams(Splitting m, int b) : split_packets{true}, mode{m}, bufsize{b}
+        struct max_streams
         {
-            if (b <= 0)
-                throw std::out_of_range{"Bufsize must be positive"};
-            if (b > 1 << 14)
-                throw std::out_of_range{"Bufsize too large"};
-            if (b % 4 != 0)
-                throw std::invalid_argument{"Bufsize must be evenly divisible between 4 rows"};
-        }
-    };
+            uint64_t stream_count{DEFAULT_MAX_BIDI_STREAMS};
+            max_streams() = default;
+            explicit max_streams(uint64_t s) : stream_count{s} {}
+        };
 
-    // supported ALPNs for outbound connections
-    struct outbound_alpns
-    {
-        std::vector<ustring> alpns;
-        explicit outbound_alpns(std::vector<ustring> alpns = {}) : alpns{std::move(alpns)} {}
-
-        // Convenience wrapper that sets a single ALPN value from a regular string:
-        explicit outbound_alpns(std::string_view alpn) : outbound_alpns{{ustring{to_usv(alpn)}}} {}
-    };
-
-    // supported ALPNs for inbound connections
-    struct inbound_alpns
-    {
-        std::vector<ustring> alpns;
-        explicit inbound_alpns(std::vector<ustring> alpns = {}) : alpns{std::move(alpns)} {}
-
-        // Convenience wrapper that sets a single ALPN value from a regular string:
-        explicit inbound_alpns(std::string_view alpn) : inbound_alpns{{ustring{to_usv(alpn)}}} {}
-    };
-
-    // Sets the inbound and outbound ALPNs simulatneous to the same value(s).  This is equivalent to
-    // passing outbound_alpns and inbound_alps, separately, with the same vector argument.
-    struct alpns
-    {
-        std::vector<ustring> inout_alpns;
-        explicit alpns(std::vector<ustring> alpns = {}) : inout_alpns{std::move(alpns)} {}
-
-        // Convenience wrapper that sets a single ALPN value from a regular string:
-        explicit alpns(std::string_view alpn) : alpns{{ustring{to_usv(alpn)}}} {}
-    };
-
-    struct handshake_timeout
-    {
-        std::chrono::nanoseconds timeout;
-        explicit handshake_timeout(std::chrono::nanoseconds ns = 0ns) : timeout{ns} {}
-    };
-
-    // Used to provide precalculated static secret data for an endpoint to use for validation
-    // tokens.  If not provided, 32 random bytes are generated during endpoint construction.  The
-    // data provided must be (at least) SECRET_MIN_SIZE long (longer values are ignored).  For a
-    // deterministic value you should not pass sensitive data here (such as a raw private key), but
-    // instead use a cryptographically secure hash (ideally with a unique key or suffix) of such
-    // data.
-    struct static_secret
-    {
-        inline static constexpr size_t SECRET_MIN_SIZE = 16;
-
-        ustring secret;
-        explicit static_secret(ustring s) : secret{std::move(s)}
+        // supported ALPNs for outbound connections
+        struct outbound_alpns
         {
-            if (secret.size() < SECRET_MIN_SIZE)
-                throw std::invalid_argument{
-                        "opt::static_secret requires data of at least " + std::to_string(SECRET_MIN_SIZE) + "bytes"};
-        }
-    };
+            std::vector<ustring> alpns;
+            explicit outbound_alpns(std::vector<ustring> alpns = {}) : alpns{std::move(alpns)} {}
 
-}  // namespace oxen::quic::opt
+            // Convenience wrapper that sets a single ALPN value from a regular string:
+            explicit outbound_alpns(std::string_view alpn) : outbound_alpns{{ustring{to_usv(alpn)}}} {}
+        };
+
+        // supported ALPNs for inbound connections
+        struct inbound_alpns
+        {
+            std::vector<ustring> alpns;
+            explicit inbound_alpns(std::vector<ustring> alpns = {}) : alpns{std::move(alpns)} {}
+
+            // Convenience wrapper that sets a single ALPN value from a regular string:
+            explicit inbound_alpns(std::string_view alpn) : inbound_alpns{{ustring{to_usv(alpn)}}} {}
+        };
+
+        // Sets the inbound and outbound ALPNs simulatneous to the same value(s).  This is equivalent to
+        // passing outbound_alpns and inbound_alps, separately, with the same vector argument.
+        struct alpns
+        {
+            std::vector<ustring> inout_alpns;
+            explicit alpns(std::vector<ustring> alpns = {}) : inout_alpns{std::move(alpns)} {}
+
+            // Convenience wrapper that sets a single ALPN value from a regular string:
+            explicit alpns(std::string_view alpn) : alpns{{ustring{to_usv(alpn)}}} {}
+        };
+
+        struct handshake_timeout
+        {
+            std::chrono::nanoseconds timeout;
+            explicit handshake_timeout(std::chrono::nanoseconds ns = 0ns) : timeout{ns} {}
+        };
+
+        // If non-zero, this sets a keep-alive timer for outgoing PINGs on this connection so that a
+        // functioning but idle connection can stay alive indefinitely without hitting the connection's
+        // idle timeout.  Typically in designing a protocol you need only one side to send pings; the
+        // responses to a ping keep the connection in the other direction alive.  This value should
+        // typically be lower than the idle_timeout of both sides of the connection to be effective.
+        //
+        // If this option is not specified or is set to a duration of 0 then outgoing PINGs will not be
+        // sent on the connection.
+        struct keep_alive
+        {
+            std::chrono::milliseconds time{0ms};
+            keep_alive() = default;
+            explicit keep_alive(std::chrono::milliseconds val) : time{val} {}
+        };
+
+        // Can be used to override the default (30s) maximum idle timeout for a connection.  Note that
+        // this is negotiated during connection establishment, and the lower value advertised by each
+        // side will be used for the connection.  Can be 0 to disable idle timeout entirely, but such an
+        // option has caveats for connections across unknown internet boxes (see comments in RFC 9000,
+        // section 10.1.2).
+        struct idle_timeout
+        {
+            std::chrono::milliseconds timeout{DEFAULT_IDLE_TIMEOUT};
+            idle_timeout() = default;
+            explicit idle_timeout(std::chrono::milliseconds val) : timeout{val} {}
+        };
+
+        /// This can be initialized a few different ways. Simply passing a default constructed struct
+        /// to Network::Endpoint(...) will enable datagrams without packet-splitting. From there, pass
+        /// `Splitting::ACTIVE` to the constructor to enable packet-splitting.
+        ///
+        /// The size of the rotating datagram buffer can also be specified as a second parameter to the
+        /// constructor. Buffer size is subdivided amongst 4 equally sized buffer rows, so the bufsize
+        /// must be perfectly divisible by 4
+        ///
+        /// In some use cases, the user may want the receive data as a string view or a string literal.
+        /// The default is string literal; setting
+        ///
+        /// The max size of a transmittable datagram can be queried directly from connection_interface::
+        /// get_max_datagram_size(). At connection initialization, ngtcp2 will default this value to 1200.
+        /// The actual value is negotiated upwards via path discovery, reaching a theoretical maximum of
+        /// NGTCP2_MAX_PMTUD_UDP_PAYLOAD_SIZE (1452), or near it, per datagram. Please note that enabling
+        /// datagram splitting will double whatever value is returned.
+        ///
+        /// Note: this setting CANNOT be changed for an endpoint after creation, it must be
+        /// destroyed and re-initialized with the desired settings.
+        struct enable_datagrams
+        {
+            bool split_packets{false};
+            Splitting mode{Splitting::NONE};
+            // Note: this is the size of the entire buffer, divided amongst 4 rows
+            int bufsize{4096};
+
+            enable_datagrams() = default;
+            explicit enable_datagrams(bool e) = delete;
+            explicit enable_datagrams(Splitting m) : split_packets{true}, mode{m} {}
+            explicit enable_datagrams(Splitting m, int b) : split_packets{true}, mode{m}, bufsize{b}
+            {
+                if (b <= 0)
+                    throw std::out_of_range{"Bufsize must be positive"};
+                if (b > 1 << 14)
+                    throw std::out_of_range{"Bufsize too large"};
+                if (b % 4 != 0)
+                    throw std::invalid_argument{"Bufsize must be evenly divisible between 4 rows"};
+            }
+        };
+
+        // Used to provide precalculated static secret data for an endpoint to use for validation
+        // tokens.  If not provided, 32 random bytes are generated during endpoint construction.  The
+        // data provided must be (at least) SECRET_MIN_SIZE long (longer values are ignored).  For a
+        // deterministic value you should not pass sensitive data here (such as a raw private key), but
+        // instead use a cryptographically secure hash (ideally with a unique key or suffix) of such
+        // data.
+        struct static_secret
+        {
+            inline static constexpr size_t SECRET_MIN_SIZE = 16;
+
+            ustring secret;
+            explicit static_secret(ustring s) : secret{std::move(s)}
+            {
+                if (secret.size() < SECRET_MIN_SIZE)
+                    throw std::invalid_argument{
+                            "opt::static_secret requires data of at least " + std::to_string(SECRET_MIN_SIZE) + "bytes"};
+            }
+        };
+
+        // Used to provide a callback that bypasses sending packets out through the UDP socket. The passing of
+        // this opt will also bypass the creation of the UDP socket entirely. The application will also need to
+        // take responsibility for passing packets into the Endpoint via Endpoint::manually_receive_packet(...)
+        struct manual_routing
+        {
+            using send_handler_t = std::function<void(Path, bstring_view)>;
+
+          private:
+            friend Endpoint;
+
+            manual_routing() = default;
+
+            send_handler_t send_hook = nullptr;
+
+          public:
+            explicit manual_routing(send_handler_t cb) : send_hook{std::move(cb)}
+            {
+                if (not send_hook)
+                    throw std::runtime_error{"opt::manual_routing must be constructed with a send handler hook!"};
+            }
+
+            io_result operator()(const Path& p, bstring_view data, size_t& n)
+            {
+                send_hook(p, data);
+                n = 0;
+                return io_result{};
+            }
+
+            explicit operator bool() const { return send_hook != nullptr; }
+        };
+    }  //  namespace opt
+}  // namespace oxen::quic

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -524,7 +524,8 @@ namespace oxen::quic
     {
         auto ts = get_timestamp().count();
         log::trace(log_cat, "Calling ngtcp2_conn_read_pkt...");
-        auto rv = ngtcp2_conn_read_pkt(*this, pkt.path, &pkt.pkt_info, u8data(pkt.data), pkt.data.size(), ts);
+        auto data = pkt.data<uint8_t>();
+        auto rv = ngtcp2_conn_read_pkt(*this, pkt.path, &pkt.pkt_info, data.data(), data.size(), ts);
 
         switch (rv)
         {

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -821,7 +821,7 @@ namespace oxen::quic
             // We're blocked from a previous call, and haven't finished sending all our packets yet
             // so there's nothing to do for now (once the packets are fully sent we'll get called
             // again so that we can keep working on sending).
-            log::trace(log_cat, "Skipping this flush_streams call; we still have {} queued packets", n_packets);
+            log::debug(log_cat, "Skipping this flush_streams call; we still have {} queued packets", n_packets);
             return;
         }
 

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -102,7 +102,7 @@ namespace oxen::quic
 
     void Endpoint::manually_receive_packet(Packet&& pkt)
     {
-        call([this, pkt]() mutable { handle_packet(std::move(pkt)); });
+        call([this, packet = std::move(pkt)]() mutable { handle_packet(std::move(packet)); });
     }
 
     void Endpoint::_init_internals()
@@ -652,7 +652,8 @@ namespace oxen::quic
     std::optional<quic_cid> Endpoint::handle_packet_connid(const Packet& pkt)
     {
         ngtcp2_version_cid vid;
-        auto rv = ngtcp2_pkt_decode_version_cid(&vid, u8data(pkt.data), pkt.data.size(), NGTCP2_MAX_CIDLEN);
+        auto data = pkt.data<uint8_t>();
+        auto rv = ngtcp2_pkt_decode_version_cid(&vid, data.data(), data.size(), NGTCP2_MAX_CIDLEN);
 
         if (rv == NGTCP2_ERR_VERSION_NEGOTIATION)
         {  // version negotiation has not been sent yet, ignore packet
@@ -684,7 +685,8 @@ namespace oxen::quic
 
         ngtcp2_pkt_hd hdr;
 
-        auto rv = ngtcp2_accept(&hdr, u8data(pkt.data), pkt.data.size());
+        auto data = pkt.data<uint8_t>();
+        auto rv = ngtcp2_accept(&hdr, data.data(), data.size());
 
         if (rv < 0)  // catches all other possible ngtcp2 errors
         {
@@ -692,7 +694,7 @@ namespace oxen::quic
                     log_cat,
                     "Unknown packet received from {}, length={}, code={}; ignoring it.",
                     pkt.path.remote,
-                    pkt.data.size(),
+                    data.size(),
                     ngtcp2_strerror(rv));
             return nullptr;
         }

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -847,7 +847,7 @@ namespace oxen::quic
         size_t bufsize = buf.size();
         auto res = send_packets(p, buf.data(), &bufsize, ecn, n_pkts);
 
-        if (res.blocked())
+        if (res.blocked() and not _manual_routing)
         {
             socket->when_writeable([this, p, buf = std::move(buf), ecn, cb = std::move(callback)]() mutable {
                 send_or_queue_packet(p, std::move(buf), ecn, std::move(cb));
@@ -857,7 +857,7 @@ namespace oxen::quic
             callback({});
     }
 
-    void Endpoint::send_version_negotiation(const ngtcp2_version_cid& vid, const Path& p)
+    void Endpoint::send_version_negotiation(const ngtcp2_version_cid& vid, Path p)
     {
         uint8_t rint;
         gnutls_rnd(GNUTLS_RND_RANDOM, &rint, 8);

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -856,7 +856,7 @@ namespace oxen::quic
             });
         }
         else if (callback)
-            callback({});
+            callback(res);
     }
 
     void Endpoint::send_version_negotiation(const ngtcp2_version_cid& vid, Path p)

--- a/src/gnutls_creds.cpp
+++ b/src/gnutls_creds.cpp
@@ -170,23 +170,4 @@ namespace oxen::quic
     {
         return std::make_unique<GNUTLSSession>(*this, c, alpns);
     }
-
-    // void GNUTLSCreds::set_client_tls_hook(gnutls_callback func, unsigned int htype, unsigned int when, unsigned int
-    // incoming)
-    // {
-    //     client_tls_hook.cb = std::move(func);
-    //     client_tls_hook.htype = htype;
-    //     client_tls_hook.when = when;
-    //     client_tls_hook.incoming = incoming;
-    // }
-
-    // void GNUTLSCreds::set_server_tls_hook(gnutls_callback func, unsigned int htype, unsigned int when, unsigned int
-    // incoming)
-    // {
-    //     server_tls_hook.cb = std::move(func);
-    //     server_tls_hook.htype = htype;
-    //     server_tls_hook.when = when;
-    //     server_tls_hook.incoming = incoming;
-    // }
-
 }  // namespace oxen::quic

--- a/src/udp.cpp
+++ b/src/udp.cpp
@@ -781,7 +781,7 @@ namespace oxen::quic
                  {static_cast<const sockaddr*>(hdr.msg_name), hdr.msg_namelen}
 #endif
             },
-            data{data}
+            pkt_data{data}
     {
         assert(path.remote.is_ipv4() || path.remote.is_ipv6());
 

--- a/tests/011-manual_transmission.cpp
+++ b/tests/011-manual_transmission.cpp
@@ -7,7 +7,7 @@
 
 namespace oxen::quic::test
 {
-    TEST_CASE("011 - Manual Transmission: Both ends re-route", "[011][manual]")
+    TEST_CASE("011 - Manual Transmission: Both ends re-route", "[011][manual][bidi]")
     {
         auto client_established = callback_waiter{[](connection_interface&) {}};
         auto server_established = callback_waiter{[](connection_interface&) {}};
@@ -19,7 +19,6 @@ namespace oxen::quic::test
         std::future<bool> d_future = d_promise.get_future();
 
         stream_data_callback server_data_cb = [&](Stream&, bstring_view dat) {
-            log::debug(log_cat, "Calling server stream data callback... data received...");
             REQUIRE(good_msg == dat);
             d_promise.set_value(true);
         };
@@ -29,11 +28,11 @@ namespace oxen::quic::test
         Address server_local{};
         Address client_local{};
 
-        opt::manual_routing client_sender{[&](Path p, bstring_view d) {
+        opt::manual_routing client_sender{[&](const Path& p, bstring_view d) {
             server_endpoint->manually_receive_packet(Packet{p.invert(), d});
         }};
 
-        opt::manual_routing server_sender{[&](Path p, bstring_view d) {
+        opt::manual_routing server_sender{[&](const Path& p, bstring_view d) {
             client_endpoint->manually_receive_packet(Packet{p.invert(), d});
         }};
 
@@ -42,14 +41,14 @@ namespace oxen::quic::test
         server_endpoint = test_net.endpoint(server_local, server_sender, server_established);
         REQUIRE_NOTHROW(server_endpoint->listen(server_tls, server_data_cb));
 
-        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, server_local};
 
         client_endpoint = test_net.endpoint(client_local, client_sender, client_established);
 
         auto conn_interface = client_endpoint->connect(client_remote, client_tls);
 
-        CHECK(client_established.wait(1s));
-        CHECK(server_established.wait(1s));
+        CHECK(client_established.wait());
+        CHECK(server_established.wait());
 
         // client make stream and send; message displayed by server_data_cb
         auto client_stream = conn_interface->open_stream();
@@ -57,5 +56,79 @@ namespace oxen::quic::test
         REQUIRE_NOTHROW(client_stream->send(good_msg));
 
         require_future(d_future);
+    }
+
+    /** Binary test case:
+        This is designed to emulate the use case in which a manually routed endpoint is using a normal QUIC endpoint as a
+        tunnel to connect to a remote manual endpoint.
+
+        [manual client] <- manual -> [vanilla client] <- quic datagram -> [vanilla server] <- manual -> [manual server]
+
+    */
+    TEST_CASE("011 - Manual Transmission: Binary endpoints", "[011][manual][binary]")
+    {
+        auto vanilla_client_established = callback_waiter{[](connection_interface&) {}};
+        auto manual_client_established = callback_waiter{[](connection_interface&) {}};
+        auto vanilla_server_established = callback_waiter{[](connection_interface&) {}};
+        auto manual_server_established = callback_waiter{[](connection_interface&) {}};
+
+        Network test_net{};
+
+        std::shared_ptr<connection_interface> vanilla_client_ci, vanilla_server_ci, manual_client_ci;
+
+        std::shared_ptr<Endpoint> manual_client, vanilla_client, manual_server, vanilla_server;
+
+        Address manual_server_addr{}, vanilla_server_addr{};
+        Address manual_client_addr{}, vanilla_client_addr{};
+
+        opt::enable_datagrams enable_dgrams{};
+
+        dgram_data_callback vanilla_client_recv_dgram_cb = [&](dgram_interface&, bstring data) {
+            manual_client->manually_receive_packet(Packet{Path{manual_client_addr, manual_server_addr}, std::move(data)});
+        };
+
+        dgram_data_callback vanilla_server_recv_dgram_cb = [&](dgram_interface&, bstring data) {
+            manual_server->manually_receive_packet(Packet{Path{manual_server_addr, manual_client_addr}, std::move(data)});
+        };
+
+        opt::manual_routing manual_client_sender{
+                [&](const Path&, bstring_view d) { vanilla_client_ci->send_datagram(bstring{d}); }};
+
+        opt::manual_routing manual_server_sender{
+                [&](const Path&, bstring_view d) { vanilla_server_ci->send_datagram(bstring{d}); }};
+
+        auto [client_tls, server_tls] = defaults::tls_creds_from_ed_keys();
+
+        vanilla_server = test_net.endpoint(
+                vanilla_server_addr, vanilla_server_established, enable_dgrams, vanilla_server_recv_dgram_cb);
+        vanilla_client = test_net.endpoint(
+                vanilla_client_addr, vanilla_client_established, enable_dgrams, vanilla_client_recv_dgram_cb);
+        manual_client = test_net.endpoint(manual_client_addr, manual_client_sender, manual_client_established);
+        manual_server = test_net.endpoint(manual_server_addr, manual_server_sender, manual_server_established);
+
+        REQUIRE_NOTHROW(vanilla_server->listen(server_tls));
+        REQUIRE_NOTHROW(manual_server->listen(server_tls));
+
+        RemoteAddress vanilla_client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, vanilla_server->local().port()};
+
+        vanilla_client_ci = vanilla_client->connect(vanilla_client_remote, client_tls);
+
+        CHECK(vanilla_client_established.wait());
+        CHECK(vanilla_server_established.wait());
+
+        std::this_thread::sleep_for(25ms);
+
+        vanilla_server_ci = vanilla_server->get_all_conns(Direction::INBOUND).front();
+
+        CHECK(vanilla_server_ci);
+
+        std::this_thread::sleep_for(25ms);
+
+        RemoteAddress manual_client_remote{defaults::SERVER_PUBKEY, manual_server_addr};
+
+        manual_client_ci = manual_client->connect(manual_client_remote, client_tls);
+
+        CHECK(manual_client_established.wait());
+        CHECK(manual_server_established.wait());
     }
 }  //  namespace oxen::quic::test

--- a/tests/011-manual_transmission.cpp
+++ b/tests/011-manual_transmission.cpp
@@ -1,0 +1,61 @@
+#include <catch2/catch_test_macros.hpp>
+#include <oxen/quic.hpp>
+#include <oxen/quic/gnutls_crypto.hpp>
+#include <thread>
+
+#include "utils.hpp"
+
+namespace oxen::quic::test
+{
+    TEST_CASE("011 - Manual Transmission: Both ends re-route", "[011][manual]")
+    {
+        auto client_established = callback_waiter{[](connection_interface&) {}};
+        auto server_established = callback_waiter{[](connection_interface&) {}};
+
+        Network test_net{};
+        auto good_msg = "hello from the other siiiii-iiiiide"_bsv;
+
+        std::promise<bool> d_promise;
+        std::future<bool> d_future = d_promise.get_future();
+
+        stream_data_callback server_data_cb = [&](Stream&, bstring_view dat) {
+            log::debug(log_cat, "Calling server stream data callback... data received...");
+            REQUIRE(good_msg == dat);
+            d_promise.set_value(true);
+        };
+
+        std::shared_ptr<Endpoint> client_endpoint, server_endpoint;
+
+        Address server_local{};
+        Address client_local{};
+
+        opt::manual_routing client_sender{[&](Path p, bstring_view d) {
+            server_endpoint->manually_receive_packet(Packet{p.invert(), d});
+        }};
+
+        opt::manual_routing server_sender{[&](Path p, bstring_view d) {
+            client_endpoint->manually_receive_packet(Packet{p.invert(), d});
+        }};
+
+        auto [client_tls, server_tls] = defaults::tls_creds_from_ed_keys();
+
+        server_endpoint = test_net.endpoint(server_local, server_sender, server_established);
+        REQUIRE_NOTHROW(server_endpoint->listen(server_tls, server_data_cb));
+
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+
+        client_endpoint = test_net.endpoint(client_local, client_sender, client_established);
+
+        auto conn_interface = client_endpoint->connect(client_remote, client_tls);
+
+        CHECK(client_established.wait(1s));
+        CHECK(server_established.wait(1s));
+
+        // client make stream and send; message displayed by server_data_cb
+        auto client_stream = conn_interface->open_stream();
+
+        REQUIRE_NOTHROW(client_stream->send(good_msg));
+
+        require_future(d_future);
+    }
+}  //  namespace oxen::quic::test

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,6 +37,7 @@ if(LIBQUIC_BUILD_TESTS)
         008-conn_hooks.cpp
         009-alpns.cpp
         010-migration.cpp
+        011-manual_transmission.cpp
 
         main.cpp
         case_logger.cpp


### PR DESCRIPTION
- Now you can provide a callback that bypasses sending packets through the UDP socket
- This also disables creation of the UDP socket entirely
- The application will need to take responsibility for passing packets into the Endpoint via Endpoint::manually_receive_packet(...)