### PR TITLE
Add three-way operator to Address and fix port order

### DIFF
--- a/tests/001-handshake.cpp
+++ b/tests/001-handshake.cpp
@@ -104,6 +104,14 @@ namespace oxen::quic::test
             CHECK_FALSE(public_ipv6.is_any_port());
             CHECK(public_ipv6.is_addressable());
             CHECK_FALSE(public_ipv6.is_loopback());
+
+            CHECK(Address{"127.0.0.1", 2} < Address{"127.0.0.1", 256});
+            CHECK(Address{"127.0.0.1", 256} < Address{"127.0.0.2", 2});
+            CHECK(Address{"127.0.0.1", 256} < public_ipv6);
+            CHECK(Address{"127.0.0.1", 2} == Address{"127.0.0.1", 2});
+            CHECK(Address{"127.0.0.1", 256} > Address{"127.0.0.1", 2});
+            CHECK(Address{"127.0.0.1", 256} <= public_ipv6);
+            CHECK(public_ipv6 >= Address{"127.0.0.1", 256});
         }
 
         SECTION("IP Address Ranges", "[range][operators][ipaddr]")


### PR DESCRIPTION
Replace `operator<` with `operator<=>` and define == and != in terms of it.

This also fixes a bug where `<` did not byte-swap the port before comparing, so 1.1.1.1:256 was considered less than 1.1.1.1:1; it is now greater than.