### PR TITLE
Max IP in range; Revamp ipv4/6 methods

### DIFF
--- a/include/oxen/quic/address.hpp
+++ b/include/oxen/quic/address.hpp
@@ -66,9 +66,9 @@ namespace oxen::quic
 
         explicit Address(const ngtcp2_addr& addr);
 
-        explicit Address(ipv4 v4, uint16_t port = 0);
+        explicit Address(const ipv4& v4, uint16_t port = 0);
 
-        explicit Address(ipv6 v6, uint16_t port = 0);
+        explicit Address(const ipv6& v6, uint16_t port = 0);
 
         // Assignment from a sockaddr pointer; we copy the sockaddr's contents
         template <RawSockAddr T>

--- a/include/oxen/quic/ip.hpp
+++ b/include/oxen/quic/ip.hpp
@@ -7,27 +7,34 @@
 
 namespace oxen::quic
 {
-    inline constexpr size_t IPV4_ARRLEN{4};
-    inline constexpr size_t IPV6_ARRLEN{16};
-
     struct ipv4
     {
         // host order
         uint32_t addr;
 
-        ipv4() = default;
+        constexpr ipv4() = default;
 
         constexpr ipv4(uint32_t a) : addr{a} {}
         constexpr ipv4(uint8_t a, uint8_t b, uint8_t c, uint8_t d) :
                 ipv4{uint32_t{a} << 24 | uint32_t{b} << 16 | uint32_t{c} << 8 | uint32_t{d}}
         {}
 
+        constexpr std::optional<ipv4> next_ip() const
+        {
+            std::optional<ipv4> ret = std::nullopt;
+
+            if (not increment_will_overflow(addr))
+                ret = ipv4{addr + 1};
+
+            return ret;
+        }
+
         const std::string to_string() const;
 
         explicit operator in_addr() const
         {
             in_addr a;
-            a.s_addr = oxenc::load_host_to_big<uint32_t>(&addr);
+            a.s_addr = oxenc::host_to_big(addr);
             return a;
         }
 
@@ -45,13 +52,19 @@ namespace oxen::quic
         ipv4 base;
         uint8_t mask;
 
-        ipv4 max_ip();
+        constexpr ipv4 max_ip() const
+        {
+            auto b = base.to_base(mask);
+
+            if (mask < 32)
+                b.addr |= (uint32_t{1} << (32 - mask)) - 1;
+
+            return b;
+        }
 
         constexpr ipv4_net(ipv4 b, uint8_t m) : base{b.to_base(m)}, mask{m} {}
 
-        const std::string to_string() const { return base.to_base(mask).to_string(); }
-
-        constexpr auto operator<=>(const ipv4_net& a) const { return std::tie(base, mask) <=> std::tie(a.base, a.mask); }
+        const std::string to_string() const;
 
         constexpr bool operator==(const ipv4_net& a) const { return std::tie(base, mask) == std::tie(a.base, a.mask); }
 
@@ -76,12 +89,28 @@ namespace oxen::quic
         // Host order
         uint64_t hi, lo;
 
-        ipv6() = default;
+        constexpr ipv6() = default;
+
+        constexpr std::optional<ipv6> next_ip() const
+        {
+            // If lo will not overflow, increment and return
+            if (not increment_will_overflow(lo))
+                return ipv6{{hi, lo + 1}};
+
+            // If lo is INT_MAX, then:
+            //  - if hi can be incremented, ++hi and set lo to all 0's
+            //  - else, return nullopt
+            if (not increment_will_overflow(hi))
+                return ipv6{{hi + 1, uint64_t{0}}};
+
+            return std::nullopt;
+        }
 
         // Network order in6_addr constructor (calls private constructor)
         ipv6(const struct in6_addr* addr) : ipv6{addr->s6_addr} {}
 
-        // Explicit to prevent collision with default constructor and make calling purposeful
+        constexpr ipv6(std::pair<uint64_t, uint64_t> hilo) : hi{hilo.first}, lo{hilo.second} {}
+
         explicit constexpr ipv6(
                 uint16_t a,
                 uint16_t b = 0x0000,
@@ -114,7 +143,7 @@ namespace oxen::quic
             else
             {
                 b.hi = (hi >> (64 - mask)) << (64 - mask);
-                b.lo = 0;
+                b.lo = uint64_t{0};
             }
             return b;
         }
@@ -125,15 +154,29 @@ namespace oxen::quic
         ipv6 base;
         uint8_t mask;
 
-        ipv6 max_ip();
+        constexpr ipv6 max_ip() const
+        {
+            auto b = base.to_base(mask);
+
+            if (mask > 64)
+            {
+                b.hi = base.hi;
+                b.lo |= (uint64_t{1} << (128 - mask)) - 1;
+            }
+            else
+            {
+                b.hi |= (uint64_t{1} << (64 - mask)) - 1;
+                b.lo = ~uint64_t{0};
+            }
+
+            return b;
+        }
 
         constexpr ipv6_net(ipv6 b, uint8_t m) : base{b.to_base(m)}, mask{m} {}
 
-        const std::string to_string() const { return base.to_base(mask).to_string(); }
+        const std::string to_string() const;
 
-        constexpr auto operator<=>(const ipv6_net& a) { return std::tie(base, mask) <=> std::tie(a.base, a.mask); }
-
-        constexpr bool operator==(const ipv6_net& a) { return base == a.base && mask == a.mask; }
+        constexpr bool operator==(const ipv6_net& a) { return std::tie(base, mask) == std::tie(a.base, a.mask); }
 
         constexpr bool contains(const ipv6& addr) const { return addr.to_base(mask) == base; }
     };

--- a/include/oxen/quic/utils.hpp
+++ b/include/oxen/quic/utils.hpp
@@ -202,6 +202,12 @@ namespace oxen::quic
 
     std::string str_tolower(std::string s);
 
+    template <std::integral T>
+    constexpr bool increment_will_overflow(T val)
+    {
+        return std::numeric_limits<T>::max() == val;
+    }
+
     /// Parses an integer of some sort from a string, requiring that the entire string be consumed
     /// during parsing.  Return false if parsing failed, sets `value` and returns true if the entire
     /// string was consumed.

--- a/src/address.cpp
+++ b/src/address.cpp
@@ -74,7 +74,7 @@ namespace oxen::quic
 
         auto& sin = reinterpret_cast<sockaddr_in&>(_sock_addr);
         sin.sin_port = oxenc::host_to_big(port);
-        oxenc::write_host_as_big<uint32_t>(v4.addr, &sin.sin_addr);
+        sin.sin_addr.s_addr = oxenc::host_to_big(v4.addr);
 
         update_socklen(sizeof(sockaddr_in));
     }
