### PR TITLE
Make to_string() formattability opt-in

### DIFF
--- a/include/oxen/quic/address.hpp
+++ b/include/oxen/quic/address.hpp
@@ -277,6 +277,7 @@ namespace oxen::quic
         // Convenience method for debugging, etc.  This is usually called implicitly by passing the
         // Address to fmt to format it.
         std::string to_string() const;
+        constexpr static bool to_string_formattable = true;
     };
 
     struct RemoteAddress : public Address
@@ -359,6 +360,7 @@ namespace oxen::quic
         Path invert() const { return {remote, local}; }
 
         std::string to_string() const;
+        constexpr static bool to_string_formattable = true;
     };
 }  // namespace oxen::quic
 

--- a/include/oxen/quic/connection_ids.hpp
+++ b/include/oxen/quic/connection_ids.hpp
@@ -38,6 +38,7 @@ namespace oxen::quic
         explicit operator const uint64_t&() const { return id; }
 
         std::string to_string() const;
+        constexpr static bool to_string_formattable = true;
     };
 
     // Wrapper for ngtcp2_cid with helper functionalities to make it passable
@@ -65,6 +66,7 @@ namespace oxen::quic
         static quic_cid random();
 
         std::string to_string() const;
+        constexpr static bool to_string_formattable = true;
     };
 }  // namespace oxen::quic
 

--- a/include/oxen/quic/format.hpp
+++ b/include/oxen/quic/format.hpp
@@ -42,6 +42,7 @@ namespace oxen::quic
         {}
 
         std::string to_string() const;
+        static constexpr bool to_string_formattable = true;
     };
 }  // namespace oxen::quic
 

--- a/include/oxen/quic/formattable.hpp
+++ b/include/oxen/quic/formattable.hpp
@@ -14,7 +14,7 @@ namespace oxen::quic
 {
     // Types can opt-in to being fmt-formattable by ensuring they have a ::to_string() method defined
     template <typename T>
-    concept CONCEPT_COMPAT ToStringFormattable = requires(T a) {
+    concept CONCEPT_COMPAT ToStringFormattable = T::to_string_formattable && requires(T a) {
         {
             a.to_string()
         } -> std::convertible_to<std::string_view>;

--- a/include/oxen/quic/gnutls_crypto.hpp
+++ b/include/oxen/quic/gnutls_crypto.hpp
@@ -15,11 +15,11 @@ namespace oxen::quic
 
     class Connection;
 
-    const std::string translate_key_format(gnutls_x509_crt_fmt_t crt);
+    std::string translate_key_format(gnutls_x509_crt_fmt_t crt);
 
-    const std::string translate_cert_type(gnutls_certificate_type_t type);
+    std::string translate_cert_type(gnutls_certificate_type_t type);
 
-    const std::string get_cert_type(gnutls_session_t session, gnutls_ctype_target_t type);
+    std::string get_cert_type(gnutls_session_t session, gnutls_ctype_target_t type);
 
     extern "C"
     {

--- a/include/oxen/quic/ip.hpp
+++ b/include/oxen/quic/ip.hpp
@@ -29,7 +29,8 @@ namespace oxen::quic
             return std::nullopt;
         }
 
-        const std::string to_string() const;
+        std::string to_string() const;
+        constexpr static bool to_string_formattable = true;
 
         explicit operator in_addr() const
         {
@@ -66,7 +67,8 @@ namespace oxen::quic
 
         constexpr ipv4_net(ipv4 b, uint8_t m) : base{b.to_base(m)}, mask{m} {}
 
-        const std::string to_string() const;
+        std::string to_string() const;
+        constexpr static bool to_string_formattable = true;
 
         constexpr bool operator==(const ipv4_net& a) const { return std::tie(base, mask) == std::tie(a.base, a.mask); }
 
@@ -136,7 +138,8 @@ namespace oxen::quic
 
         in6_addr to_in6() const;
 
-        const std::string to_string() const;
+        std::string to_string() const;
+        constexpr static bool to_string_formattable = true;
 
         constexpr auto operator<=>(const ipv6& a) const { return std::tie(hi, lo) <=> std::tie(a.hi, a.lo); }
 
@@ -187,6 +190,7 @@ namespace oxen::quic
         constexpr ipv6_net(ipv6 b, uint8_t m) : base{b.to_base(m)}, mask{m} {}
 
         const std::string to_string() const;
+        constexpr static bool to_string_formattable = true;
 
         constexpr bool operator==(const ipv6_net& a) const { return std::tie(base, mask) == std::tie(a.base, a.mask); }
 

--- a/src/gnutls_creds.cpp
+++ b/src/gnutls_creds.cpp
@@ -4,7 +4,7 @@
 
 namespace oxen::quic
 {
-    const std::string translate_key_format(gnutls_x509_crt_fmt_t crt)
+    std::string translate_key_format(gnutls_x509_crt_fmt_t crt)
     {
         if (crt == GNUTLS_X509_FMT_DER)
             return "<< DER >>";
@@ -14,7 +14,7 @@ namespace oxen::quic
         return "<< UNKNOWN >>";
     }
 
-    const std::string translate_cert_type(gnutls_certificate_type_t type)
+    std::string translate_cert_type(gnutls_certificate_type_t type)
     {
         auto t = static_cast<int>(type);
 
@@ -32,7 +32,7 @@ namespace oxen::quic
         }
     }
 
-    const std::string get_cert_type(gnutls_session_t session, gnutls_ctype_target_t type)
+    std::string get_cert_type(gnutls_session_t session, gnutls_ctype_target_t type)
     {
         return translate_cert_type(gnutls_certificate_type_get2(session, type));
     }

--- a/src/ip.cpp
+++ b/src/ip.cpp
@@ -11,7 +11,7 @@ namespace oxen::quic
         addr = oxenc::big_to_host(sin.s_addr);
     }
 
-    const std::string ipv4::to_string() const
+    std::string ipv4::to_string() const
     {
         char buf[INET_ADDRSTRLEN] = {};
         uint32_t net = oxenc::host_to_big(addr);
@@ -20,7 +20,7 @@ namespace oxen::quic
         return "{}"_format(buf);
     }
 
-    const std::string ipv4_net::to_string() const
+    std::string ipv4_net::to_string() const
     {
         return "{}/{}"_format(base.to_string(), mask);
     }
@@ -44,7 +44,7 @@ namespace oxen::quic
         lo = oxenc::load_big_to_host<uint64_t>(&sin6.s6_addr[8]);
     }
 
-    const std::string ipv6::to_string() const
+    std::string ipv6::to_string() const
     {
         char buf[INET6_ADDRSTRLEN] = {};
 


### PR DESCRIPTION
The ToStringFormattable concept leaks out of libquic into other codebases that have a to_string() method but want to define their own formattability: the result in an ambiguous formatter instantiation because libquic's concept-guarded formatters applies too broadly.

This updates it to require to_string() but *also* a `bool to_string_formattable` constexpr static member so that classes have to explicitly opt-in to the formatter-via-to_string() behaviour.

This also fixes some harmful `const` qualifications on existing to_string() methods (which prevent moving the returned, temporary string).