### PR TITLE
loop event repeater

### DIFF
--- a/include/oxen/quic/loop.hpp
+++ b/include/oxen/quic/loop.hpp
@@ -240,15 +240,14 @@ namespace oxen::quic
             }
             else
             {
-                call_soon([this,
-                           func = std::move(hook),
-                           target_time = get_timestamp<std::chrono::microseconds>() + delay]() mutable {
-                    auto updated_delay = target_time - get_timestamp<std::chrono::microseconds>();
+                call_soon([this, func = std::move(hook), target_time = get_time() + delay]() mutable {
+                    auto now = get_time();
 
-                    if (updated_delay <= 0us)
+                    if (now >= target_time)
                         func();
                     else
-                        add_oneshot_event(updated_delay, std::move(func));
+                        add_oneshot_event(
+                                std::chrono::duration_cast<std::chrono::microseconds>(target_time - now), std::move(func));
                 });
             }
         }

--- a/include/oxen/quic/network.hpp
+++ b/include/oxen/quic/network.hpp
@@ -68,6 +68,18 @@ namespace oxen::quic
             _loop->call_every(interval, std::move(caller), std::forward<Callable>(f));
         }
 
+        template <typename Callable>
+        std::shared_ptr<EventHandler> call_every(loop_time interval, Callable&& f, bool start_immediately = true)
+        {
+            return _loop->call_every(interval, std::forward<Callable>(f), start_immediately);
+        }
+
+        template <typename Callable>
+        void call_later(loop_time delay, Callable&& hook)
+        {
+            _loop->call_later(delay, std::forward<Callable>(hook));
+        }
+
       private:
         std::shared_ptr<Loop> _loop;
         std::atomic<bool> shutdown_immediate{false};

--- a/include/oxen/quic/network.hpp
+++ b/include/oxen/quic/network.hpp
@@ -63,19 +63,19 @@ namespace oxen::quic
         }
 
         template <typename Callable>
-        void call_every(loop_time interval, std::weak_ptr<void> caller, Callable&& f)
+        void call_every(std::chrono::microseconds interval, std::weak_ptr<void> caller, Callable&& f)
         {
             _loop->call_every(interval, std::move(caller), std::forward<Callable>(f));
         }
 
         template <typename Callable>
-        std::shared_ptr<EventHandler> call_every(loop_time interval, Callable&& f, bool start_immediately = true)
+        std::shared_ptr<Ticker> call_every(std::chrono::microseconds interval, Callable&& f, bool start_immediately = true)
         {
             return _loop->call_every(interval, std::forward<Callable>(f), start_immediately);
         }
 
         template <typename Callable>
-        void call_later(loop_time delay, Callable&& hook)
+        void call_later(std::chrono::microseconds delay, Callable&& hook)
         {
             _loop->call_later(delay, std::forward<Callable>(hook));
         }

--- a/include/oxen/quic/network.hpp
+++ b/include/oxen/quic/network.hpp
@@ -62,6 +62,12 @@ namespace oxen::quic
             call_soon([ptr = std::move(ptr)]() mutable { ptr.reset(); });
         }
 
+        template <typename Callable>
+        void call_every(loop_time interval, std::weak_ptr<void> caller, Callable&& f)
+        {
+            _loop->call_every(interval, std::move(caller), std::forward<Callable>(f));
+        }
+
       private:
         std::shared_ptr<Loop> _loop;
         std::atomic<bool> shutdown_immediate{false};

--- a/include/oxen/quic/utils.hpp
+++ b/include/oxen/quic/utils.hpp
@@ -200,6 +200,12 @@ namespace oxen::quic
     std::chrono::steady_clock::time_point get_time();
     std::chrono::nanoseconds get_timestamp();
 
+    template <typename unit_t>
+    auto get_timestamp()
+    {
+        return std::chrono::duration_cast<unit_t>(get_timestamp());
+    }
+
     std::string str_tolower(std::string s);
 
     template <std::integral T>

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -1,7 +1,6 @@
 #include "loop.hpp"
 
 #include "internal.hpp"