@@ -88,7 +88,7 @@ namespace oxen::quic
 
         auto in6 = v6.to_in6();
 
-        std::memcpy(&sin6.sin6_addr.s6_addr, &in6, sizeof(struct in6_addr));
+        std::memcpy(&sin6.sin6_addr, &in6, sizeof(struct in6_addr));
 
         update_socklen(sizeof(sockaddr_in6));
     }

--- a/src/ip.cpp
+++ b/src/ip.cpp
@@ -1,28 +1,21 @@
 #include "ip.hpp"
 
-#include <bit>
-
 #include "internal.hpp"
 
 namespace oxen::quic
 {
     const std::string ipv4::to_string() const
     {
-        uint32_t net = oxenc::load_host_to_big<uint32_t>(&addr);
         char buf[INET_ADDRSTRLEN] = {};
+        uint32_t net = oxenc::host_to_big(addr);
         inet_ntop(AF_INET, &net, buf, sizeof(buf));
 
         return "{}"_format(buf);
     }
 
-    ipv4 ipv4_net::max_ip()
+    const std::string ipv4_net::to_string() const
     {
-        auto b = base.to_base(mask);
-
-        if (mask < 32)
-            b.addr |= (1 << (32 - mask)) - 1;
-
-        return b;
+        return "{}/{}"_format(base.to_string(), mask);
     }
 
     in6_addr ipv6::to_in6() const
@@ -40,6 +33,7 @@ namespace oxen::quic
         char buf[INET6_ADDRSTRLEN] = {};
 
         std::array<uint8_t, 16> addr;
+
         oxenc::write_host_as_big(hi, &addr[0]);
         oxenc::write_host_as_big(lo, &addr[8]);
 
@@ -48,22 +42,8 @@ namespace oxen::quic
         return "{}"_format(buf);
     }
 
-    ipv6 ipv6_net::max_ip()
+    const std::string ipv6_net::to_string() const
     {
-        auto b = base.to_base(mask);
-
-        if (mask > 64)
-        {
-            b.hi = base.hi;
-            b.lo |= (1 << (128 - mask)) - 1;
-        }
-        else
-        {
-            b.hi |= (1 << (64 - mask)) - 1;
-            b.lo = ~uint64_t{0};
-        }
-
-        return b;
+        return "{}/{}"_format(base.to_string(), mask);
     }
-
 }  //  namespace oxen::quic

