### PR TITLE
Stream buffer watermarking

### DIFF
--- a/include/oxen/quic/stream.hpp
+++ b/include/oxen/quic/stream.hpp
@@ -80,6 +80,17 @@ namespace oxen::quic
         // Do not call this function from within a watermark callback!
         bool has_watermarks() const;
 
+        /** Stream Pause:
+            - Applications can call `::pause()` to stop extending the max stream data offset. This has the effect of limiting
+                the inflow by signalling to the sender that they should pause
+            - This is reverted by invoking `::resume()`
+        */
+        void pause();
+
+        void resume();
+
+        bool is_paused() const;
+
         // These public methods are synchronized so that they can be safely called from outside the
         // libquic main loop thread.
         bool available() const;
@@ -133,9 +144,12 @@ namespace oxen::quic
         bool _is_shutdown{false};
         bool _sent_fin{false};
         bool _ready{false};
+        bool _paused{false};
         int64_t _stream_id;
 
-        bool _be_water{false};
+        size_t _paused_offset{0};
+
+        bool _is_watermarked{false};
 
         size_t _high_mark{0};
         size_t _low_mark{0};

--- a/include/oxen/quic/stream.hpp
+++ b/include/oxen/quic/stream.hpp
@@ -13,6 +13,7 @@
 #include "connection_ids.hpp"
 #include "error.hpp"
 #include "iochannel.hpp"
+#include "opt.hpp"
 #include "types.hpp"
 #include "utils.hpp"
 
@@ -55,6 +56,29 @@ namespace oxen::quic
         int64_t stream_id() const override { return _stream_id; }
 
         const ConnectionID reference_id;
+
+        /** Buffer Watermarking:
+            - Applications can call `::set_watermark(...)` to implement logic to be executed at states dictated by the number
+                of bytes currently unsent.
+            - Application must pass `low` and `high` watermark amounts; an execute-on-low callback can be passed with or
+                without an execute-on-high callback (and vice versa)
+                - The execute-on-low callback will not be executed until the buffer state rises above the `high` value; it
+                    will not be executed again until the buffer state rises once more above the `high` value
+                - The execute-on-high callback will not be executed until the buffer state drops below the `low` value; it
+                    will not be executed again until the buffer state drops once more below the `low` value
+            - Callbacks can be passed with an optional boolean in their opt:: wrapper, indicating "clear after execution";
+                this will ensure the callback is only executed ONCE before being cleared. The default behavior is repeated
+                callback execution
+            - Invoking this function repeatedly will overwrite any currently set thresholds and callbacks
+        */
+        void set_watermark(
+                size_t low, size_t high, std::optional<opt::watermark> low_hook, std::optional<opt::watermark> high_hook);
+
+        // Clears any currently set watermarks on this stream object
+        void clear_watermarks();
+
+        // Do not call this function from within a watermark callback!
+        bool has_watermarks() const;
 
         // These public methods are synchronized so that they can be safely called from outside the
         // libquic main loop thread.
@@ -110,6 +134,17 @@ namespace oxen::quic
         bool _sent_fin{false};
         bool _ready{false};
         int64_t _stream_id;
+
+        bool _be_water{false};
+
+        size_t _high_mark{0};
+        size_t _low_mark{0};
+
+        bool _high_primed{false};
+        bool _low_primed{true};
+
+        opt::watermark _high_water;
+        opt::watermark _low_water;
 
         void wrote(size_t bytes) override;
 

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -1161,6 +1161,9 @@ namespace oxen::quic
         const bool was_closing = stream._is_closing;
         stream._is_closing = stream._is_shutdown = true;
 
+        if (stream._be_water)
+            stream.clear_watermarks();
+
         if (!was_closing)
         {
             log::trace(log_cat, "Invoking stream close callback");

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -1161,7 +1161,7 @@ namespace oxen::quic
         const bool was_closing = stream._is_closing;
         stream._is_closing = stream._is_shutdown = true;
 
-        if (stream._be_water)
+        if (stream._is_watermarked)
             stream.clear_watermarks();
 
         if (!was_closing)
@@ -1305,7 +1305,10 @@ namespace oxen::quic
         }
         else
         {
-            ngtcp2_conn_extend_max_stream_offset(conn.get(), id, data.size());
+            if (str->_paused)
+                str->_paused_offset += data.size();
+            else
+                ngtcp2_conn_extend_max_stream_offset(conn.get(), id, data.size());
             ngtcp2_conn_extend_max_offset(conn.get(), data.size());
         }
 

