### PR TITLE
GCC stringop bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,8 +112,13 @@ if (WARNINGS_AS_ERRORS)
 endif()
 add_library(libquic_internal-warnings INTERFACE)
 
-if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 11.0.0)
-    target_compile_options(libquic_internal-warnings INTERFACE -fconcepts)
+# gcc 11 and earlier bug
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12.0.0)
+    if (libquic_IS_TOPLEVEL_PROJECT)
+        list(APPEND warning_flags -Wno-error=stringop-overflow)
+    else()
+        target_compile_options(libquic_external INTERFACE -Wno-error=stringop-overflow)
+    endif()
 endif()
 
 target_compile_options(libquic_internal-warnings INTERFACE "$<$<OR:$<COMPILE_LANGUAGE:CXX>,$<COMPILE_LANGUAGE:C>>:${warning_flags}>")


### PR DESCRIPTION
- FMT will trigger a gcc bug on stringop-overflow with gcc versions 11 and earlier
- FMT issue https://github.com/fmtlib/fmt/pull/2442
- FMT issue https://github.com/fmtlib/fmt/issues/2708
- GCC bug tracker https://gcc.gnu.org/bugzilla/show_bug.cgi?id=101854
- Confirming it still appears on gcc-11 https://godbolt.org/z/d15q4Exvz