### PR TITLE
Delegating event loop destruction to primary Network object

### DIFF
--- a/include/oxen/quic/endpoint.hpp
+++ b/include/oxen/quic/endpoint.hpp
@@ -234,7 +234,7 @@ namespace oxen::quic
         std::map<ustring, ustring> encoded_transport_params;
         std::map<ustring, ustring> path_validation_tokens;
 
-        const std::shared_ptr<event_base>& get_loop() { return net.loop(); }
+        const std::shared_ptr<event_base>& get_loop() { return net._loop->loop(); }
 
         const std::unique_ptr<UDPSocket>& get_socket() { return socket; }
 
@@ -309,7 +309,7 @@ namespace oxen::quic
 
         const ustring& static_secret() const { return _static_secret; }
 
-        Connection* fetch_associated_conn(ngtcp2_cid* cid);
+        Connection* fetch_associated_conn(quic_cid& cid);
 
         ConnectionID next_reference_id();
 

--- a/include/oxen/quic/loop.hpp
+++ b/include/oxen/quic/loop.hpp
@@ -20,10 +20,10 @@ extern "C"
 namespace oxen::quic
 {
     using Job = std::function<void()>;
+    using loop_ptr = std::shared_ptr<::event_base>;
+    using caller_id_t = uint16_t;
 
     static void setup_libevent_logging();
-
-    using loop_ptr = std::shared_ptr<::event_base>;
 
     class Loop;
 
@@ -98,13 +98,13 @@ namespace oxen::quic
         }
 
       private:
-        static constexpr uint16_t loop_id{0};
+        static constexpr caller_id_t loop_id{0};
 
-        std::unordered_map<uint16_t, std::list<std::weak_ptr<Ticker>>> tickers;
+        std::unordered_map<caller_id_t, std::list<std::weak_ptr<Ticker>>> tickers;
 
         void clear_old_tickers();
 
-        std::shared_ptr<Ticker> make_handler(uint16_t _id);
+        std::shared_ptr<Ticker> make_handler(caller_id_t _id);
 
       public:
         Loop();
@@ -257,10 +257,10 @@ namespace oxen::quic
         // private method invoked in Network destructor by final Network to close shared_ptr
         void stop_thread(bool immediate = true);
 
-        void stop_tickers(uint16_t _id);
+        void stop_tickers(caller_id_t _id);
 
         template <typename Callable>
-        void _call_every(std::chrono::microseconds interval, std::weak_ptr<void> caller, Callable&& f, uint16_t _id)
+        void _call_every(std::chrono::microseconds interval, std::weak_ptr<void> caller, Callable&& f, caller_id_t _id)
         {
             auto handler = make_handler(_id);
             // grab the reference before giving ownership of the repeater to the lambda
@@ -279,7 +279,7 @@ namespace oxen::quic
 
         template <typename Callable>
         [[nodiscard]] std::shared_ptr<Ticker> _call_every(
-                std::chrono::microseconds interval, Callable&& f, uint16_t _id, bool start_immediately)
+                std::chrono::microseconds interval, Callable&& f, caller_id_t _id, bool start_immediately)
         {
             auto h = make_handler(_id);
 

--- a/include/oxen/quic/network.hpp
+++ b/include/oxen/quic/network.hpp
@@ -86,13 +86,13 @@ namespace oxen::quic
         template <typename Callable>
         void call_every(std::chrono::microseconds interval, std::weak_ptr<void> caller, Callable&& f)
         {
-            _loop->_call_every(interval, std::move(caller), std::forward<Callable>(f), netid);
+            _loop->_call_every(interval, std::move(caller), std::forward<Callable>(f), net_id);
         }
 
         template <typename Callable>
         std::shared_ptr<Ticker> call_every(std::chrono::microseconds interval, Callable&& f, bool start_immediately = true)
         {
-            return _loop->_call_every(interval, std::forward<Callable>(f), netid, start_immediately);
+            return _loop->_call_every(interval, std::forward<Callable>(f), net_id, start_immediately);
         }
 
         template <typename Callable>
@@ -112,8 +112,8 @@ namespace oxen::quic
 
         void close_gracefully();
 
-        const int netid;
+        const caller_id_t net_id;
 
-        static int next_netid;
+        static caller_id_t next_net_id;
     };
 }  // namespace oxen::quic

