### PR TITLE
Fix race in simultaneous connection/set_close_quietly test

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -77,7 +77,7 @@ local generic_build(jobs, build_type, lto, werror, cmake_extra, local_mirror, te
         ]
         + (if tests then [
              'cd build',
-             (if gdb then '../utils/ci/drone-gdb.sh ' else '') + './tests/alltests --success --log-level debug --no-ipv6 --colour-mode ansi',
+             (if gdb then '../utils/ci/drone-gdb.sh ' else '') + './tests/alltests --success -T --log-level debug --no-ipv6 --colour-mode ansi',
              'cd ..',
            ] else []);
 


### PR DESCRIPTION
The key verification callback here can rarely fire *before* the assignment to `server_ci` and `client_ci` complete, which will segfault because the `server/client_ci` won't be set yet for the lambda to invoke.

This fixes it with a mutex to delay the body of the key verification callbacks until assignment to the two `..._ci` variables is complete.

Also includes a commit to enable test tracing on every `alltests` invocation in CI.