### PR TITLE
Bidir alpns

### DIFF
--- a/include/oxen/quic/endpoint.hpp
+++ b/include/oxen/quic/endpoint.hpp
@@ -237,6 +237,7 @@ namespace oxen::quic
         void handle_ep_opt(opt::enable_datagrams dc);
         void handle_ep_opt(opt::outbound_alpns alpns);
         void handle_ep_opt(opt::inbound_alpns alpns);
+        void handle_ep_opt(opt::alpns alpns);
         void handle_ep_opt(opt::handshake_timeout timeout);
         void handle_ep_opt(dgram_data_callback dgram_cb);
         void handle_ep_opt(connection_established_callback conn_established_cb);

--- a/include/oxen/quic/endpoint.hpp
+++ b/include/oxen/quic/endpoint.hpp
@@ -38,7 +38,7 @@ namespace oxen::quic
     static constexpr void check_for_tls_creds()
     {
         static_assert(
-                (0 + ... + std::is_convertible_v<remove_cvref_t<Opt>, std::shared_ptr<TLSCreds>>) == 1,
+                (0 + ... + std::is_convertible_v<std::remove_cvref_t<Opt>, std::shared_ptr<TLSCreds>>) == 1,
                 "Endpoint listen/connect require exactly one std::shared_ptr<TLSCreds> argument");
     }
 

--- a/include/oxen/quic/gnutls_crypto.hpp
+++ b/include/oxen/quic/gnutls_crypto.hpp
@@ -154,7 +154,7 @@ namespace oxen::quic
 #endif
                 source = std::move(path);
             }
