### PR TITLE
Cherry-pick some fixes/changes from dev to stable

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -86,7 +86,7 @@ set(OXEN_LOGGING_SOURCE_ROOT "${OXEN_LOGGING_SOURCE_ROOT};${PROJECT_SOURCE_DIR}"
 
 # oxenc
 if (NOT TARGET oxenc)
-    system_or_submodule(OXENC oxenc liboxenc>=1.0.10 oxen-encoding)
+    system_or_submodule(OXENC oxenc liboxenc>=1.1.0 oxen-encoding)
 endif()
 
 # libevent

--- a/include/oxen/quic/btstream.hpp
+++ b/include/oxen/quic/btstream.hpp
@@ -80,7 +80,7 @@ namespace oxen::quic
         //  }
         explicit operator bool() const { return !timed_out && !is_error(); }
 
-        template <typename Char = char, typename = std::enable_if_t<sizeof(Char) == 1>>
+        template <oxenc::basic_char Char = char>
         std::basic_string_view<Char> view() const
         {
             return {reinterpret_cast<const Char*>(data.data()), data.size()};
@@ -94,13 +94,13 @@ namespace oxen::quic
         std::string_view endpoint() const { return {reinterpret_cast<const char*>(data.data()) + ep.first, ep.second}; }
         std::string endpoint_str() const { return std::string{endpoint()}; }
 
-        template <typename Char = char, typename = std::enable_if_t<sizeof(Char) == 1>>
+        template <oxenc::basic_char Char = char>
         std::basic_string_view<Char> body() const
         {
             return {reinterpret_cast<const Char*>(data.data()) + req_body.first, req_body.second};
         }
 
-        template <typename Char = char, typename = std::enable_if_t<sizeof(Char) == 1>>
+        template <oxenc::basic_char Char = char>
         std::basic_string<Char> body_str() const
         {
             return std::basic_string<Char>{body<Char>()};

--- a/include/oxen/quic/datagram.hpp
+++ b/include/oxen/quic/datagram.hpp
@@ -26,21 +26,20 @@ namespace oxen::quic
 
         std::shared_ptr<connection_interface> get_conn_interface();
 
-        template <
-                typename CharType,
-                std::enable_if_t<sizeof(CharType) == 1 && !std::is_same_v<CharType, std::byte>, int> = 0>
+        template <oxenc::basic_char CharType>
+            requires(!std::same_as<CharType, std::byte>)
         void reply(std::basic_string_view<CharType> data, std::shared_ptr<void> keep_alive = nullptr)
         {
             reply(convert_sv<std::byte>(data), std::move(keep_alive));
         }
 
-        template <typename Char, std::enable_if_t<sizeof(Char) == 1, int> = 0>
+        template <oxenc::basic_char Char>
         void send_datagram(std::vector<Char>&& buf)
         {
             reply(std::basic_string_view<Char>{buf.data(), buf.size()}, std::make_shared<std::vector<Char>>(std::move(buf)));
         }
 
-        template <typename CharType>
+        template <oxenc::basic_char CharType>
         void reply(std::basic_string<CharType>&& data)
         {
             auto keep_alive = std::make_shared<std::basic_string<CharType>>(std::move(data));

--- a/include/oxen/quic/format.hpp
+++ b/include/oxen/quic/format.hpp
@@ -6,6 +6,7 @@
 // library).
 
 #include <fmt/format.h>
+#include <oxenc/common.h>
 
 #include <iostream>
 
@@ -19,24 +20,24 @@ namespace oxen::quic
 
         // Constructed from any type of string_view<T> for a single-byte T (char, std::byte,
         // uint8_t, etc.)
-        template <typename T, typename = std::enable_if_t<sizeof(T) == 1>>
+        template <oxenc::basic_char T>
         explicit buffer_printer(std::basic_string_view<T> buf) :
                 buf{reinterpret_cast<const std::byte*>(buf.data()), buf.size()}
         {}
 
         // Constructed from any type of lvalue string<T> for a single-byte T (char, std::byte,
         // uint8_t, etc.)
-        template <typename T, typename = std::enable_if_t<sizeof(T) == 1>>
+        template <oxenc::basic_char T>
         explicit buffer_printer(const std::basic_string<T>& buf) : buffer_printer(std::basic_string_view<T>{buf})
         {}
 
         // *Not* constructable from a string<T> rvalue (because we only hold a view and do not take
         // ownership).
-        template <typename T, typename = std::enable_if_t<sizeof(T) == 1>>
+        template <oxenc::basic_char T>
         explicit buffer_printer(std::basic_string<T>&& buf) = delete;
 
         // Constructable from a (T*, size) argument pair, for byte-sized T's.
-        template <typename T, typename = std::enable_if_t<sizeof(T) == 1>>
+        template <oxenc::basic_char T>
         explicit buffer_printer(const T* data, size_t size) : buffer_printer(std::basic_string_view<T>{data, size})
         {}
 

--- a/include/oxen/quic/ip.hpp
+++ b/include/oxen/quic/ip.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <array>
+
 #include "formattable.hpp"
 #include "utils.hpp"
 

--- a/include/oxen/quic/messages.hpp
+++ b/include/oxen/quic/messages.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <array>
+
 #include "address.hpp"
 #include "types.hpp"
 #include "utils.hpp"

--- a/include/oxen/quic/types.hpp
+++ b/include/oxen/quic/types.hpp
@@ -1,5 +1,9 @@
 #pragma once
 
+#ifdef _WIN32
+#include <array>
+#endif
+
 #include "utils.hpp"
 
 namespace oxen::quic

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -524,7 +524,8 @@ namespace oxen::quic
     {
         auto ts = get_timestamp().count();
         log::trace(log_cat, "Calling ngtcp2_conn_read_pkt...");
-        auto rv = ngtcp2_conn_read_pkt(*this, pkt.path, &pkt.pkt_info, u8data(pkt.data), pkt.data.size(), ts);
+        auto data = pkt.data<uint8_t>();
+        auto rv = ngtcp2_conn_read_pkt(*this, pkt.path, &pkt.pkt_info, data.data(), data.size(), ts);
 
         switch (rv)
         {

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -647,7 +647,8 @@ namespace oxen::quic
     std::optional<quic_cid> Endpoint::handle_packet_connid(const Packet& pkt)
     {
         ngtcp2_version_cid vid;
-        auto rv = ngtcp2_pkt_decode_version_cid(&vid, u8data(pkt.data), pkt.data.size(), NGTCP2_MAX_CIDLEN);
+        auto data = pkt.data<uint8_t>();
+        auto rv = ngtcp2_pkt_decode_version_cid(&vid, data.data(), data.size(), NGTCP2_MAX_CIDLEN);
 
         if (rv == NGTCP2_ERR_VERSION_NEGOTIATION)
         {  // version negotiation has not been sent yet, ignore packet
@@ -679,7 +680,8 @@ namespace oxen::quic
 
         ngtcp2_pkt_hd hdr;
 
-        auto rv = ngtcp2_accept(&hdr, u8data(pkt.data), pkt.data.size());
+        auto data = pkt.data<uint8_t>();
+        auto rv = ngtcp2_accept(&hdr, data.data(), data.size());
 
         if (rv < 0)  // catches all other possible ngtcp2 errors
         {
@@ -687,7 +689,7 @@ namespace oxen::quic
                     log_cat,
                     "Unknown packet received from {}, length={}, code={}; ignoring it.",
                     pkt.path.remote,
-                    pkt.data.size(),
+                    data.size(),
                     ngtcp2_strerror(rv));
             return nullptr;
         }

--- a/src/udp.cpp
+++ b/src/udp.cpp
@@ -766,7 +766,7 @@ namespace oxen::quic
                  {static_cast<const sockaddr*>(hdr.msg_name), hdr.msg_namelen}
 #endif
             },
-            data{data}
+            pkt_data{data}
     {
         assert(path.remote.is_ipv4() || path.remote.is_ipv6());
 

--- a/tests/001-handshake.cpp
+++ b/tests/001-handshake.cpp
@@ -508,10 +508,10 @@ namespace oxen::quic::test
         // Instead of using randomly generated seeds and pubkeys, hardcoded strings are used to deterministically
         // produce the same test result. The key verify callback compares the pubkeys in lexicographical order,
         // deferring to the connetion initiated by the pubkey that appears first in said order.
-        const std::string C_SEED = "468e7ed2cd914ca44568e7189245c7b8e5488404fc88a4019c73b51d9dbc48a5"_hex;
-        const std::string C_PUBKEY = "626136fe40c8860ee5bdc57fd9f15a03ef6777bb9237c18fc4d7ef2aacfe4f88"_hex;
-        const std::string S_SEED = "fefbb50cdd4cde3be0ae75042c44ff42b026def4fd6be4fb1dc6e81ea0480c9b"_hex;
-        const std::string S_PUBKEY = "d580d5c68937095ea997f6a88f07a86cdd26dfa0d7d268e80ea9bbb5f3ca0304"_hex;
+        constexpr auto C_SEED = "468e7ed2cd914ca44568e7189245c7b8e5488404fc88a4019c73b51d9dbc48a5"_hex;
+        constexpr auto C_PUBKEY = "626136fe40c8860ee5bdc57fd9f15a03ef6777bb9237c18fc4d7ef2aacfe4f88"_hex;
+        constexpr auto S_SEED = "fefbb50cdd4cde3be0ae75042c44ff42b026def4fd6be4fb1dc6e81ea0480c9b"_hex;
+        constexpr auto S_PUBKEY = "d580d5c68937095ea997f6a88f07a86cdd26dfa0d7d268e80ea9bbb5f3ca0304"_hex;
 
         Network test_net{};
 
@@ -524,11 +524,11 @@ namespace oxen::quic::test
         std::vector<std::array<std::string, 3>> defer_i_l_r;  // incoming/local/remote
 
         auto defer_hook = [&defer_i_l_r](
-                                  const std::string& incoming,
-                                  const std::string& local,
-                                  const std::string& remote,
+                                  std::string_view incoming,
+                                  std::string_view local,
+                                  std::string_view remote,
                                   std::shared_ptr<connection_interface> local_outbound) -> bool {
-            defer_i_l_r.push_back({incoming, local, remote});
+            defer_i_l_r.push_back({std::string{incoming}, std::string{local}, std::string{remote}});
 
             // If the LHS parameter to std::strcmp appears FIRST in lexicographical order, then rv < 0. As a result,
             // if the incoming pubkey appears BEFORE the server pubkey in lexicographical order, we will defer to the
@@ -545,8 +545,7 @@ namespace oxen::quic::test
 
         server_tls->set_key_verify_callback([&](const ustring_view& key, const ustring_view&) {
             std::lock_guard lock{ci_mutex};
-            return defer_hook(
-                    std::string{reinterpret_cast<const char*>(key.data()), key.size()}, S_PUBKEY, C_PUBKEY, server_ci);
+            return defer_hook({reinterpret_cast<const char*>(key.data()), key.size()}, S_PUBKEY, C_PUBKEY, server_ci);
         });
 
         client_tls->set_key_verify_callback([&](const ustring_view& key, const ustring_view&) {

--- a/tests/002-send-receive.cpp
+++ b/tests/002-send-receive.cpp
@@ -14,7 +14,7 @@ namespace oxen::quic::test
     TEST_CASE("002 - Simple client to server transmission", "[002][simple][execute]")
     {
         Network test_net{};
-        auto good_msg = "hello from the other siiiii-iiiiide"_bsv;
+        constexpr auto good_msg = "hello from the other siiiii-iiiiide"_bsv;
 
         std::promise<bool> d_promise;
         std::future<bool> d_future = d_promise.get_future();
@@ -49,7 +49,7 @@ namespace oxen::quic::test
     TEST_CASE("002 - Simple client to server transmission", "[002][simple][bidirectional]")
     {
         Network test_net{};
-        auto good_msg = "hello from the other siiiii-iiiiide"_bsv;
+        constexpr auto good_msg = "hello from the other siiiii-iiiiide"_bsv;
 
         std::vector<std::promise<void>> d_promises{2};
         std::vector<std::future<void>> d_futures{2};
@@ -101,7 +101,7 @@ namespace oxen::quic::test
     TEST_CASE("002 - Simple client to server transmission", "[002][simple][2x2]")
     {
         Network test_net{};
-        auto good_msg = "hello from the other siiiii-iiiiide"_bsv;
+        constexpr auto good_msg = "hello from the other siiiii-iiiiide"_bsv;
 
         std::vector<std::promise<void>> d_promises{2};
         std::vector<std::future<void>> d_futures{2};

--- a/tests/003-multiclient.cpp
+++ b/tests/003-multiclient.cpp
@@ -31,7 +31,7 @@ namespace oxen::quic::test
     TEST_CASE("003 - Multi-client to server transmission: Execution", "[003][multi-client][execute]")
     {
         Network test_net{};
-        auto msg = "hello from the other siiiii-iiiiide"_bsv;
+        constexpr auto msg = "hello from the other siiiii-iiiiide"_bsv;
 
         std::atomic<int> data_check{0};
         std::vector<std::promise<void>> stream_promises{4};

--- a/tests/004-streams.cpp
+++ b/tests/004-streams.cpp
@@ -39,7 +39,7 @@ namespace oxen::quic::test
     TEST_CASE("004 - Multiple pending streams: streams available", "[004][streams][pending][config]")
     {
         Network test_net{};
-        auto msg = "hello from the other siiiii-iiiiide"_bsv;
+        constexpr auto msg = "hello from the other siiiii-iiiiide"_bsv;
 
         std::promise<void> data_promise;
         std::future<void> data_future = data_promise.get_future();
@@ -75,7 +75,7 @@ namespace oxen::quic::test
         auto client_established = callback_waiter{[](connection_interface&) {}};
 
         Network test_net{};
-        auto msg = "hello from the other siiiii-iiiiide"_bsv;
+        constexpr auto msg = "hello from the other siiiii-iiiiide"_bsv;
 
         std::promise<void> data_promise;
         std::future<void> data_future = data_promise.get_future();
@@ -129,7 +129,7 @@ namespace oxen::quic::test
         auto client_established = callback_waiter{[](connection_interface&) {}};
 
         Network test_net{};
-        auto msg = "hello from the other siiiii-iiiiide"_bsv;
+        constexpr auto msg = "hello from the other siiiii-iiiiide"_bsv;
 
         std::atomic<size_t> index{0};
         std::atomic<size_t> data_check{0};
@@ -258,7 +258,7 @@ namespace oxen::quic::test
     TEST_CASE("004 - Subclassing quic::stream, custom to standard", "[004][customstream][cross]")
     {
         Network test_net{};
-        auto msg = "hello from the other siiiii-iiiiide"_bsv;
+        constexpr auto msg = "hello from the other siiiii-iiiiide"_bsv;
 
         std::promise<void> ss_p, sc_p, cs_p, cc_p;
         std::future<void> ss_f = ss_p.get_future(), sc_f = sc_p.get_future(), cs_f = cs_p.get_future(),
@@ -310,7 +310,7 @@ namespace oxen::quic::test
     TEST_CASE("004 - Subclassing quic::stream, custom to custom", "[004][customstream][subclass]")
     {
         Network test_net{};
-        auto msg = "hello from the other siiiii-iiiiide"_bsv;
+        constexpr auto msg = "hello from the other siiiii-iiiiide"_bsv;
 
         std::promise<void> server_promise, client_promise;
         std::future<void> server_future = server_promise.get_future();

--- a/tests/006-server-send.cpp
+++ b/tests/006-server-send.cpp
@@ -10,7 +10,7 @@ namespace oxen::quic::test
     TEST_CASE("006 - Server streams: Direct creation and transmission", "[006][server][streams][send][execute]")
     {
         Network test_net{};
-        auto msg = "hello from the other siiiii-iiiiide"_bsv;
+        constexpr auto msg = "hello from the other siiiii-iiiiide"_bsv;
 
         std::atomic<int> data_check{0};
 
@@ -67,8 +67,8 @@ namespace oxen::quic::test
     TEST_CASE("006 - Server streams: Remote initiation, server send", "[006][server][streams][send][execute]")
     {
         Network test_net{};
-        auto msg = "hello from the other siiiii-iiiiide"_bsv;
-        auto response = "okay okay i get it already"_bsv;
+        constexpr auto msg = "hello from the other siiiii-iiiiide"_bsv;
+        constexpr auto response = "okay okay i get it already"_bsv;
 
         std::atomic<int> ci{0}, si{0};
         std::atomic<int> data_check{0};

--- a/tests/007-datagrams.cpp
+++ b/tests/007-datagrams.cpp
@@ -153,7 +153,7 @@ namespace oxen::quic::test
             auto client_established = callback_waiter{[](connection_interface&) {}};
 
             Network test_net{};
-            auto msg = "hello from the other siiiii-iiiiide"_bsv;
+            constexpr auto msg = "hello from the other siiiii-iiiiide"_bsv;
 
             std::promise<void> data_promise;
             std::future<void> data_future = data_promise.get_future();

--- a/tests/010-migration.cpp
+++ b/tests/010-migration.cpp
@@ -10,7 +10,7 @@ namespace oxen::quic::test
     TEST_CASE("010 - Migration", "[010][migration]")
     {
         Network test_net{};
-        auto good_msg = "hello from the other siiiii-iiiiide"_bsv;
+        constexpr auto good_msg = "hello from the other siiiii-iiiiide"_bsv;
 
         auto [client_tls, server_tls] = defaults::tls_creds_from_ed_keys();
 


### PR DESCRIPTION
Needed to include <array> in a few places, and the commit that already fixed that on dev has other useful things anyway.

C++20 concepts, constexpr _bsv, _usv, oxen-encoding

Adds more C++20 usage:

- "..."_bsv and "..."_usv are now constexpr
- updating oxen-encoding for constexpr _hex, etc.
- replaces all the "sizeof(Char) == 1" stuff with the oxenc::basic_char concept (which is slightly more robust)
- replaces std::enable_if_ts with requires and/or concepts
- makes GNUTLSCreds construction take string_views instead of copying std::strings