--- a/tests/001-handshake.cpp
+++ b/tests/001-handshake.cpp
@@ -128,51 +128,53 @@ namespace oxen::quic::test
             CHECK((ipv6(0x2001, 0xdb8) / 32).contains(ipv6(0x2001, 0xdb8, 0xffff, 0xffff)));
             CHECK((ipv6(0x2001, 0xdb8, 0xffff) / 32).contains(ipv6(0x2001, 0xdb8)));
             CHECK((ipv6(0x2001, 0xdb8, 0xffff) / 32).contains(ipv6(0x2001, 0xdb8)));
+
+            auto v4_net = ipv4(10, 0, 0, 0) / 8;
+            auto v4_max = Address{v4_net.max_ip()};
+
+            REQUIRE(v4_max.to_string() == "10.255.255.255:0"s);
+
+            auto v6_net = ipv6(0x2001, 0xdb8) / 32;
+            auto v6_max = Address{v6_net.max_ip()};
+
+            REQUIRE(v6_max.to_string() == "[2001:db8::ffff:ffff:ffff:ffff]:0"s);
         }
 
         SECTION("IPv4 Addresses", "[ipv4][constructors][ipaddr]")
         {
-            uint32_t v4_n;                      // network order ipv4 addr
-            auto v4_h = "192.168.1.1"s;         // host order ipv4 string
+            uint32_t v4_h;                      // host order ipv4 addr
+            auto v4_hstr = "192.168.1.1"s;      // host order ipv4 string
             auto v4_full = "192.168.1.1:123"s;  // full ipv4 addr/port string
 
-            REQUIRE(inet_pton(AF_INET, v4_h.c_str(), &v4_n));
+            char buf[INET_ADDRSTRLEN] = {};
+            REQUIRE(inet_pton(AF_INET, v4_hstr.c_str(), &buf));
+            v4_h = oxenc::load_big_to_host<uint32_t>(&buf);
 
-            in_addr v4_inaddr;
-#ifndef _WIN32
-            v4_inaddr.s_addr = v4_n;
-#else
-            v4_inaddr.S_un.S_addr = v4_n;
-#endif
+            ipv4 v4_host_order{v4_h};
+            in_addr v4_inaddr = v4_host_order.operator in_addr();
 
-            ipv4 v4_net_order{v4_n};
-            ipv4 v4_private{v4_h};
+            Address v4_from_ipv4{v4_hstr, 123};
+            ipv4 v4_private = v4_from_ipv4.to_ipv4();
 
-            Address v4_from_ipv4{v4_private, 123};
-            Address v4_from_ipv4_n{v4_net_order, 123};
+            Address v4_from_ipv4_h{v4_host_order, 123};
             Address v4_from_inaddr{};
             v4_from_inaddr.set_addr(&v4_inaddr);
             v4_from_inaddr.set_port(123);
 
-            CHECK(v4_from_ipv4 == v4_from_ipv4_n);
-            CHECK(v4_from_ipv4_n == v4_from_inaddr);
+            CHECK(v4_from_ipv4 == v4_from_ipv4_h);
+            CHECK(v4_from_ipv4_h == v4_from_inaddr);
 
-            CHECK(v4_net_order == v4_inaddr);
-            CHECK(v4_private == v4_net_order);
-
-            CHECK(v4_private.to_string() == v4_h);
-            CHECK(v4_net_order.to_string() == v4_h);
+            CHECK(v4_private.to_string() == v4_hstr);
 
             auto ipv4_from_addr = v4_from_ipv4.to_ipv4();
-            auto ipv4_from_addr_n = v4_from_ipv4_n.to_ipv4();
+            auto ipv4_from_addr_n = v4_from_ipv4_h.to_ipv4();
 
             REQUIRE(ipv4_from_addr == ipv4_from_addr_n);
 
             CHECK(ipv4_from_addr == v4_private);
-            CHECK(ipv4_from_addr == v4_net_order);
 
             CHECK(v4_from_ipv4.to_string() == v4_full);
-            CHECK(v4_from_ipv4_n.to_string() == v4_full);
+            CHECK(v4_from_ipv4_h.to_string() == v4_full);
         }
 
         SECTION("IPv6 Addresses", "[ipv6][constructors][ipaddr]")
@@ -186,7 +188,7 @@ namespace oxen::quic::test
             ipv6 addr_from_in6addr{&localnet_in6addr};
             in6_addr localnet_from_ipv6 = addr_from_in6addr.to_in6();
 
-            ipv6 weird_addr{weird};
+            ipv6 weird_addr = Address{weird, 0}.to_ipv6();
 
             Address address_from_v6{addr_localnet, 123};
             Address address_from_v6_in6{addr_from_in6addr, 123};


### PR DESCRIPTION
- iprange now has ::max_ip() method
- ipv4 enforces internal host-order storage
- methods in other objects now understand this
- [001] updated