--- a/include/oxen/quic/network.hpp
+++ b/include/oxen/quic/network.hpp
@@ -14,15 +14,36 @@ namespace oxen::quic
 {
     class Endpoint;
 
-    class Network
+    /** Network:
+            This object is the entry point to libquic, providing functionalities like job scheduling and endpoint creation
+        for application implementation. Networks can have one of two relationships to event loop that it manages:
+            - Standard ownership: The event loop's lifetime is entirely managed within the Network object. It is not a
+                publicly exposed attribute, and cannot be accessed to directly construct other networks "chained" off of the
+                same event loop. If the application requires multiple networks that share one underlying event loop, invoking
+                the `::create_linked_network()` method will return a new Network object sharing its own event loop. For the
+                application code, this has the effect of only destroying the event loop when the last Network sharing it is
+                destroyed.
+            - Application ownership: The event loop's lifetime is entirely managed by the application code and managing
+                context. A standalone Loop object is created and passed by value in each subsequent Network construction. It
+                is the responsibility of the application code to ensure that the event loop is last to be destroyed. Objects
+                like endpoints are held in shared_pointers with deleters scheduled on the event loop. The event loop must
+                persist until all objects held externally (Network, Endpoint, Connection, etc) are destroyed.
+     */
+
+    class Network final
     {
       public:
-        Network(std::shared_ptr<::event_base> loop_ptr, std::thread::id loop_thread_id);
-        Network(std::shared_ptr<Loop> ev_loop);
         Network();
+        explicit Network(std::shared_ptr<Loop> ev_loop);
+
+        Network(const Network& n) : Network{n._loop} {};
+
+        Network& operator=(Network) = delete;
+        Network& operator=(Network&&) = delete;
+
         ~Network();
 
-        const std::shared_ptr<::event_base>& loop() const { return _loop->loop(); }
+        [[nodiscard]] Network create_linked_network();
 
         bool in_event_loop() const { return _loop->in_event_loop(); }
 
@@ -65,13 +86,13 @@ namespace oxen::quic
         template <typename Callable>
         void call_every(std::chrono::microseconds interval, std::weak_ptr<void> caller, Callable&& f)
         {
-            _loop->call_every(interval, std::move(caller), std::forward<Callable>(f));
+            _loop->_call_every(interval, std::move(caller), std::forward<Callable>(f), netid);
         }
 
         template <typename Callable>
         std::shared_ptr<Ticker> call_every(std::chrono::microseconds interval, Callable&& f, bool start_immediately = true)
         {
-            return _loop->call_every(interval, std::forward<Callable>(f), start_immediately);
+            return _loop->_call_every(interval, std::forward<Callable>(f), netid, start_immediately);
         }
 
         template <typename Callable>
@@ -90,5 +111,9 @@ namespace oxen::quic
         friend class Stream;
 
         void close_gracefully();
+
+        const int netid;
+
+        static int next_netid;
     };
 }  // namespace oxen::quic

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -221,7 +221,7 @@ namespace oxen::quic
         // check existing conns
         log::trace(log_cat, "Incoming connection ID: {}", dcid);
 
-        auto cptr = fetch_associated_conn(&dcid);
+        auto cptr = fetch_associated_conn(dcid);
 
         if (!cptr)
         {
@@ -502,10 +502,8 @@ namespace oxen::quic
         conn_lookup.erase(ccid);
     }
 
-    Connection* Endpoint::fetch_associated_conn(ngtcp2_cid* cid)
+    Connection* Endpoint::fetch_associated_conn(quic_cid& ccid)
     {
-        auto ccid = quic_cid{*cid};
-
         if (auto it_a = conn_lookup.find(ccid); it_a != conn_lookup.end())
         {
             if (auto it_b = conns.find(it_a->second); it_b != conns.end())

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -232,7 +232,7 @@ namespace oxen::quic
         }
     }
 
-    std::shared_ptr<Ticker> Loop::make_handler(uint16_t _id)
+    std::shared_ptr<Ticker> Loop::make_handler(caller_id_t _id)
     {
         clear_old_tickers();
         auto t = make_shared<Ticker>();
@@ -240,7 +240,7 @@ namespace oxen::quic
         return t;
     }
 
