### PR TITLE
Datagram remote_key getter

### DIFF
--- a/include/oxen/quic/datagram.hpp
+++ b/include/oxen/quic/datagram.hpp
@@ -26,6 +26,8 @@ namespace oxen::quic
 
         std::shared_ptr<connection_interface> get_conn_interface();
 
+        ustring remote_key() const;
+
         template <
                 typename CharType,
                 std::enable_if_t<sizeof(CharType) == 1 && !std::is_same_v<CharType, std::byte>, int> = 0>

--- a/src/datagram.cpp
+++ b/src/datagram.cpp
@@ -34,15 +34,18 @@ namespace oxen::quic
         log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
         return false;
     }
+
     bool DatagramIO::sent_fin() const
     {
         log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
         return false;
     }
+
     void DatagramIO::set_fin(bool)
     {
         log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
     }
+
     size_t DatagramIO::unsent_impl() const
     {
         log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
@@ -53,14 +56,17 @@ namespace oxen::quic
             sum += entry.size();
         return sum;
     }
+
     bool DatagramIO::has_unsent_impl() const
     {
         return not is_empty_impl();
     }
+
     void DatagramIO::wrote(size_t)
     {
         log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
     }
+
     std::vector<ngtcp2_vec> DatagramIO::pending()
     {
         log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
@@ -72,6 +78,11 @@ namespace oxen::quic
     std::shared_ptr<connection_interface> dgram_interface::get_conn_interface()
     {
         return ci.shared_from_this();
+    }
+
+    ustring dgram_interface::remote_key() const
+    {
+        return ustring{ci.remote_key()};
     }
 
     void dgram_interface::reply(bstring_view data, std::shared_ptr<void> keep_alive)


### PR DESCRIPTION
- Added method to get `remote_key` from `dgram_interface` wrapper. In lokinet, this is the upstream RouterID; it is easier to grab it directly from the `dgram_interface` rather than having to create an `std::shared_ptr<connection_interface>` every time
- It would be weird to return a ustring_view like the `connection_interface` method being called, as the `dgram_interface` makes no assurances of keeping the underlying connection objects alive
- Making a copy of the ustring ensures that we are not pointing a view at data that we are not managing