--- a/tests/012-watermarks.cpp
+++ b/tests/012-watermarks.cpp
@@ -1,0 +1,104 @@
+#include <catch2/catch_test_macros.hpp>
+#include <oxen/quic.hpp>
+#include <oxen/quic/gnutls_crypto.hpp>
+#include <thread>
+
+#include "utils.hpp"
+
+namespace oxen::quic::test
+{
+    TEST_CASE("012 - Stream Buffer Watermarking", "[012][watermark][streams]")
+    {
+        Network test_net{};
+        bstring req_msg(100'000, std::byte{'a'});
+
+        std::promise<bool> d_promise;
+        std::future<bool> d_future = d_promise.get_future();
+
+        auto client_established = callback_waiter{[](connection_interface&) {}};
+        auto server_established = callback_waiter{[](connection_interface&) {}};
+
+        auto [client_tls, server_tls] = defaults::tls_creds_from_ed_keys();
+
+        Address server_local{};
+        Address client_local{};
+
+        auto server_endpoint = test_net.endpoint(server_local, server_established);
+        REQUIRE_NOTHROW(server_endpoint->listen(server_tls));
+
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+
+        auto client_endpoint = test_net.endpoint(client_local, client_established);
+        auto conn_interface = client_endpoint->connect(client_remote, client_tls);
+
+        CHECK(client_established.wait());
+        CHECK(server_established.wait());
+
+        auto client_stream = conn_interface->open_stream();
+
+        CHECK_FALSE(client_stream->has_watermarks());
+
+        SECTION("Watermarks self-clear")
+        {
+            auto low_water = callback_waiter{[](Stream&) {}};
+            auto high_water = callback_waiter{[](Stream&) {}};
+            client_stream->set_watermark(500, 1000, opt::watermark{low_water, false}, opt::watermark{high_water, false});
+
+            CHECK(client_stream->has_watermarks());
+
+            REQUIRE_NOTHROW(client_stream->send(bstring_view{req_msg}));
+
+            CHECK(low_water.wait());
+
+            REQUIRE_NOTHROW(client_stream->send(bstring_view{req_msg}));
+            REQUIRE_NOTHROW(client_stream->send(bstring_view{req_msg}));
+
+            CHECK(high_water.wait());
+
+            REQUIRE_FALSE(client_stream->has_watermarks());
+        }
+
+        SECTION("Watermarks persist")
+        {
+            std::atomic<int> low_count{0}, high_count{0};
+
+            client_stream->set_watermark(
+                    500,
+                    2000,
+                    opt::watermark{
+                            [&](const Stream&) {
+                                log::debug(log_cat, "Executing low hook!");
+                                low_count += 1;
+                            },
+                            true},
+                    opt::watermark{
+                            [&](const Stream&) {
+                                log::debug(log_cat, "Executing high hook!");
+                                high_count += 1;
+                            },
+                            true});
+
+            REQUIRE_NOTHROW(client_stream->send(bstring_view{req_msg}));
+
+            std::this_thread::sleep_for(100ms);
+
+            REQUIRE_NOTHROW(client_stream->send(bstring_view{req_msg}));
+            REQUIRE_NOTHROW(client_stream->send(bstring_view{req_msg}));
+
+            std::this_thread::sleep_for(150ms);
+
+            REQUIRE_NOTHROW(client_stream->send(bstring_view{req_msg}));
+            REQUIRE_NOTHROW(client_stream->send(bstring_view{req_msg}));
+
+            std::this_thread::sleep_for(150ms);
+
+            REQUIRE(low_count >= 2);
+            REQUIRE(high_count > 1);
+            REQUIRE(low_count >= high_count);
+
+            client_stream->clear_watermarks();
+
+            REQUIRE_FALSE(client_stream->has_watermarks());
+        }
+    }
+}  //  namespace oxen::quic::test

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,6 +38,7 @@ if(LIBQUIC_BUILD_TESTS)
         009-alpns.cpp
         010-migration.cpp
         011-manual_transmission.cpp
+        012-watermarks.cpp
 
         main.cpp
         case_logger.cpp


### PR DESCRIPTION
- Applications can call `Stream::set_watermark(...)` to implement logic to be executed at states dictated by the number of bytes currently unsent.
- Application must pass `low` and `high` watermark amounts; an `execute-on-low` callback can be passed with or without an `execute-on-high` callback (and vice versa) - The `execute-on-low` callback will not be executed until the buffer state rises above the `high` value; it will not be executed again until the buffer state rises once more above the `high` value - The `execute-on-high` callback will not be executed until the buffer state drops below the `low` value; it will not be executed again until the buffer state drops once more below the `low` value
- Callbacks can be passed with an optional boolean in their opt:: wrapper, indicating "clear after execution"; this will ensure the callback is only executed ONCE before being cleared. The default behavior is repeated callback execution
- Invoking this function repeatedly will overwrite any currently set thresholds and callbacks