-// #include "utils.hpp"
 
 namespace oxen::quic
 {
@@ -42,7 +41,9 @@ namespace oxen::quic
      */
     timeval loop_time_to_timeval(std::chrono::microseconds t)
     {
-        return timeval{.tv_sec = static_cast<time_t>(t / 1s), .tv_usec = static_cast<suseconds_t>((t % 1s) / 1us)};
+        return timeval{
+                .tv_sec = static_cast<decltype(timeval::tv_sec)>(t / 1s),
+                .tv_usec = static_cast<decltype(timeval::tv_usec)>((t % 1s) / 1us)};
     }
 
     bool Ticker::start()

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -29,6 +29,17 @@ namespace oxen::quic
         });
     }
 
+    /** Static casting to `decltype(timeval::tv_{sec,usec})` makes sure that;
+        - on linux
+            .tv_sec is type __time_t
+            .tv_usec is type __suseconds_t
+        - on OSX    (https://developer.apple.com/documentation/kernel/timeval)
+            .tv_sec is type __darwin_time_t
+                - this is an annoying typedef of `time_t`
+            .tv_usec is type __darwin_suseconds_t
+                - this is an equally annoying typedef for `suseconds_t`
+        Alas, yet again another mac idiosyncrasy...
+     */
     timeval loop_time_to_timeval(loop_time t)
     {
         return timeval{
@@ -36,7 +47,46 @@ namespace oxen::quic
                 .tv_usec = static_cast<decltype(timeval::tv_usec)>((t % 1s) / 1us)};
     }
 
-    void EventHandler::start(const loop_ptr& _loop, loop_time _interval, std::function<void()> task)
+    bool EventHandler::start()
+    {
+        if (_is_running or _is_stopped)
+            return false;
+
+        return event_add(ev.get(), &interval) == 0;
+    }
+
+    bool EventHandler::pause()
+    {
+        if (not _is_running or _is_stopped)
+            return false;
+
+        if (event_del(ev.get()) != 0)
+        {
+            log::critical(log_cat, "EventHandler failed to pause repeating event!");
+            return false;
+        }
+
+        return true;
+    }
+
+    bool EventHandler::stop()
+    {
+        if (not _is_running and _is_stopped)
+        {
+            log::critical(log_cat, "EventHandler is already permanently stopped!");
+            return false;
+        }
+
+        ev.reset();
+        f = nullptr;
+        _is_running = false;
+        _is_stopped = true;
+
+        return true;
+    }
+
+    void EventHandler::start_event(
+            const loop_ptr& _loop, loop_time _interval, std::function<void()> task, bool persist, bool start_immediately)
     {
         f = std::move(task);
         interval = loop_time_to_timeval(_interval);
@@ -44,27 +94,34 @@ namespace oxen::quic
         ev.reset(event_new(
                 _loop.get(),
                 -1,
-                EV_PERSIST,
+                persist ? EV_PERSIST : 0,
                 [](evutil_socket_t, short, void* s) {
-                    auto* self = reinterpret_cast<EventHandler*>(s);
-                    // execute callback
-                    self->f();
+                    try
+                    {
+                        auto* self = reinterpret_cast<EventHandler*>(s);
+                        // execute callback
+                        self->f();
+                    }
+                    catch (const std::exception& e)
+                    {
+                        log::critical(log_cat, "EventHandler caught exception: {}", e.what());
+                    }
                 },
                 this));
 
-        event_add(ev.get(), &interval);
+        if (start_immediately and not start())
+            log::critical(log_cat, "Failed to immediately start event repeater!");
     }
 
     EventHandler::~EventHandler()
     {
-        log::critical(log_cat, "Shutting down repeate eventhandler!");
         ev.reset();
         f = nullptr;
     }
 
     std::shared_ptr<EventHandler> Loop::make_handler()
     {
-        return std::make_shared<EventHandler>();
+        return make_shared<EventHandler>();
     }
 
     Loop::Loop(std::shared_ptr<::event_base> loop_ptr, std::thread::id thread_id) :
@@ -162,17 +219,6 @@ namespace oxen::quic
 #ifdef _WIN32
         WSACleanup();
 #endif
