### PR TITLE
Allowing specifying a dgram data callback in listen/connect

### DIFF
--- a/include/oxen/quic/context.hpp
+++ b/include/oxen/quic/context.hpp
@@ -42,6 +42,7 @@ namespace oxen::quic
         stream_open_callback stream_open_cb;
         stream_close_callback stream_close_cb;
         stream_constructor_callback stream_construct_cb;
+        dgram_data_callback dgram_data_cb;
         connection_established_callback conn_established_cb;
         connection_closed_callback conn_closed_cb;
         user_config config{};
@@ -68,6 +69,8 @@ namespace oxen::quic
         void handle_ioctx_opt(stream_open_callback func);
         void handle_ioctx_opt(stream_close_callback func);
         void handle_ioctx_opt(stream_constructor_callback func);
+        // Overrides the datagram callback specified at the endpoint level, if given.
+        void handle_ioctx_opt(dgram_data_callback func);
         void handle_ioctx_opt(connection_established_callback func);
         void handle_ioctx_opt(connection_closed_callback func);
 

--- a/include/oxen/quic/opt.hpp
+++ b/include/oxen/quic/opt.hpp
@@ -93,9 +93,6 @@ namespace oxen::quic
         /// constructor. Buffer size is subdivided amongst 4 equally sized buffer rows, so the bufsize
         /// must be perfectly divisible by 4
         ///
-        /// In some use cases, the user may want the receive data as a string view or a string literal.
-        /// The default is string literal; setting
-        ///
         /// The max size of a transmittable datagram can be queried directly from connection_interface::
         /// get_max_datagram_size(). At connection initialization, ngtcp2 will default this value to 1200.
         /// The actual value is negotiated upwards via path discovery, reaching a theoretical maximum of

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -1543,7 +1543,8 @@ namespace oxen::quic
                                ? is_outbound() ? std::move(context->conn_closed_cb) : context->conn_closed_cb
                                : nullptr;
 
-        datagrams = _endpoint.make_shared<DatagramIO>(*this, _endpoint, ep.dgram_recv_cb);
+        datagrams = _endpoint.make_shared<DatagramIO>(
+                *this, _endpoint, context->dgram_data_cb ? context->dgram_data_cb : ep.dgram_recv_cb);
         pseudo_stream = _endpoint.make_shared<Stream>(*this, _endpoint);
         pseudo_stream->_stream_id = -1;
 

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -66,6 +66,12 @@ namespace oxen::quic
         stream_construct_cb = std::move(func);
     }
 
+    void IOContext::handle_ioctx_opt(dgram_data_callback func)
+    {
+        log::trace(log_cat, "IO context stored datagram data callback");
+        dgram_data_cb = std::move(func);
+    }
+
     void IOContext::handle_ioctx_opt(connection_established_callback func)
     {
         log::trace(log_cat, "IO context stored connection established callback");


### PR DESCRIPTION
It felt restrictive (and a little unintuitive) to have to specify the dgram callback at the endpoint because then I can't have a different callback for individual connections or for incoming versus outgoing connections.  It also feels a little weird because a default stream data callback, in contrast, is only at the listen/connect level but not at the endpoint level.

This commit allows also specifying the datagram callback to `connect()` or `listen()` -- if specified as such, it takes precedence over the one given to endpoint.