### PR TITLE
Default ip range constructors

### DIFF
--- a/include/oxen/quic/ip.hpp
+++ b/include/oxen/quic/ip.hpp
@@ -62,6 +62,8 @@ namespace oxen::quic
             return b;
         }
 
+        constexpr ipv4_net() = default;
+
         constexpr ipv4_net(ipv4 b, uint8_t m) : base{b.to_base(m)}, mask{m} {}
 
         const std::string to_string() const;
@@ -171,6 +173,8 @@ namespace oxen::quic
 
             return b;
         }
+
+        constexpr ipv6_net() = default;
 
         constexpr ipv6_net(ipv6 b, uint8_t m) : base{b.to_base(m)}, mask{m} {}
 


### PR DESCRIPTION
Added default constexpr constructors for `ipv{4,6}_net` objects