-    void Loop::stop_tickers(uint16_t id)
+    void Loop::stop_tickers(caller_id_t id)
     {
         if (auto it = tickers.find(id); it != tickers.end())
         {

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -12,14 +12,14 @@
 
 namespace oxen::quic
 {
-    int Network::next_netid = 0;
+    caller_id_t Network::next_net_id = 0;
 
-    Network::Network(std::shared_ptr<Loop> ev_loop) : _loop{std::move(ev_loop)}, netid{++next_netid}
+    Network::Network(std::shared_ptr<Loop> ev_loop) : _loop{std::move(ev_loop)}, net_id{++next_net_id}
     {
         log::trace(log_cat, "Creating network context with pre-existing event loop!");
     }
 
-    Network::Network() : _loop{std::make_shared<Loop>()}, netid{++next_netid} {}
+    Network::Network() : _loop{std::make_shared<Loop>()}, net_id{++next_net_id} {}
 
     Network::~Network()
     {
@@ -33,7 +33,7 @@ namespace oxen::quic
         if (_loop.use_count() == 1)
             _loop->stop_thread(shutdown_immediate);
 
-        _loop->stop_tickers(netid);
+        _loop->stop_tickers(net_id);
 
         log::info(log_cat, "Network shutdown complete");
     }

--- a/tests/001-handshake.cpp
+++ b/tests/001-handshake.cpp
@@ -11,6 +11,20 @@ namespace oxen::quic::test
 
     TEST_CASE("001 - Handshaking: Types", "[001][handshake][tls][types]")
     {
+        SECTION("Network and Loop Construction")
+        {
+            // Standard ownership
+            auto standard_neta = std::make_unique<Network>();
+            auto standard_netb = std::make_unique<Network>(standard_neta->create_linked_network());
+            REQUIRE_FALSE(standard_neta == standard_netb);
+
+            // Application ownership
+            auto loop = std::make_shared<Loop>();
+            auto app_neta = std::make_unique<Network>(loop);
+            auto app_netb = std::make_unique<Network>(loop);
+            REQUIRE_FALSE(app_neta == app_netb);
+        }
+
         SECTION("TLS Credentials")
         {
             auto [client_tls, server_tls] = defaults::tls_creds_from_ed_keys();

--- a/tests/002-send-receive.cpp
+++ b/tests/002-send-receive.cpp
@@ -131,18 +131,18 @@ namespace oxen::quic::test
         RemoteAddress server_remote_a{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint_a->local().port()};
         RemoteAddress server_remote_b{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint_b->local().port()};
 
-        auto server_a_ci = server_endpoint_b->connect(server_remote_a, server_tls);
-        auto server_a_stream = server_a_ci->open_stream();
-
-        server_a_stream->send(good_msg);
-
-        require_future(d_futures[0]);
-
-        auto server_b_ci = server_endpoint_a->connect(server_remote_b, server_tls);
-
+        auto server_b_ci = server_endpoint_b->connect(server_remote_a, server_tls);
         auto server_b_stream = server_b_ci->open_stream();
 
         server_b_stream->send(good_msg);
+
+        require_future(d_futures[0]);
+
+        auto server_a_ci = server_endpoint_a->connect(server_remote_b, server_tls);
+
+        auto server_a_stream = server_a_ci->open_stream();
+
+        server_a_stream->send(good_msg);
 
         require_future(d_futures[1]);
     }


### PR DESCRIPTION
## __**Problem:**__
Previously, Network objects deferred all closing and cleanup logic to the destructor, in accordance with RAII. This is a good thing, as it simplifies object creation/destruction in relation to the current scope in which it is existing. However, this causes some issues with the ambiguous ownership model with respect to the event loop.

If the Networks exist in different owning objects and/or contexts, the closure of one (ex: if stored in a unique_ptr) will result in the destruction of the shared loop object. This can result in undefined behavior, segfaults, and other wild stuff. Libquic also exposes the ability to create an arbitrary number of Networks using either a pre-existing Loop object, or using the Loop accessor in the Network object

The main functional objects in Libquic (i.e. Endpoints, Connections, Streams, etc) are constructed within shared pointers to be given to the application code. These shared pointers are constructed with custom deleters that schedule the invocation on the event loop. When combined with an ambiguous ownership model, the following may happen:
- If Network A makes a loop, and B is created off of it, B will destroy the loop on invocation of its destructor.
- However, when A invokes its destructor, the endpoint shared pointers will try to `::call()` the deleters, causing a segfault
If Network A or B has any objects persisting in the application code, they will compound the issue when they attempt to close, finding the loop closed as well

## __**Updated Ownership Model:**__
Networks can have one of two relationships to event loop that it manages:

- Standard ownership: The event loop's lifetime is entirely managed within the Network object. It is not a
publicly exposed attribute, and cannot be accessed to directly construct other networks "chained" off of the
same event loop. If the application requires multiple networks that share one underlying event loop, invoking
the `::create_linked_network()` method will return a new Network object sharing its own event loop. For the
application code, this has the effect of only destroying the event loop when the last Network sharing it is
destroyed.
- Application ownership: The event loop's lifetime is entirely managed by the application code and managing
context. A standalone Loop object is created and passed by value in each subsequent Network construction. It
is the responsibility of the application code to ensure that the event loop is last to be destroyed. Objects
like endpoints are held in shared_pointers with deleters scheduled on the event loop. The event loop must
persist until all objects held externally (Network, Endpoint, Connection, etc) are destroyed.