### PR TITLE
Make to_string() formattability opt-in (stable branch)

### DIFF
--- a/include/oxen/quic/address.hpp
+++ b/include/oxen/quic/address.hpp
@@ -305,6 +305,7 @@ namespace oxen::quic
         // Convenience method for debugging, etc.  This is usually called implicitly by passing the
         // Address to fmt to format it.
         std::string to_string() const;
+        constexpr static bool to_string_formattable = true;
     };
 
     struct RemoteAddress : public Address
@@ -381,6 +382,7 @@ namespace oxen::quic
         }
 
         std::string to_string() const;
+        constexpr static bool to_string_formattable = true;
     };
 }  // namespace oxen::quic
 

--- a/include/oxen/quic/connection_ids.hpp
+++ b/include/oxen/quic/connection_ids.hpp
@@ -38,6 +38,7 @@ namespace oxen::quic
         explicit operator const uint64_t&() const { return id; }
 
         std::string to_string() const;
+        constexpr static bool to_string_formattable = true;
     };
 
     // Wrapper for ngtcp2_cid with helper functionalities to make it passable
@@ -65,6 +66,7 @@ namespace oxen::quic
         static quic_cid random();
 
         std::string to_string() const;
+        constexpr static bool to_string_formattable = true;
     };
 }  // namespace oxen::quic
 

--- a/include/oxen/quic/format.hpp
+++ b/include/oxen/quic/format.hpp
@@ -41,6 +41,7 @@ namespace oxen::quic
         {}
 
         std::string to_string() const;
+        static constexpr bool to_string_formattable = true;
     };
 }  // namespace oxen::quic
 

--- a/include/oxen/quic/formattable.hpp
+++ b/include/oxen/quic/formattable.hpp
@@ -14,7 +14,7 @@ namespace oxen::quic
 {
     // Types can opt-in to being fmt-formattable by ensuring they have a ::to_string() method defined
     template <typename T>
-    concept CONCEPT_COMPAT ToStringFormattable = requires(T a) {
+    concept CONCEPT_COMPAT ToStringFormattable = T::to_string_formattable && requires(T a) {
         {
             a.to_string()
         } -> std::convertible_to<std::string_view>;

--- a/include/oxen/quic/gnutls_crypto.hpp
+++ b/include/oxen/quic/gnutls_crypto.hpp
@@ -13,11 +13,11 @@ namespace oxen::quic
 {
     class Connection;
 
-    const std::string translate_key_format(gnutls_x509_crt_fmt_t crt);
+    std::string translate_key_format(gnutls_x509_crt_fmt_t crt);
 
-    const std::string translate_cert_type(gnutls_certificate_type_t type);
+    std::string translate_cert_type(gnutls_certificate_type_t type);
 
-    const std::string get_cert_type(gnutls_session_t session, gnutls_ctype_target_t type);
+    std::string get_cert_type(gnutls_session_t session, gnutls_ctype_target_t type);
 
     extern "C"
     {

--- a/include/oxen/quic/ip.hpp
+++ b/include/oxen/quic/ip.hpp
@@ -19,7 +19,8 @@ namespace oxen::quic
                 ipv4{uint32_t{a} << 24 | uint32_t{b} << 16 | uint32_t{c} << 8 | uint32_t{d}}
         {}
 
-        const std::string to_string() const;
+        std::string to_string() const;
+        constexpr static bool to_string_formattable = true;
 
         explicit operator in_addr() const
         {
@@ -44,7 +45,8 @@ namespace oxen::quic
         ipv4 base;
         uint8_t mask;
 
-        const std::string to_string() const { return base.to_base(mask).to_string(); }
+        std::string to_string() const { return base.to_base(mask).to_string(); }
+        constexpr static bool to_string_formattable = true;
 
         constexpr bool operator==(const ipv4_net& a) const { return base == a.base && mask == a.mask; }
 
@@ -94,7 +96,8 @@ namespace oxen::quic
 
         in6_addr to_in6() const;
 
-        const std::string to_string() const;
+        std::string to_string() const;
+        constexpr static bool to_string_formattable = true;
 
         constexpr bool operator==(const ipv6& a) const { return hi == a.hi && lo == a.lo; }
 
@@ -124,7 +127,8 @@ namespace oxen::quic
         ipv6 base;
         uint8_t mask;
 
-        const std::string to_string() const { return base.to_base(mask).to_string(); }
+        std::string to_string() const { return base.to_base(mask).to_string(); }
+        constexpr static bool to_string_formattable = true;
 
         constexpr bool operator==(const ipv6_net& a) { return base == a.base && mask == a.mask; }
 

--- a/src/gnutls_creds.cpp
+++ b/src/gnutls_creds.cpp
@@ -4,7 +4,7 @@
 
 namespace oxen::quic
 {
-    const std::string translate_key_format(gnutls_x509_crt_fmt_t crt)
+    std::string translate_key_format(gnutls_x509_crt_fmt_t crt)
     {
         if (crt == GNUTLS_X509_FMT_DER)
             return "<< DER >>";
@@ -14,7 +14,7 @@ namespace oxen::quic
         return "<< UNKNOWN >>";
     }
 
-    const std::string translate_cert_type(gnutls_certificate_type_t type)
+    std::string translate_cert_type(gnutls_certificate_type_t type)
     {
         auto t = static_cast<int>(type);
 
@@ -32,7 +32,7 @@ namespace oxen::quic
         }
     }
 
-    const std::string get_cert_type(gnutls_session_t session, gnutls_ctype_target_t type)
+    std::string get_cert_type(gnutls_session_t session, gnutls_ctype_target_t type)
     {
         return translate_cert_type(gnutls_certificate_type_get2(session, type));
     }

--- a/src/ip.cpp
+++ b/src/ip.cpp
@@ -18,7 +18,7 @@ namespace oxen::quic
             throw std::invalid_argument{"IPv4 constructor failed to parse input: {}"_format(ip)};
     }
 
-    const std::string ipv4::to_string() const
+    std::string ipv4::to_string() const
     {
         char buf[INET_ADDRSTRLEN] = {};
         inet_ntop(AF_INET, &addr, buf, sizeof(buf));
@@ -54,7 +54,7 @@ namespace oxen::quic
         return ret;
     }
 
-    const std::string ipv6::to_string() const
+    std::string ipv6::to_string() const
     {
         char buf[INET6_ADDRSTRLEN] = {};
 


### PR DESCRIPTION
The ToStringFormattable concept leaks out of libquic into other codebases that have a to_string() method but want to define their own formattability: the result in an ambiguous formatter instantiation because libquic's concept-guarded formatters applies too broadly.

This updates it to require to_string() but *also* a `bool to_string_formattable` constexpr static member so that classes have to explicitly opt-in to the formatter-via-to_string() behaviour.

This also fixes some harmful `const` qualifications on existing to_string() methods (which prevent moving the returned, temporary string).