### PR TITLE
Custom client SCID's

### DIFF
--- a/include/oxen/quic/connection.hpp
+++ b/include/oxen/quic/connection.hpp
@@ -36,6 +36,7 @@ namespace oxen::quic
         virtual std::shared_ptr<Stream> open_stream_impl(
                 std::function<std::shared_ptr<Stream>(Connection& c, Endpoint& e)> make_stream) = 0;
         virtual std::shared_ptr<Stream> get_stream_impl(int64_t id) = 0;
+        virtual ustring initial_client_scid_impl() const = 0;
 
       public:
         virtual ustring_view selected_alpn() const = 0;
@@ -158,6 +159,7 @@ namespace oxen::quic
         virtual bool is_inbound() const = 0;
         virtual bool is_outbound() const = 0;
         virtual std::string direction_str() = 0;
+        ustring initial_client_scid();
 
         // Non-virtual base class wrappers for the virtual methods of the same name with _impl
         // appended (e.g.  path_impl); these versions in the base class wrap the _impl call in a
@@ -364,6 +366,10 @@ namespace oxen::quic
         // might be shared pointers in application space that keep the connection and/or stream
         // alive after it gets dropped from libquic internal structures).
         void drop_streams();
+
+        // Returns the initial scid chosen by the client, which will be the value of whatever was passed in
+        // opt::outbound_scid on the client's initiation of the connection
+        ustring initial_client_scid_impl() const override;
 
       private:
         // private Constructor (publicly construct via `make_conn` instead, so that we can properly

--- a/include/oxen/quic/connection_ids.hpp
+++ b/include/oxen/quic/connection_ids.hpp
@@ -9,7 +9,6 @@ extern "C"
 
 #include "formattable.hpp"
 #include "types.hpp"
-#include "utils.hpp"
 
 namespace oxen::quic
 {

--- a/include/oxen/quic/context.hpp
+++ b/include/oxen/quic/context.hpp
@@ -29,6 +29,8 @@ namespace oxen::quic
         bool split_packet{false};
         // splitting policy
         Splitting policy{Splitting::NONE};
+        // outbound scid
+        std::optional<quic_cid> scid{std::nullopt};
 
         user_config() = default;
     };
@@ -65,6 +67,7 @@ namespace oxen::quic
         void handle_ioctx_opt(opt::keep_alive ka);
         void handle_ioctx_opt(opt::idle_timeout ito);
         void handle_ioctx_opt(opt::handshake_timeout hto);
+        void handle_ioctx_opt(opt::outbound_scid scid);
         void handle_ioctx_opt(stream_data_callback func);
         void handle_ioctx_opt(stream_open_callback func);
         void handle_ioctx_opt(stream_close_callback func);

--- a/include/oxen/quic/endpoint.hpp
+++ b/include/oxen/quic/endpoint.hpp
@@ -39,7 +39,7 @@ namespace oxen::quic
     {
         static_assert(
                 (0 + ... + std::is_convertible_v<std::remove_cvref_t<Opt>, std::shared_ptr<TLSCreds>>) == 1,
-                "Endpoint listen/connect require exactly one std::shared_ptr<TLSCreds> argument");
+                "Endpoint::{listen,connect}(...) require exactly one std::shared_ptr<TLSCreds> argument");
     }
 
     class Endpoint : public std::enable_shared_from_this<Endpoint>
@@ -108,8 +108,10 @@ namespace oxen::quic
 
                     for (;;)
                     {
+                        auto scid = outbound_ctx->config.scid.value_or(quic_cid::random());
+
                         // emplace random CID into lookup keyed to unique reference ID
-                        if (auto [it_a, res_a] = conn_lookup.emplace(quic_cid::random(), next_rid); res_a)
+                        if (auto [it_a, res_a] = conn_lookup.emplace(scid, next_rid); res_a)
                         {
                             qcid = it_a->first;
 

--- a/include/oxen/quic/format.hpp
+++ b/include/oxen/quic/format.hpp
@@ -11,6 +11,7 @@
 #include <iostream>
 
 #include "formattable.hpp"
+#include "utils.hpp"
 
 namespace oxen::quic
 {

--- a/include/oxen/quic/formattable.hpp
+++ b/include/oxen/quic/formattable.hpp
@@ -2,19 +2,11 @@
 
 #include <string_view>
 
-// GCC before 10 requires a "bool" keyword in concept; this CONCEPT_COMPAT is empty by default, but
-// expands to bool if under such a GCC.
-#if (!(defined(__clang__)) && defined(__GNUC__) && __GNUC__ < 10)
-#define CONCEPT_COMPAT bool
-#else
-#define CONCEPT_COMPAT
-#endif
-
 namespace oxen::quic
 {
     // Types can opt-in to being fmt-formattable by ensuring they have a ::to_string() method defined
     template <typename T>
-    concept CONCEPT_COMPAT ToStringFormattable = requires(T a) {
+    concept ToStringFormattable = requires(T a) {
         {
             a.to_string()
         } -> std::convertible_to<std::string_view>;

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -474,6 +474,13 @@ namespace oxen::quic
         return tls_session.get();
     }
 
+    ustring Connection::initial_client_scid_impl() const
+    {
+        auto ret = _is_outbound ? _source_cid.to_string() : _dest_cid.to_string();
+        auto reusv = to_usv(ret);
+        return ustring{reusv.data(), reusv.find_first_of('\0')};
+    }
+
     void Connection::halt_events()
     {
         log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
@@ -1756,6 +1763,11 @@ namespace oxen::quic
                 stream->check_timeouts();
         for (const auto& s : pending_streams)
             s->check_timeouts();
+    }
+
+    ustring connection_interface::initial_client_scid()
+    {
+        return endpoint().call_get([this]() { return initial_client_scid_impl(); });
     }
 
     size_t connection_interface::num_streams_active()

--- a/src/connection_ids.cpp
+++ b/src/connection_ids.cpp
@@ -15,7 +15,12 @@ namespace oxen::quic
 
     std::string quic_cid::to_string() const
     {
-        return oxenc::to_hex(data, data + datalen);
+        if (oxenc::is_hex(data, data + datalen))
+        {
+            return oxenc::to_hex(data, data + datalen);
+        }
+        else
+            return {data, data + datalen};
     }
 
     quic_cid quic_cid::random()

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -42,6 +42,14 @@ namespace oxen::quic
         log::trace(log_cat, "User passed connection handshake_timeout config value: {}", config.handshake_timeout->count());
     }
 
+    void IOContext::handle_ioctx_opt(opt::outbound_scid scid)
+    {
+        if (dir == Direction::INBOUND)
+            throw std::runtime_error{"Inbound connection contexts cannot store an outbound scid!"};
+
+        config.scid.emplace(scid);
+    }
+
     void IOContext::handle_ioctx_opt(stream_data_callback func)
     {
         log::trace(log_cat, "IO context stored stream close callback");


### PR DESCRIPTION
Endpoints can now specify a custom SCID to set for the initial connection attempt. This can be accessed by the receiving remote, and can be used to coordinate information in a reliable (not in the transport params) way