-            else if (bool pem = starts_with(input, "-----"); pem || (starts_with(input, "\x30") && input.size() >= 48))
+            else if (bool pem = input.starts_with("-----"); pem || (input.starts_with("\x30") && input.size() >= 48))
             {
                 source = std::move(input);
                 update_datum();

--- a/include/oxen/quic/iochannel.hpp
+++ b/include/oxen/quic/iochannel.hpp
@@ -95,7 +95,7 @@ namespace oxen::quic
         template <
                 typename Class,
                 typename T,
-                typename Ret = remove_cvref_t<T>,
+                typename Ret = std::remove_cvref_t<T>,
                 typename EP = std::enable_if_t<std::is_base_of_v<IOChannel, Class>, Endpoint>>
         Ret call_get_accessor(T (Class::*getter)() const) const
         {
@@ -106,7 +106,7 @@ namespace oxen::quic
         // Wraps a Connection accessor member function pointer in a call_get for synchronous access
         // that always returns by value (even if the member function returns by reference) through
         // the IOChannel's connection pointer.  Throws if the Connection doesn't exist anymore.
-        template <typename T, typename Ret = remove_cvref_t<T>, typename EP = Endpoint>
+        template <typename T, typename Ret = std::remove_cvref_t<T>, typename EP = Endpoint>
         Ret call_get_accessor(T (Connection::*getter)() const) const
         {
             // This do-nothing static cast to force deferred instantiation until later on (when the

--- a/include/oxen/quic/opt.hpp
+++ b/include/oxen/quic/opt.hpp
@@ -89,6 +89,9 @@ namespace oxen::quic::opt
     {
         std::vector<ustring> alpns;
         explicit outbound_alpns(std::vector<ustring> alpns = {}) : alpns{std::move(alpns)} {}
+
+        // Convenience wrapper that sets a single ALPN value from a regular string:
+        explicit outbound_alpns(std::string_view alpn) : outbound_alpns{{ustring{to_usv(alpn)}}} {}
     };
 
     // supported ALPNs for inbound connections
@@ -96,6 +99,20 @@ namespace oxen::quic::opt
     {
         std::vector<ustring> alpns;
         explicit inbound_alpns(std::vector<ustring> alpns = {}) : alpns{std::move(alpns)} {}
+
+        // Convenience wrapper that sets a single ALPN value from a regular string:
+        explicit inbound_alpns(std::string_view alpn) : inbound_alpns{{ustring{to_usv(alpn)}}} {}
+    };
+
+    // Sets the inbound and outbound ALPNs simulatneous to the same value(s).  This is equivalent to
+    // passing outbound_alpns and inbound_alps, separately, with the same vector argument.
+    struct alpns
+    {
+        std::vector<ustring> inout_alpns;
+        explicit alpns(std::vector<ustring> alpns = {}) : inout_alpns{std::move(alpns)} {}
+
+        // Convenience wrapper that sets a single ALPN value from a regular string:
+        explicit alpns(std::string_view alpn) : alpns{{ustring{to_usv(alpn)}}} {}
     };
 
     struct handshake_timeout

--- a/include/oxen/quic/utils.hpp
+++ b/include/oxen/quic/utils.hpp
@@ -171,18 +171,6 @@ namespace oxen::quic
         return {reinterpret_cast<const char*>(x.data()), x.size()};
     }
 
-    // Quasi-backport of C++20 str.starts_with/ends_with
-    template <typename T>
-    using remove_cvref_t = std::remove_cv_t<std::remove_reference_t<T>>;
-    inline constexpr bool starts_with(std::string_view str, std::string_view prefix)
-    {
-        return prefix.size() <= str.size() && str.substr(0, prefix.size()) == prefix;
-    }
-    inline constexpr bool ends_with(std::string_view str, std::string_view suffix)
-    {
-        return suffix.size() <= str.size() && str.substr(str.size() - suffix.size()) == suffix;
-    }
-
     std::chrono::steady_clock::time_point get_time();
     std::chrono::nanoseconds get_timestamp();
 

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -45,6 +45,12 @@ namespace oxen::quic
         inbound_alpns = std::move(alpns.alpns);
     }
 
+    void Endpoint::handle_ep_opt(opt::alpns alpns)
+    {
+        inbound_alpns = std::move(alpns.inout_alpns);
+        outbound_alpns = inbound_alpns;
+    }
+
     void Endpoint::handle_ep_opt(opt::handshake_timeout timeout)
     {
         handshake_timeout = timeout.timeout;

--- a/tests/009-alpns.cpp
+++ b/tests/009-alpns.cpp
@@ -113,6 +113,40 @@ namespace oxen::quic::test
             REQUIRE(client_established2.wait());
             REQUIRE(conn2->selected_alpn() == "relay"_usv);
         }
+
+        SECTION("Bidirectional ALPN incoming")
+        {
+            opt::alpns server_alpns{"special-alpn"};
+
+            auto server_endpoint = test_net.endpoint(server_local, server_alpns, timeout);
+            REQUIRE_NOTHROW(server_endpoint->listen(server_tls));
+
+            RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+
+            opt::outbound_alpns client_alpns{{"foobar"_us}};
+            auto client_endpoint = test_net.endpoint(client_local, client_established, client_closed, client_alpns, timeout);
+
+            auto conn = client_endpoint->connect(client_remote, client_tls);
+            CHECK(client_closed.wait(2s));
+            REQUIRE_FALSE(client_established.is_ready());
+        }
+
+        SECTION("Bidirectional ALPN outgoing")
+        {
+            opt::inbound_alpns server_alpns{"special-alpn"};
+
+            auto server_endpoint = test_net.endpoint(server_local, server_alpns, timeout);
+            REQUIRE_NOTHROW(server_endpoint->listen(server_tls));
+
+            RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+
+            opt::alpns client_alpns{"special-alpn"};
+            auto client_endpoint = test_net.endpoint(client_local, client_established, client_alpns, timeout);
+
+            auto conn = client_endpoint->connect(client_remote, client_tls);
+            REQUIRE(client_established.wait());
+            REQUIRE(conn->selected_alpn() == "special-alpn"_usv);
+        }
     }
 
 }  // namespace oxen::quic::test


### PR DESCRIPTION
Fixes #103

Adds `opt::alpns{...}` which is equivalent to specifying both `opt::inbound_alpns{...}` and `outbound_alpns{...}` but is very often what a bidirectional endpoint needs (and in many cases is fine even for a unidirectional endpoint) and thus simplifies what calling code needs to do to specify its ALPN.

This also adds a convenience constructor to all three alpns options that allows passing a single string-like (not `ustring`), to simplify invoking the typical case where there is just a single plain text ALPN value.

Thus a typical ALPNs-providing endpoint invocation can be simplified from:
```C++
    net->endpoint(...,
        opt::inbound_alpns{{"MyALPN"_us}},
        opt::outbound_alpns{{"MyALPN"_us}});
```
to just:
```C++
    net->endpoint(..., opt::alpns{"MyALPN"});
```
but leaves the separate opt::in/outbound_alpns for advanced cases where the ALPNs need to differ based on direction.


There's also a commit in here to drop a couple C++20 backports (starts_width/ends_with and remove_cvref_t) that are no longer needed.  (These seem random, but came along with a change I was making for the other commit here that ended up not being needed -- but are still worthwhile keeping).