### PR TITLE
Add public Network.close() method to perform controlled network shutdown

### DIFF
--- a/include/oxen/quic/endpoint.hpp
+++ b/include/oxen/quic/endpoint.hpp
@@ -38,15 +38,6 @@ namespace oxen::quic
         connection_closed_callback connection_close_cb;
 
         template <typename... Opt>
-        Endpoint(Network& n, const Address& listen_addr, Opt&&... opts) : net{n}, _local{listen_addr}
-        {
-            ((void)handle_ep_opt(std::forward<Opt>(opts)), ...);
-            _init_internals();
-            if (_static_secret.empty())
-                _static_secret = make_static_secret();
-        }
-
-        template <typename... Opt>
         void listen(Opt&&... opts)
         {
             check_for_tls_creds<Opt...>();
@@ -179,6 +170,15 @@ namespace oxen::quic
         friend class Connection;
         friend struct connection_callbacks;
         friend class TestHelper;
+
+        template <typename... Opt>
+        Endpoint(Network& n, const Address& listen_addr, Opt&&... opts) : net{n}, _local{listen_addr}
+        {
+            ((void)handle_ep_opt(std::forward<Opt>(opts)), ...);
+            _init_internals();
+            if (_static_secret.empty())
+                _static_secret = make_static_secret();
+        }
 
         Network& net;
         Address _local;

--- a/include/oxen/quic/network.hpp
+++ b/include/oxen/quic/network.hpp
@@ -70,6 +70,22 @@ namespace oxen::quic
         // complete.
         void close_soon(std::shared_ptr<Endpoint>&& endpoint);
 
+        // Initiates shutdown of the entire Network instance by closing all of the connections on
+        // this object, synchronously.  This is normally called during destruction, but can also be
+        // called manually to control the sequence of shutdown (for instance, if connections or
+        // streams have callbacks that will be fired during destruction that need a Network instance
+        // to remain alive externally).
+        //
+        // The caller should consider the Network dead and *must not* perform any network operations
+        // (such as creating a new connection) after calling this.
+        //
+        // Calling this implicitly calls `set_shutdown_immediate()` so that, after this call,
+        // destruction will happen assuming all connections/streams have been properly terminated.
+        void close();
+
+        // Initiates shutdown (as close() does), but does not wait for closing to complete.
+        void close_soon();
+
         template <typename T, typename... Args>
         std::shared_ptr<T> make_shared(Args&&... args)
         {
@@ -127,8 +143,6 @@ namespace oxen::quic
         friend class Endpoint;
         friend class Connection;
         friend class Stream;
-
-        void close_gracefully();
 
         const caller_id_t net_id;
 

--- a/include/oxen/quic/network.hpp
+++ b/include/oxen/quic/network.hpp
@@ -52,9 +52,9 @@ namespace oxen::quic
         template <typename... Opt>
         std::shared_ptr<Endpoint> endpoint(const Address& local_addr, Opt&&... opts)
         {
-            auto [it, added] = endpoints.emplace(std::make_shared<Endpoint>(*this, local_addr, std::forward<Opt>(opts)...));
-
-            return *it;
+            auto ep = _loop->make_shared<Endpoint>(*this, local_addr, std::forward<Opt>(opts)...);
+            endpoints.insert(ep);
+            return ep;
         }
 
         // Shuts down an endpoint, closing all connections and sockets in the process, and blocks


### PR DESCRIPTION
This renames the close_gracefully() method to just `close()` and makes
it public so that an application has a bit more control over Network
shutdown.

libsession-util ran into an issue where the quic::Network destruction
segfaults because it has callbacks (e.g. connection closing) that expect
to be able to use their local `quic::Network` instance, but can't
because it's in the process of being destroyed.

Essentially the pattern is this:

    class A {
        quic::Network net;
    };
    A a;
    // start a connection with a connection_close callback that
    // references `a`.

If the quic::Network destruction is triggered by the destruction of `a`,
then the quic::Network destructor is firing *after* `a` is no longer in
a valid state, and so the callback referencing `a` is invalid.

Exposing close() allows the application to deal with this: it can add a
`net.close()` either in `A`'s destructor or some other shutdown code so
that it can ensure the quic Network shutdown happens *before* `a`
becomes unusable.

This also adds a non-synchronous `call_soon()` to mirror the call(ep)
and call_soon(ep) methods for shutdown down individual endpoints.