-    }
-
-    void Loop::call_soon(std::function<void(void)> f)
-    {
-        {
-            std::lock_guard lock{job_queue_mutex};
-            job_queue.emplace(std::move(f));
-            log::trace(log_cat, "Event loop now has {} jobs queued", job_queue.size());
-        }
-
-        event_active(job_waker.get(), 0, 0);
     }
 
     void Loop::shutdown(bool immediate)

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -42,9 +42,7 @@ namespace oxen::quic
      */
     timeval loop_time_to_timeval(std::chrono::microseconds t)
     {
-        return timeval{
-                .tv_sec = static_cast<decltype(timeval::tv_sec)>(t / 1s),
-                .tv_usec = static_cast<decltype(timeval::tv_usec)>((t % 1s) / 1us)};
+        return timeval{.tv_sec = static_cast<time_t>(t / 1s), .tv_usec = static_cast<suseconds_t>((t % 1s) / 1us)};
     }
 
     bool Ticker::start()

--- a/tests/002-send-receive.cpp
+++ b/tests/002-send-receive.cpp
@@ -739,4 +739,41 @@ namespace oxen::quic::test
             slow_response.join();
     }
 
+    TEST_CASE("002 - Send via Repeater", "[002][repeater]")
+    {
+        Network test_net{};
+        const int NUM_ITERATIONS{50};
+        constexpr auto msg = "hello from the other siiiii-iiiiide"_bsv;
+
+        std::promise<bool> d_promise;
+        std::future<bool> d_future = d_promise.get_future();
+
+        std::atomic<int> counter{};
+
+        stream_data_callback server_data_cb = [&](Stream&, bstring_view) {
+            if (++counter == NUM_ITERATIONS)
+                d_promise.set_value(true);
+        };
+
+        auto [client_tls, server_tls] = defaults::tls_creds_from_ed_keys();
+
+        Address server_local{};
+        Address client_local{};
+
+        auto server_endpoint = test_net.endpoint(server_local);
+        REQUIRE_NOTHROW(server_endpoint->listen(server_tls, server_data_cb));
+
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+
+        auto client_endpoint = test_net.endpoint(client_local);
+        auto conn_interface = client_endpoint->connect(client_remote, client_tls);
+
+        // client make stream and send; message displayed by server_data_cb
+        auto client_stream = conn_interface->open_stream();
+
+        test_net.call_every(10ms, client_endpoint->weak_from_this(), [&]() { client_stream->send(msg); });
+
+        require_future(d_future, 5s);
+    }
+
 }  // namespace oxen::quic::test

