### PR TITLE
BTRequestStream: fire callbacks if invoked on closing stream

### DIFF
--- a/include/oxen/quic/connection.hpp
+++ b/include/oxen/quic/connection.hpp
@@ -241,6 +241,14 @@ namespace oxen::quic
         virtual size_t get_max_datagram_size_impl() = 0;
     };
 
+    // Exception thrown if attempting to open or queue a stream on a Connection that is closing or
+    // closed.
+    class connection_closed_error : public std::runtime_error
+    {
+      public:
+        using std::runtime_error::runtime_error;
+    };
+
     class Connection : public connection_interface
     {
         friend class TestHelper;

--- a/include/oxen/quic/connection.hpp
+++ b/include/oxen/quic/connection.hpp
@@ -241,14 +241,6 @@ namespace oxen::quic
         virtual size_t get_max_datagram_size_impl() = 0;
     };
 
-    // Exception thrown if attempting to open or queue a stream on a Connection that is closing or
-    // closed.
-    class connection_closed_error : public std::runtime_error
-    {
-      public:
-        using std::runtime_error::runtime_error;
-    };
-
     class Connection : public connection_interface
     {
         friend class TestHelper;

--- a/include/oxen/quic/stream.hpp
+++ b/include/oxen/quic/stream.hpp
@@ -78,12 +78,7 @@ namespace oxen::quic
                 data_callback(*this, data);
         }
 
-        virtual void closed(uint64_t app_code)
-        {
-            if (close_callback)
-                close_callback(*this, app_code);
-            _conn = nullptr;
-        }
+        virtual void closed(uint64_t app_code);
 
         // Called immediately after set_ready so that a subclass can do thing as soon as the stream
         // becomes ready. The default does nothing.

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -635,6 +635,8 @@ namespace oxen::quic
             std::function<std::shared_ptr<Stream>(Connection& c, Endpoint& e)> make_stream)
     {
         return _endpoint.call_get([this, &make_stream]() {
+            if (is_closing() || is_draining())
+                throw connection_closed_error{"Unable to queue incoming stream: connection is closed"};
             std::shared_ptr<Stream> stream;
             if (make_stream)
                 stream = make_stream(*this, _endpoint);
@@ -661,6 +663,8 @@ namespace oxen::quic
             std::function<std::shared_ptr<Stream>(Connection& c, Endpoint& e)> make_stream)
     {
         return _endpoint.call_get([this, &make_stream]() {
+            if (is_closing() || is_draining())
+                throw connection_closed_error{"Unable to open a stream: connection is closed"};
             std::shared_ptr<Stream> stream;
             if (make_stream)
                 stream = make_stream(*this, _endpoint);

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -93,6 +93,24 @@ namespace oxen::quic
         });
     }
 
+    void Stream::closed(uint64_t app_code)
+    {
+        if (close_callback)
+        {
+            try
+            {
+                close_callback(*this, app_code);
+            }
+            catch (const std::exception& e)
+            {
+                log::error(log_cat, "Uncaught exception in stream close callback: {}", e.what());
+            }
+        }
+
+        _conn = nullptr;
+        _is_closing = _is_shutdown = true;
+    }
+
     void Stream::append_buffer(bstring_view buffer, std::shared_ptr<void> keep_alive)
     {
         log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);

--- a/tests/004-streams.cpp
+++ b/tests/004-streams.cpp
@@ -1016,7 +1016,8 @@ namespace oxen::quic::test
 
         auto [client_tls, server_tls] = defaults::tls_creds_from_ed_keys();
 
-        // The server is going to close the connection instan
+        // The server is going to close the connection instance right away to cause the client's
+        // connection to close (almost) right away.
         auto server_endpoint = test_net.endpoint(server_local, [](connection_interface& ci) { ci.close_connection(123); });
         server_endpoint->listen(server_tls);
 
@@ -1038,6 +1039,47 @@ namespace oxen::quic::test
 
         REQUIRE(cmd_cb.wait());
         CHECK(got_timeout);
+    }
+
+    TEST_CASE("004 - Exceptions when opening/queueing streams on a closed connection", "[004][streams][dead][exception]")
+    {
+        // Related to the above test case, if you opened or queued a stream in a race with the
+        // connection closing then whether or not the stream's close callback fires depended on
+        // whether or not the open/queue won the race to the event loop before the connection close
+        // gets processed.
+        //
+        // We avoid it now by throwing if you attempt to queue or open a stream on a
+        // closed/closing/draining connection.
+        //
+        auto client_established = callback_waiter{[](connection_interface&) {}};
+        auto client_closed = callback_waiter{[](connection_interface&, uint64_t) {}};
+
+        Network test_net{};
+
+        Address server_local{};
+        Address client_local{};
+
+        auto [client_tls, server_tls] = defaults::tls_creds_from_ed_keys();
+
+        // Close right away so that the client closes
+        auto server_endpoint = test_net.endpoint(server_local, [](connection_interface& ci) { ci.close_connection(123); });
+        server_endpoint->listen(server_tls);
+
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+
+        auto client_endpoint = test_net.endpoint(client_local, client_established);
+        auto conn = client_endpoint->connect(client_remote, client_tls, client_closed);
+
+        // This is our simulated race: in the real world we don't know the close has happened yet
+        // (and a close callback like the one we're using here in the test suite won't work: the
+        // close could easily happen after we call `->command` below, but before the command
+        // actually hits the libquic event loop).
+        REQUIRE(client_closed.wait());
+
+        CHECK_THROWS_AS(conn->open_stream(), quic::connection_closed_error);
+        CHECK_THROWS_AS(conn->queue_incoming_stream(), quic::connection_closed_error);
+        CHECK(conn->num_streams_active() == 0);
+        CHECK(conn->num_streams_pending() == 0);
     }
 
 }  // namespace oxen::quic::test


### PR DESCRIPTION
There is a race condition possible where a connection closes before the application notices, but meanwhile the application submits a command.

If the connection close happens before the command, then the close triggers all the stream close callbacks, but then the subsequent `command()` gets added to `sent_reqs` but never fired (since we only fire closed callbacks once).

This addresses it by firing the callback (immediately) if a command with a callback gets invoked on a closed connection, just as would have happened if the `command()` arrived just *before* the connection closed.

(The `REQUIRE(cmd_cb.wait());` in the test added here fails without the other changes made here).

This also makes some other small changes closely related to this:

- rearranges the BTRequestStream closed() call to use the superclass method to invoke the close_callback, rather than doing it itself.
- moved the try/catch around the stream close callback from BTRequestStream into Stream (which didn't have one).
- also set `_is_shutdown` and `_is_closing` to true in the Stream::closed so that `is_closing()` can be used to determine that the Stream was closed.  Previously these were only set for specifically closed streams, but not streams closed implicitly by a connection closing.