--- a/tests/013-eventhandler.cpp
+++ b/tests/013-eventhandler.cpp
@@ -1,0 +1,146 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
+#include <future>
+#include <oxen/quic.hpp>
+#include <oxen/quic/gnutls_crypto.hpp>
+#include <thread>
+
+#include "utils.hpp"
+
+namespace oxen::quic::test
+{
+    struct lifetime : public std::enable_shared_from_this<lifetime>
+    {};
+
+    TEST_CASE("013 - EventHandler event repeater: calling object lifetime bound", "[013][repeater][caller]")
+    {
+        Network test_net{};
+        const int NUM_ITERATIONS{10};
+        constexpr auto msg = "hello from the other siiiii-iiiiide"_bsv;
+
+        std::promise<bool> d_promise;
+        std::future<bool> d_future = d_promise.get_future();
+
+        std::atomic<int> recv_counter{}, send_counter{};
+
+        stream_data_callback server_data_cb = [&](Stream&, bstring_view) { recv_counter += 1; };
+
+        auto [client_tls, server_tls] = defaults::tls_creds_from_ed_keys();
+
+        Address server_local{};
+        Address client_local{};
+
+        auto server_endpoint = test_net.endpoint(server_local);
+        REQUIRE_NOTHROW(server_endpoint->listen(server_tls, server_data_cb));
+
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+
+        auto client_endpoint = test_net.endpoint(client_local);
+        auto conn_interface = client_endpoint->connect(client_remote, client_tls);
+
+        // client make stream and send; message displayed by server_data_cb
+        auto client_stream = conn_interface->open_stream();
+
+        auto life = std::make_shared<lifetime>();
+
+        test_net.call_every(10ms, life->weak_from_this(), [&]() {
+            if (send_counter <= NUM_ITERATIONS)
+            {
+                ++send_counter;
+                client_stream->send(msg);
+            }
+            else
+                life.reset();
+        });
+
+        test_net.call_later(1s, [&]() {
+            REQUIRE(recv_counter == send_counter);
+            REQUIRE(!life);
+            d_promise.set_value(true);
+        });
+
+        require_future(d_future, 5s);
+    }
+
+    TEST_CASE("013 - EventHandler event repeater: EventHandler managed lifetime", "[013][repeater][managed]")
+    {
+        Network test_net{};
+        const int NUM_ITERATIONS{10};
+        constexpr auto msg = "hello from the other siiiii-iiiiide"_bsv;
+
+        std::promise<bool> prom_a, prom_b;
+        std::future<bool> fut_a = prom_a.get_future(), fut_b = prom_b.get_future();
+
+        std::atomic<int> recv_counter{}, send_counter{};
+        std::atomic<bool> have_paused_handler{false};
+
+        std::shared_ptr<EventHandler> handler;
+
+        stream_data_callback server_data_cb = [&](Stream&, bstring_view) {
+            recv_counter += 1;
+            if (recv_counter == NUM_ITERATIONS)
+            {
+                if (not have_paused_handler)
+                {
+                    handler->pause();
+                    have_paused_handler = true;
+                }
+                else
+                {
+                    handler->stop();
+                }
+            }
+        };
+
+        auto [client_tls, server_tls] = defaults::tls_creds_from_ed_keys();
+
+        Address server_local{};
+        Address client_local{};
+
+        auto server_endpoint = test_net.endpoint(server_local);
+        REQUIRE_NOTHROW(server_endpoint->listen(server_tls, server_data_cb));
+
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+
+        auto client_endpoint = test_net.endpoint(client_local);
+        auto conn_interface = client_endpoint->connect(client_remote, client_tls);
+
+        // client make stream and send; message displayed by server_data_cb
+        auto client_stream = conn_interface->open_stream();
+
+        handler = test_net.call_every(10ms, [&]() {
+            if (send_counter <= NUM_ITERATIONS)
+            {
+                send_counter += 1;
+                client_stream->send(msg);
+            }
+        });
+
+        test_net.call_later(1s, [&]() {
+            REQUIRE(recv_counter == send_counter);
+            prom_a.set_value(true);
+        });
+
+        require_future(fut_a, 5s);
+
+        REQUIRE(handler->is_paused());
+        REQUIRE_FALSE(handler->is_stopped());
+        REQUIRE_FALSE(handler->is_running());
+
+        recv_counter = 0;
+        send_counter = 0;
+
+        REQUIRE(handler->start());
+
+        test_net.call_later(1s, [&]() {
+            REQUIRE(recv_counter == send_counter);
+            prom_b.set_value(true);
+        });
+
+        require_future(fut_b, 5s);
+
+        REQUIRE(handler->is_stopped());
+        REQUIRE_FALSE(handler->is_running());
+        REQUIRE_FALSE(handler->is_paused());
+    }
+}  //  namespace oxen::quic::test

--- a/tests/013-eventhandler.cpp
+++ b/tests/013-eventhandler.cpp
@@ -19,9 +19,6 @@ namespace oxen::quic::test
     TEST_CASE("013 - EventHandler event repeater: calling object lifetime bound", "[013][repeater][caller]")
     {
         Network test_net{};
-        // const int NUM_ITERATIONS{10};
-        // const auto INTERVAL{10ms};
-        // const auto DELAY{2 * NUM_ITERATIONS * INTERVAL};
         constexpr auto msg = "hello from the other siiiii-iiiiide"_bsv;
 
         std::promise<void> d_promise;
@@ -69,9 +66,6 @@ namespace oxen::quic::test
     TEST_CASE("013 - EventHandler event repeater: EventHandler managed lifetime", "[013][repeater][managed]")
     {
         Network test_net{};
-        // const int NUM_ITERATIONS{10};
-        // const auto INTERVAL{10ms};
-        // const auto DELAY{2 * NUM_ITERATIONS * INTERVAL};
         constexpr auto msg = "hello from the other siiiii-iiiiide"_bsv;
 
         std::promise<void> prom_a, prom_b;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,6 +39,7 @@ if(LIBQUIC_BUILD_TESTS)
         010-migration.cpp
         011-manual_transmission.cpp
         012-watermarks.cpp
+        013-eventhandler.cpp
 
         main.cpp
         case_logger.cpp


### PR DESCRIPTION
- Repeating events can be instantiated using `::call_every(...)`
- `EventHandler` object is added for lifetime management of repeated events. Application can start/pause/stop at will
- Application has the choice of tying the lifetime of the event to the calling object, or using the `EventHandler`
- 002 test case added sending via repeater
- `std::move` -> `std::forward` where necessary