### PR TITLE
0RTT, Early data, session ticketing, key verification, stateless reset

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,20 +1,35 @@
 BasedOnStyle: Google
+
+AccessModifierOffset: -2
+
+# alignment
 AlignAfterOpenBracket: AlwaysBreak
 AlignConsecutiveAssignments: 'false'
 AlignConsecutiveDeclarations: 'false'
 AlignEscapedNewlines: Left
 AlignOperands: AlignAfterOperator
 AlignTrailingComments: 'true'
+
+# inlining
 AllowAllArgumentsOnNextLine: 'true'
 AllowShortBlocksOnASingleLine: 'false'
 AllowShortCaseLabelsOnASingleLine: 'false'
-AllowShortFunctionsOnASingleLine: Inline
+AllowShortFunctionsOnASingleLine: 'Inline'
 AllowShortIfStatementsOnASingleLine: 'false'
 AllowShortLoopsOnASingleLine: 'false'
+RequiresClausePosition: 'OwnLine'
+
+# breaking
 AlwaysBreakAfterReturnType: None
 AlwaysBreakTemplateDeclarations: Yes
 BreakBeforeBinaryOperators: None
 BreakBeforeBraces: Custom
+BreakBeforeConceptDeclarations: 'Always'
+BreakBeforeTernaryOperators: 'true'
+BreakConstructorInitializers: AfterColon
+PenaltyBreakString: '3'
+
+# bracing
 BraceWrapping:
   AfterCaseLabel: true
   AfterClass: true
@@ -33,29 +48,29 @@ BraceWrapping:
   SplitEmptyFunction: false
   SplitEmptyRecord: false
   SplitEmptyNamespace: false
-BreakBeforeTernaryOperators: 'true'
-BreakConstructorInitializers: AfterColon
+
+ColumnLimit: 125
+CompactNamespaces: 'true'
+ConstructorInitializerIndentWidth: 8
+ContinuationIndentWidth: 8
 Cpp11BracedListStyle: 'true'
+IndentWidth: 4
 KeepEmptyLinesAtTheStartOfBlocks: 'true'
 NamespaceIndentation: All
-CompactNamespaces: 'true'
-PenaltyBreakString: '3'
+QualifierAlignment: Left
+RemoveSemicolon: true
+SortIncludes: true
+
+# spacing
 SpaceBeforeParens: ControlStatements
 SpacesInAngles: 'false'
 SpacesInContainerLiterals: 'false'
 SpacesInParentheses: 'false'
 SpacesInSquareBrackets: 'false'
-Standard: c++20
-UseTab: Never
-SortIncludes: true
-ColumnLimit: 125
-IndentWidth: 4
-AccessModifierOffset: -2
-ConstructorInitializerIndentWidth: 8
-ContinuationIndentWidth: 8
-QualifierAlignment: Left
 
-RemoveSemicolon: true
+Standard: c++20
+
+UseTab: Never
 
 # treat pointers and reference declarations as if part of the type
 DerivePointerAlignment: false

--- a/include/oxen/quic/address.hpp
+++ b/include/oxen/quic/address.hpp
@@ -6,7 +6,7 @@
 
 #include "formattable.hpp"
 #include "ip.hpp"
-#include "utils.hpp"
+#include "types.hpp"
 
 #if defined(__OpenBSD__) || defined(__DragonFly__)
 // These systems are known to disallow dual stack binding, and so on such systems when
@@ -24,9 +24,6 @@
 namespace oxen::quic
 {
     inline constexpr std::array<uint8_t, 16> _ipv6_any_addr = {0};
-
-    template <typename T>
-    concept RawSockAddr = std::same_as<T, sockaddr> || std::same_as<T, sockaddr_in> || std::same_as<T, sockaddr_in6>;
 
     // Holds an address, with a ngtcp2_addr held for easier passing into ngtcp2 functions
     struct Address
@@ -71,7 +68,7 @@ namespace oxen::quic
         explicit Address(const ipv6& v6, uint16_t port = 0);
 
         // Assignment from a sockaddr pointer; we copy the sockaddr's contents
-        template <RawSockAddr T>
+        template <concepts::raw_sockaddr_type T>
         Address& operator=(const T* s)
         {
             _addr.addrlen = std::is_same_v<T, sockaddr>
@@ -215,12 +212,12 @@ namespace oxen::quic
         // pointer to other things (like bool) won't occur.
         //
         // If the given pointer is mutated you *must* call update_socklen() afterwards.
-        template <RawSockAddr T>
+        template <concepts::raw_sockaddr_type T>
         operator T*()
         {
             return reinterpret_cast<T*>(&_sock_addr);
         }
-        template <RawSockAddr T>
+        template <concepts::raw_sockaddr_type T>
         operator const T*() const
         {
             return reinterpret_cast<const T*>(&_sock_addr);

--- a/include/oxen/quic/address.hpp
+++ b/include/oxen/quic/address.hpp
@@ -25,6 +25,18 @@ namespace oxen::quic
 {
     inline constexpr std::array<uint8_t, 16> _ipv6_any_addr = {0};
 
+    struct Address;
+
+    inline namespace concepts
+    {
+        template <typename T>
+        concept raw_sockaddr_type =
+                std::same_as<T, sockaddr> || std::same_as<T, sockaddr_in> || std::same_as<T, sockaddr_in6>;
+
+        template <typename T>
+        concept quic_address_type = std::derived_from<T, Address>;
+    }  // namespace concepts
+
     // Holds an address, with a ngtcp2_addr held for easier passing into ngtcp2 functions
     struct Address
     {

--- a/include/oxen/quic/address.hpp
+++ b/include/oxen/quic/address.hpp
@@ -366,12 +366,10 @@ namespace oxen::quic
 
 namespace std
 {
-    inline constexpr size_t inverse_golden_ratio = sizeof(size_t) >= 8 ? 0x9e37'79b9'7f4a'7c15 : 0x9e37'79b9;
-
     template <>
     struct hash<oxen::quic::Address>
     {
-        size_t operator()(const oxen::quic::Address& addr) const
+        size_t operator()(const oxen::quic::Address& addr) const noexcept
         {
             std::string_view addr_data;
             uint16_t port;
@@ -390,7 +388,7 @@ namespace std
             }
 
             auto h = hash<string_view>{}(addr_data);
-            h ^= hash<decltype(port)>{}(port) + inverse_golden_ratio + (h << 6) + (h >> 2);
+            h ^= hash<decltype(port)>{}(port) + oxen::quic::inverse_golden_ratio + (h << 6) + (h >> 2);
             return h;
         }
     };
@@ -398,10 +396,10 @@ namespace std
     template <>
     struct hash<oxen::quic::Path>
     {
-        size_t operator()(const oxen::quic::Path& addr) const
+        size_t operator()(const oxen::quic::Path& addr) const noexcept
         {
             auto h = hash<oxen::quic::Address>{}(addr.local);
-            h ^= hash<oxen::quic::Address>{}(addr.remote) + inverse_golden_ratio + (h << 6) + (h >> 2);
+            h ^= hash<oxen::quic::Address>{}(addr.remote) + oxen::quic::inverse_golden_ratio + (h << 6) + (h >> 2);
             return h;
         }
     };

--- a/include/oxen/quic/btstream.hpp
+++ b/include/oxen/quic/btstream.hpp
@@ -6,8 +6,6 @@
 
 namespace oxen::quic
 {
-    using time_point = std::chrono::steady_clock::time_point;
-
     // timeout is used for sent requests awaiting responses
     inline constexpr std::chrono::seconds DEFAULT_TIMEOUT{10s};
 

--- a/include/oxen/quic/connection.hpp
+++ b/include/oxen/quic/connection.hpp
@@ -317,6 +317,9 @@ namespace oxen::quic
         bool datagrams_enabled() const override { return _datagrams_enabled; }
         bool packet_splitting_enabled() const override { return _packet_splitting; }
 
+        bool zero_rtt_enabled() const { return _0rtt_enabled; }
+        unsigned int zero_rtt_window() const { return _0rtt_window; }
+
         std::optional<size_t> max_datagram_size_changed() override;
 
         // public debug functions; to be removed with friend test fixture class
@@ -395,6 +398,9 @@ namespace oxen::quic
         quic_cid _dest_cid;
 
         Path _path;
+
+        const bool _0rtt_enabled{false};
+        const unsigned int _0rtt_window{};
 
         const uint64_t _max_streams{DEFAULT_MAX_BIDI_STREAMS};
         const bool _datagrams_enabled{false};

--- a/include/oxen/quic/connection.hpp
+++ b/include/oxen/quic/connection.hpp
@@ -418,7 +418,7 @@ namespace oxen::quic
 
         ustring remote_pubkey{};
 
-        std::set<int64_t> _early_streams;
+        std::vector<int64_t> _early_streams;
 
         void make_early_streams(ngtcp2_conn* connptr);
 

--- a/include/oxen/quic/connection.hpp
+++ b/include/oxen/quic/connection.hpp
@@ -315,6 +315,8 @@ namespace oxen::quic
         bool zero_rtt_enabled() const { return _0rtt_enabled; }
         unsigned int zero_rtt_window() const { return _0rtt_window; }
 
+        bool stateless_reset_enabled() const { return _stateless_reset_enabled; }
+
         std::optional<size_t> max_datagram_size_changed() override;
 
         // public debug functions; to be removed with friend test fixture class
@@ -340,13 +342,19 @@ namespace oxen::quic
 
         void store_associated_cid(const quic_cid& cid);
 
+        void delete_associated_cid(const quic_cid& cid);
+
         std::unordered_set<quic_cid>& associated_cids() { return _associated_cids; }
 
         int client_handshake_completed();
 
         int server_handshake_completed();
 
-        int server_path_validation(const ngtcp2_path* path);
+        int recv_stateless_reset(std::shared_ptr<gtls_reset_token> tok);
+
+        int client_path_validation(const ngtcp2_path* path, bool res, uint32_t flags);
+
+        int server_path_validation(const ngtcp2_path* path, bool res, uint32_t flags);
 
         void set_new_path(Path new_path);
 
@@ -394,8 +402,10 @@ namespace oxen::quic
 
         Path _path;
 
-        const bool _0rtt_enabled{false};
+        bool _0rtt_enabled{false};
         const unsigned int _0rtt_window{};
+
+        bool _stateless_reset_enabled{false};
 
         const uint64_t _max_streams{DEFAULT_MAX_BIDI_STREAMS};
         const bool _datagrams_enabled{false};

--- a/include/oxen/quic/connection.hpp
+++ b/include/oxen/quic/connection.hpp
@@ -416,7 +416,7 @@ namespace oxen::quic
         std::atomic<bool> _close_quietly{false};
         std::atomic<bool> _is_validated{false};
 
-        ustring remote_pubkey;
+        ustring remote_pubkey{};
 
         std::set<int64_t> _early_streams;
 

--- a/include/oxen/quic/connection.hpp
+++ b/include/oxen/quic/connection.hpp
@@ -483,7 +483,7 @@ namespace oxen::quic
         // streams are added to the back and popped from the front (FIFO)
         std::deque<std::shared_ptr<Stream>> pending_streams;
 
-        int init(
+        void init(
                 ngtcp2_settings& settings,
                 ngtcp2_transport_params& params,
                 ngtcp2_callbacks& callbacks,

--- a/include/oxen/quic/connection.hpp
+++ b/include/oxen/quic/connection.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <concepts>
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
@@ -15,7 +14,6 @@
 #include "context.hpp"
 #include "format.hpp"
 #include "types.hpp"
-#include "utils.hpp"
 
 namespace oxen::quic
 {
@@ -24,9 +22,6 @@ namespace oxen::quic
 
     inline constexpr uint64_t MAX_ACTIVE_CIDS{8};
     inline constexpr size_t NGTCP2_RETRY_SCIDLEN{18};
-
-    template <typename T>
-    concept StreamDerived = std::derived_from<T, Stream>;
 
     class connection_interface : public std::enable_shared_from_this<connection_interface>
     {
@@ -45,7 +40,7 @@ namespace oxen::quic
         /// ID; it will be made ready once the associated stream id is seen from the remote
         /// connection.  Note that this constructor bypasses the stream constructor callback for the
         /// applicable stream id.
-        template <StreamDerived StreamT, typename... Args, typename EndpointDeferred = Endpoint>
+        template <concepts::stream_derived_type StreamT, typename... Args, typename EndpointDeferred = Endpoint>
         std::shared_ptr<StreamT> queue_incoming_stream(Args&&... args)
         {
             // We defer resolution of `Endpoint` here via `EndpointDeferred` because the header only
@@ -70,7 +65,7 @@ namespace oxen::quic
         /// such as from an increase in available stream ids resulting from the closure of an
         /// existing stream.  Note that this constructor bypasses the stream constructor callback
         /// for the applicable stream id.
-        template <StreamDerived StreamT, typename... Args, typename EndpointDeferred = Endpoint>
+        template <concepts::stream_derived_type StreamT, typename... Args, typename EndpointDeferred = Endpoint>
             requires std::derived_from<StreamT, Stream>
         std::shared_ptr<StreamT> open_stream(Args&&... args)
         {
@@ -90,7 +85,7 @@ namespace oxen::quic
         /// StreamT is specified, is of the given Stream subclass).  Returns nullptr if the id is
         /// not currently an open stream; throws std::invalid_argument if the stream exists but is
         /// not an instance of the given StreamT type.
-        template <StreamDerived StreamT = Stream>
+        template <concepts::stream_derived_type StreamT = Stream>
         std::shared_ptr<StreamT> maybe_stream(int64_t id)
         {
             auto s = get_stream_impl(id);
@@ -111,7 +106,7 @@ namespace oxen::quic
         /// StreamT is specified, is of the given Stream subclass).  Otherwise throws
         /// std::out_of_range if the stream was not found, and std::invalid_argument if the stream
         /// was found, but is not an instance of StreamT.
-        template <StreamDerived StreamT = Stream>
+        template <concepts::stream_derived_type StreamT = Stream>
         std::shared_ptr<StreamT> get_stream(int64_t id)
         {
             if (auto s = maybe_stream<StreamT>(id))

--- a/include/oxen/quic/connection_ids.hpp
+++ b/include/oxen/quic/connection_ids.hpp
@@ -77,7 +77,7 @@ namespace std
     template <>
     struct hash<oxen::quic::quic_cid>
     {
-        size_t operator()(const oxen::quic::quic_cid& cid) const
+        size_t operator()(const oxen::quic::quic_cid& cid) const noexcept
         {
             static_assert(
                     alignof(oxen::quic::quic_cid) >= alignof(size_t) &&
@@ -89,6 +89,9 @@ namespace std
     template <>
     struct hash<oxen::quic::ConnectionID>
     {
-        size_t operator()(const oxen::quic::ConnectionID& rid) const { return std::hash<decltype(rid.id)>{}(rid.id); }
+        size_t operator()(const oxen::quic::ConnectionID& rid) const noexcept
+        {
+            return std::hash<decltype(rid.id)>{}(rid.id);
+        }
     };
 }  // namespace std

--- a/include/oxen/quic/context.hpp
+++ b/include/oxen/quic/context.hpp
@@ -46,6 +46,7 @@ namespace oxen::quic
         connection_established_callback conn_established_cb;
         connection_closed_callback conn_closed_cb;
         user_config config{};
+        bool disable_key_verification = false;
 
         template <typename... Opt>
         IOContext(Direction d, Opt&&... opts) : dir{d}
@@ -73,6 +74,7 @@ namespace oxen::quic
         void handle_ioctx_opt(dgram_data_callback func);
         void handle_ioctx_opt(connection_established_callback func);
         void handle_ioctx_opt(connection_closed_callback func);
+        void handle_ioctx_opt(opt::disable_key_verification db);
 
         /// Unwraps an optional option: does nothing if nullopt, otherwise applies the option.  This
         /// is here to make runtime-dependent options (i.e. options whose presence depends on a

--- a/include/oxen/quic/crypto.hpp
+++ b/include/oxen/quic/crypto.hpp
@@ -14,7 +14,7 @@ extern "C"
 
 namespace oxen::quic
 {
-    inline constexpr auto default_alpn_str = "default"sv;
+    inline constexpr auto default_alpn_str = "default"_usv;
     inline constexpr std::chrono::milliseconds DEFAULT_ANTI_REPLAY_WINDOW{10min};
 
     class TLSSession;
@@ -35,11 +35,10 @@ namespace oxen::quic
         ngtcp2_crypto_conn_ref conn_ref;
         virtual void* get_session() = 0;
         virtual void* get_anti_replay() const = 0;
-        virtual const void* get_session_ticket_key() const = 0;
         virtual bool get_early_data_accepted() const = 0;
-        virtual ustring_view selected_alpn() = 0;
+        virtual ustring_view selected_alpn() const = 0;
         virtual ustring_view remote_key() const = 0;
-        virtual void set_expected_remote_key(ustring key) = 0;
+        virtual void set_expected_remote_key(ustring_view key) = 0;
         virtual ~TLSSession() = default;
         virtual int send_session_ticket() = 0;
     };

--- a/include/oxen/quic/crypto.hpp
+++ b/include/oxen/quic/crypto.hpp
@@ -14,7 +14,8 @@ extern "C"
 
 namespace oxen::quic
 {
-    constexpr auto default_alpn_str = "default"sv;
+    inline constexpr auto default_alpn_str = "default"sv;
+    inline constexpr std::chrono::milliseconds DEFAULT_ANTI_REPLAY_WINDOW{10min};
 
     class TLSSession;
     class Connection;

--- a/include/oxen/quic/crypto.hpp
+++ b/include/oxen/quic/crypto.hpp
@@ -19,11 +19,13 @@ namespace oxen::quic
 
     class TLSSession;
     class Connection;
+    struct IOContext;
 
     class TLSCreds
     {
       public:
-        virtual std::unique_ptr<TLSSession> make_session(Connection& c, const std::vector<ustring>& alpns) = 0;
+        virtual std::unique_ptr<TLSSession> make_session(
+                Connection& c, const std::shared_ptr<IOContext>& ctx, const std::vector<ustring>& alpns) = 0;
         virtual ~TLSCreds() = default;
     };
 

--- a/include/oxen/quic/endpoint.hpp
+++ b/include/oxen/quic/endpoint.hpp
@@ -197,16 +197,8 @@ namespace oxen::quic
         bool zero_rtt_enabled() const { return _0rtt_enabled; }
         unsigned int zero_rtt_window() const { return _0rtt_window; }
 
-        gtls_db_validate_cb _validate_0rtt_ticket;
-
-        gtls_db_get_cb _get_session_ticket;
-
-        gtls_db_put_cb _put_session_ticket;
-
         int validate_anti_replay(gtls_session_ticket ticket, time_t exp);
-
         void store_session_ticket(gtls_session_ticket ticket);
-
         gtls_ticket_ptr get_session_ticket(const ustring_view& remote_pk);
 
       private:
@@ -229,6 +221,10 @@ namespace oxen::quic
         opt::manual_routing _manual_routing;
         bool _0rtt_enabled{false};
         unsigned int _0rtt_window{};
+
+        gtls_db_validate_cb _validate_0rtt_ticket;
+        gtls_db_get_cb _get_session_ticket;
+        gtls_db_put_cb _put_session_ticket;
 
         uint64_t _next_rid{0};
 

--- a/include/oxen/quic/endpoint.hpp
+++ b/include/oxen/quic/endpoint.hpp
@@ -165,8 +165,8 @@ namespace oxen::quic
 
         bool stateless_reset_enabled() const { return _stateless_reset_enabled; }
 
-        int validate_anti_replay(gtls_session_ticket ticket, time_t exp);
-        void store_session_ticket(gtls_session_ticket ticket);
+        int validate_anti_replay(gtls_ticket_ptr ticket, time_t exp);
+        void store_session_ticket(gtls_ticket_ptr ticket);
         gtls_ticket_ptr get_session_ticket(const ustring_view& remote_pk);
 
       private:

--- a/include/oxen/quic/endpoint.hpp
+++ b/include/oxen/quic/endpoint.hpp
@@ -316,11 +316,15 @@ namespace oxen::quic
 
         void activate_cid(const ngtcp2_cid* cid, const uint8_t* token, Connection& conn);
 
+        void deactivate_cid(const ngtcp2_cid* cid, Connection& conn);
+
         void associate_cid(quic_cid qcid, Connection& conn);
 
         void associate_cid(const ngtcp2_cid* cid, Connection& conn);
 
         void dissociate_cid(const ngtcp2_cid* cid, Connection& conn);
+
+        void dissociate_cid(quic_cid qcid, Connection& conn);
 
         const ustring& static_secret() const { return _static_secret; }
 
@@ -383,8 +387,8 @@ namespace oxen::quic
         std::unordered_map<quic_cid, ConnectionID> conn_lookup;
 
         // only used if stateless reset enabled
-        std::unordered_map<ConnectionID, std::shared_ptr<gtls_reset_token>> reset_token_lookup;
-        std::unordered_map<std::shared_ptr<gtls_reset_token>, ConnectionID> reset_token_map;
+        std::unordered_map<quic_cid, std::shared_ptr<gtls_reset_token>> reset_token_lookup;
+        std::unordered_map<std::shared_ptr<gtls_reset_token>, quic_cid> reset_token_map;
 
         std::map<std::chrono::steady_clock::time_point, ConnectionID> draining_closing;
 

--- a/include/oxen/quic/endpoint.hpp
+++ b/include/oxen/quic/endpoint.hpp
@@ -90,7 +90,7 @@ namespace oxen::quic
                     // initialize client context and client tls context simultaneously
                     outbound_ctx = std::make_shared<IOContext>(Direction::OUTBOUND, std::forward<Opt>(opts)...);
                     _set_context_globals(outbound_ctx);
-                    _connect(std::move(remote), qcid, next_rid, p);
+                    p.set_value(_connect(std::move(remote), qcid, next_rid));
                 }
                 catch (...)
                 {
@@ -220,14 +220,10 @@ namespace oxen::quic
         // Does the non-templated bit of `listen()`
         void _listen();
 
-        void _connect(RemoteAddress remote, quic_cid qcid, ConnectionID rid, std::promise<std::shared_ptr<Connection>>& p);
+        std::shared_ptr<Connection> _connect(RemoteAddress remote, quic_cid qcid, ConnectionID rid);
 
-        void _connect(
-                Address remote,
-                quic_cid qcid,
-                ConnectionID rid,
-                std::promise<std::shared_ptr<Connection>>& p,
-                std::optional<ustring> pk = std::nullopt);
+        std::shared_ptr<Connection> _connect(
+                Address remote, quic_cid qcid, ConnectionID rid, std::optional<ustring> pk = std::nullopt);
 
         void handle_ep_opt(opt::enable_datagrams dc);
         void handle_ep_opt(opt::outbound_alpns alpns);

--- a/include/oxen/quic/endpoint.hpp
+++ b/include/oxen/quic/endpoint.hpp
@@ -239,9 +239,10 @@ namespace oxen::quic
         std::vector<ustring> inbound_alpns;
         std::chrono::nanoseconds handshake_timeout{DEFAULT_HANDSHAKE_TIMEOUT};
 
-        std::unordered_map<ustring_view, gtls_session_ticket> session_tickets;
-        std::unordered_map<ustring_view, gtls_ticket_ptr> _session_tickets;
+        std::unordered_map<ustring_view, gtls_ticket_ptr> session_tickets;
+
         std::unordered_map<ustring, ustring> encoded_transport_params;
+
         std::unordered_map<ustring, ustring> path_validation_tokens;
 
         const std::shared_ptr<event_base>& get_loop() { return net._loop->loop(); }

--- a/include/oxen/quic/endpoint.hpp
+++ b/include/oxen/quic/endpoint.hpp
@@ -359,6 +359,8 @@ namespace oxen::quic
 
         std::unordered_map<quic_cid, ConnectionID> conn_lookup;
 
+        void expire_reset_tokens(time_point now = get_time());
+
         // only used if stateless reset enabled
         std::unordered_map<quic_cid, std::shared_ptr<gtls_reset_token>> reset_token_lookup;
         std::unordered_map<std::shared_ptr<gtls_reset_token>, quic_cid> reset_token_map;

--- a/include/oxen/quic/endpoint.hpp
+++ b/include/oxen/quic/endpoint.hpp
@@ -163,6 +163,8 @@ namespace oxen::quic
         bool zero_rtt_enabled() const { return _0rtt_enabled; }
         unsigned int zero_rtt_window() const { return _0rtt_window; }
 
+        bool stateless_reset_enabled() const { return _stateless_reset_enabled; }
+
         int validate_anti_replay(gtls_session_ticket ticket, time_t exp);
         void store_session_ticket(gtls_session_ticket ticket);
         gtls_ticket_ptr get_session_ticket(const ustring_view& remote_pk);

--- a/include/oxen/quic/endpoint.hpp
+++ b/include/oxen/quic/endpoint.hpp
@@ -222,7 +222,7 @@ namespace oxen::quic
         bool _0rtt_enabled{false};
         unsigned int _0rtt_window{};
 
-        bool _stateless_reset_enabled{false};
+        bool _stateless_reset_enabled{true};
 
         gtls_db_validate_cb _validate_0rtt_ticket;
         gtls_db_get_cb _get_session_ticket;
@@ -263,7 +263,7 @@ namespace oxen::quic
         void handle_ep_opt(opt::static_secret ssecret);
         void handle_ep_opt(opt::manual_routing mrouting);
         void handle_ep_opt(opt::enable_0rtt_ticketing rtt);
-        void handle_ep_opt(opt::enable_stateless_reset rst);
+        void handle_ep_opt(opt::disable_stateless_reset rst);
 
         // Takes a std::optional-wrapped option that does nothing if the optional is empty,
         // otherwise passes it through to the above.  This is here to allow runtime-dependent

--- a/include/oxen/quic/endpoint.hpp
+++ b/include/oxen/quic/endpoint.hpp
@@ -207,7 +207,7 @@ namespace oxen::quic
         std::vector<ustring> inbound_alpns;
         std::chrono::nanoseconds handshake_timeout{DEFAULT_HANDSHAKE_TIMEOUT};
 
-        std::unordered_map<ustring_view, gtls_ticket_ptr> session_tickets;
+        std::unordered_map<ustring_view, gtls_ticket_ptr, detail::ustring_hasher> session_tickets;
 
         std::unordered_map<Address, ustring> encoded_transport_params;
 
@@ -222,7 +222,12 @@ namespace oxen::quic
 
         void _connect(RemoteAddress remote, quic_cid qcid, ConnectionID rid, std::promise<std::shared_ptr<Connection>>& p);
 
-        void _connect(Address remote, quic_cid qcid, ConnectionID rid, std::promise<std::shared_ptr<Connection>>& p);
+        void _connect(
+                Address remote,
+                quic_cid qcid,
+                ConnectionID rid,
+                std::promise<std::shared_ptr<Connection>>& p,
+                std::optional<ustring> pk = std::nullopt);
 
         void handle_ep_opt(opt::enable_datagrams dc);
         void handle_ep_opt(opt::outbound_alpns alpns);
@@ -408,9 +413,9 @@ namespace oxen::quic
         static constexpr void check_address_scheme()
         {
             if constexpr ((std::is_same_v<opt::disable_key_verification, std::remove_cvref_t<Opt>> || ...))
-            {
                 static_assert(std::is_same_v<T, Address>, "Disabling key verification requires keyless address!");
-            }
+            else
+                static_assert(std::is_same_v<T, RemoteAddress>, "Key verification requires keyed address!");
         }
     };
 

--- a/include/oxen/quic/error.hpp
+++ b/include/oxen/quic/error.hpp
@@ -50,6 +50,10 @@ namespace oxen::quic
     inline constexpr uint64_t CONN_SEND_FAIL = ERROR_BASE + 1002;
     // Connection closing because it reached idle timeout
     inline constexpr uint64_t CONN_IDLE_CLOSED = ERROR_BASE + 1003;
+    // Early data rejected:
+    inline constexpr uint64_t CONN_EARLY_DATA_REJECTED = ERROR_BASE + 1004;
+    // Stateless reset received
+    inline constexpr uint64_t CONN_STATELESS_RESET = ERROR_BASE + 1005;
 
     inline std::string quic_strerror(uint64_t e)
     {

--- a/include/oxen/quic/format.hpp
+++ b/include/oxen/quic/format.hpp
@@ -48,7 +48,7 @@ namespace oxen::quic
 
 namespace fmt
 {
-    template <oxen::quic::ToStringFormattable T>
+    template <oxen::quic::concepts::ToStringFormattable T>
     struct formatter<T, char> : formatter<std::string_view>
     {
         template <typename FormatContext>

--- a/include/oxen/quic/formattable.hpp
+++ b/include/oxen/quic/formattable.hpp
@@ -2,14 +2,17 @@
 
 #include <string_view>
 
-namespace oxen::quic::concepts
+namespace oxen::quic
 {
-    // Types can opt-in to being fmt-formattable by ensuring they have a ::to_string() method defined
-    template <typename T>
-    concept ToStringFormattable = T::to_string_formattable && requires(T a) {
-        {
-            a.to_string()
-        } -> std::convertible_to<std::string_view>;
-    };
+    inline namespace concepts
+    {
+        // Types can opt-in to being fmt-formattable by ensuring they have a ::to_string() method defined
+        template <typename T>
+        concept ToStringFormattable = T::to_string_formattable && requires(T a) {
+            {
+                a.to_string()
+            } -> std::convertible_to<std::string_view>;
+        };
+    }  // namespace concepts
 
-}  // namespace oxen::quic::concepts
+}  // namespace oxen::quic

--- a/include/oxen/quic/formattable.hpp
+++ b/include/oxen/quic/formattable.hpp
@@ -2,22 +2,14 @@
 
 #include <string_view>
 
-// GCC before 10 requires a "bool" keyword in concept; this CONCEPT_COMPAT is empty by default, but
-// expands to bool if under such a GCC.
-#if (!(defined(__clang__)) && defined(__GNUC__) && __GNUC__ < 10)
-#define CONCEPT_COMPAT bool
-#else
-#define CONCEPT_COMPAT
-#endif
-
-namespace oxen::quic
+namespace oxen::quic::concepts
 {
     // Types can opt-in to being fmt-formattable by ensuring they have a ::to_string() method defined
     template <typename T>
-    concept CONCEPT_COMPAT ToStringFormattable = T::to_string_formattable && requires(T a) {
+    concept ToStringFormattable = T::to_string_formattable && requires(T a) {
         {
             a.to_string()
         } -> std::convertible_to<std::string_view>;
     };
 
-}  // namespace oxen::quic
+}  // namespace oxen::quic::concepts

--- a/include/oxen/quic/gnutls_crypto.hpp
+++ b/include/oxen/quic/gnutls_crypto.hpp
@@ -262,9 +262,6 @@ namespace oxen::quic
 
     struct gtls_session_ticket
     {
-        friend class Endpoint;
-        friend class Connection;
-
         std::vector<unsigned char> _key;
         std::vector<unsigned char> _ticket;
         gnutls_datum_t _data;

--- a/include/oxen/quic/gnutls_crypto.hpp
+++ b/include/oxen/quic/gnutls_crypto.hpp
@@ -28,8 +28,6 @@ namespace oxen::quic
 
         void gnutls_log(int level, const char* str);
 
-        int anti_replay_db_add_func(void* dbf, time_t exp_time, const gnutls_datum_t* key, const gnutls_datum_t* data);
-
         struct gnutls_log_setter
         {
             gnutls_log_setter()
@@ -364,7 +362,8 @@ namespace oxen::quic
         gnutls_priority_t priority_cache;
 
       public:
-        std::unique_ptr<TLSSession> make_session(Connection& c, const std::vector<ustring>& alpns) override;
+        std::unique_ptr<TLSSession> make_session(
+                Connection& c, const std::shared_ptr<IOContext>&, const std::vector<ustring>& alpns) override;
 
         void load_keys(x509_loader& seed, x509_loader& pk);
 
@@ -391,6 +390,7 @@ namespace oxen::quic
       public:
         GNUTLSSession(
                 GNUTLSCreds& creds,
+                const std::shared_ptr<IOContext>& ctx,
                 Connection& c,
                 const std::vector<ustring>& alpns,
                 std::optional<gnutls_key> expected_key = std::nullopt);

--- a/include/oxen/quic/gnutls_crypto.hpp
+++ b/include/oxen/quic/gnutls_crypto.hpp
@@ -359,16 +359,22 @@ namespace oxen::quic
         static constexpr size_t TOKENSIZE{NGTCP2_STATELESS_RESET_TOKENLEN};
         static constexpr size_t RANDSIZE{NGTCP2_MIN_STATELESS_RESET_RANDLEN};
 
+        static constexpr std::chrono::milliseconds LIFETIME{10min};
+
       private:
         gtls_reset_token(const uint8_t* _tok, const uint8_t* _rand = nullptr);
         gtls_reset_token(uint8_t* _static_secret, size_t _secret_len, const quic_cid& cid);
 
       public:
+        std::chrono::steady_clock::time_point expiry{get_time() + LIFETIME};
+
         std::array<uint8_t, TOKENSIZE> _tok{};
         std::array<uint8_t, RANDSIZE> _rand{};
 
         const uint8_t* token() { return _tok.data(); }
         const uint8_t* rand() { return _rand.data(); }
+
+        bool is_expired(time_point now) const { return expiry < now; }
 
         static void generate_token(uint8_t* buffer, uint8_t* _static_secret, size_t _secret_len, const quic_cid& cid);
         static void generate_rand(uint8_t* buffer);

--- a/include/oxen/quic/iochannel.hpp
+++ b/include/oxen/quic/iochannel.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <concepts>
+
 #include "connection_ids.hpp"
 #include "messages.hpp"
 #include "utils.hpp"

--- a/include/oxen/quic/iochannel.hpp
+++ b/include/oxen/quic/iochannel.hpp
@@ -1,5 +1,4 @@
 #pragma once
-#include <concepts>
 
 #include "connection_ids.hpp"
 #include "messages.hpp"

--- a/include/oxen/quic/loop.hpp
+++ b/include/oxen/quic/loop.hpp
@@ -206,17 +206,17 @@ namespace oxen::quic
 
             Configurable parameters:
                 - start_immediately : will call ::event_add() before returning the ticker
-                - fixed_interval :
-                        - if FALSE (default behavior), will attempt to execute every `interval`, regardless of how long the
-                            event itself takes
-                        - if TRUE, will wait the entire `interval` after finishing execution of the event before attempting
-                            execution again
+                - wait :
+                    - if FALSE (default behavior), the interval will not wait for the event to complete. will attempt to
+                        execute every `interval`, regardless of how long the event itself takes.
+                    - if TRUE, the interval will wait for the event to complete before beginning. It will wait the entire
+                        `interval` after finishing execution of the event before attempting execution again.
         */
         template <typename Callable>
         [[nodiscard]] std::shared_ptr<Ticker> call_every(
-                std::chrono::microseconds interval, Callable&& f, bool start_immediately = true, bool fixed_interval = false)
+                std::chrono::microseconds interval, Callable&& f, bool start_immediately = true, bool wait = false)
         {
-            return _call_every(interval, std::forward<Callable>(f), Loop::loop_id, start_immediately, fixed_interval);
+            return _call_every(interval, std::forward<Callable>(f), Loop::loop_id, start_immediately, wait);
         }
 
         template <std::invocable Callable>

--- a/include/oxen/quic/network.hpp
+++ b/include/oxen/quic/network.hpp
@@ -88,17 +88,17 @@ namespace oxen::quic
 
             Configurable parameters:
                 - start_immediately : will call ::event_add() before returning the ticker
-                - fixed_interval :
-                        - if FALSE (default behavior), will attempt to execute every `interval`, regardless of how long the
-                            event itself takes
-                        - if TRUE, will wait the entire `interval` after finishing execution of the event before attempting
-                            execution again
+                - wait :
+                    - if FALSE (default behavior), the interval will not wait for the event to complete. will attempt to
+                        execute every `interval`, regardless of how long the event itself takes.
+                    - if TRUE, the interval will wait for the event to complete before beginning. It will wait the entire
+                        `interval` after finishing execution of the event before attempting execution again.
         */
         template <typename Callable>
         [[nodiscard]] std::shared_ptr<Ticker> call_every(
-                std::chrono::microseconds interval, Callable&& f, bool start_immediately = true, bool fixed_interval = false)
+                std::chrono::microseconds interval, Callable&& f, bool start_immediately = true, bool wait = false)
         {
-            return _loop->_call_every(interval, std::forward<Callable>(f), net_id, start_immediately, fixed_interval);
+            return _loop->_call_every(interval, std::forward<Callable>(f), net_id, start_immediately, wait);
         }
 
         template <typename Callable>

--- a/include/oxen/quic/opt.hpp
+++ b/include/oxen/quic/opt.hpp
@@ -204,8 +204,6 @@ namespace oxen::quic
         };
     }  // namespace opt
 
-    using gtls_ticket_ptr = std::unique_ptr<gtls_session_ticket>;
-
     using gtls_db_validate_cb = std::function<bool(gtls_ticket_ptr, time_t)>;
     using gtls_db_get_cb = std::function<gtls_ticket_ptr(ustring_view)>;
     using gtls_db_put_cb = std::function<void(gtls_ticket_ptr, time_t)>;

--- a/include/oxen/quic/opt.hpp
+++ b/include/oxen/quic/opt.hpp
@@ -228,7 +228,7 @@ namespace oxen::quic
                         - ...and is expired -> store ticket, return true
                         - ...and is NOT expired -> KEEP TICKET, return false
             see:
-           https://www.gnutls.org/manual/html_node/Core-TLS-API.html#gnutls_005fanti_005freplay_005fset_005fadd_005ffunction
+            https://www.gnutls.org/manual/html_node/Core-TLS-API.html#gnutls_005fanti_005freplay_005fset_005fadd_005ffunction
 
 
             - `gtls_db_get_cb` : The invocation is provided one ustring_view storing the ticket key. The application will
@@ -251,6 +251,8 @@ namespace oxen::quic
             gtls_db_get_cb _fetch = nullptr;
             gtls_db_put_cb _put = nullptr;
 
+            enable_0rtt_ticketing() = default;
+
             explicit enable_0rtt_ticketing(std::chrono::milliseconds w) : window{w} {}
 
             explicit enable_0rtt_ticketing(
@@ -262,10 +264,23 @@ namespace oxen::quic
             }
         };
 
-        /** This can be passed on endpoint creation to turn OFF key verification in the handshake process. This can be passed
+        /** Handshake Key Verification:
+            This can be passed on endpoint creation to turn OFF key verification in the handshake process. This can be passed
             to either endpoint::listen(...) or endpoint::connect(...) to disable it for that tls session
          */
         struct disable_key_verification
+        {};
+
+        /** Stateless Reset Tokens:
+            This can be passed on endpoint creation to turn ON stateless reset tokens. This will result in few main
+            functional differences:
+                - When processing incoming packets, if both the dcid cannot be matched to an active connection and calls to
+                    `ngtcp2_accept` are unsuccessful, then a stateless reset packet will be sent
+                -
+
+            Note: DO NOT ENABLE STATELESS RESET AMONGST ENDPOINTS SHARING THE SAME STATIC KEY
+         */
+        struct enable_stateless_reset
         {};
     }  //  namespace opt
 }  // namespace oxen::quic

--- a/include/oxen/quic/opt.hpp
+++ b/include/oxen/quic/opt.hpp
@@ -204,7 +204,7 @@ namespace oxen::quic
         };
     }  // namespace opt
 
-    using gtls_db_validate_cb = std::function<bool(gtls_ticket_ptr, time_t)>;
+    using gtls_db_validate_cb = std::function<int(gtls_ticket_ptr, time_t)>;
     using gtls_db_get_cb = std::function<gtls_ticket_ptr(ustring_view)>;
     using gtls_db_put_cb = std::function<void(gtls_ticket_ptr, time_t)>;
 
@@ -228,10 +228,10 @@ namespace oxen::quic
             - `gtls_db_validate_cb` : The invocation of this cb provides the session ticket and the current ticket time given
                 by ngtcp2. All tickets should be held through the application chosen expiry window. The server must return
                 true/false in the following circumstances:
-                    - Ticket not found -> store ticket, return true
+                    - Ticket not found -> store ticket, return 0
                     - Ticket found...
-                        - ...and is expired -> store ticket, return true
-                        - ...and is NOT expired -> KEEP TICKET, return false
+                        - ...and is expired -> store ticket, return non-zero
+                        - ...and is NOT expired -> KEEP TICKET, return 0
             see:
             https://www.gnutls.org/manual/html_node/Core-TLS-API.html#gnutls_005fanti_005freplay_005fset_005fadd_005ffunction
 

--- a/include/oxen/quic/opt.hpp
+++ b/include/oxen/quic/opt.hpp
@@ -202,5 +202,11 @@ namespace oxen::quic
                     _hook = nullptr;
             }
         };
+
+        /// Used to enable QUIC 0-RTT mode.
+        struct enable_0rtt
+        {
+            std::chrono::milliseconds window{DEFAULT_ANTI_REPLAY_WINDOW};
+        };
     }  //  namespace opt
 }  // namespace oxen::quic

--- a/include/oxen/quic/opt.hpp
+++ b/include/oxen/quic/opt.hpp
@@ -261,5 +261,11 @@ namespace oxen::quic
                     throw std::invalid_argument{"All callbacks must be set!"};
             }
         };
+
+        /** This can be passed on endpoint creation to turn OFF key verification in the handshake process. This can be passed
+            to either endpoint::listen(...) or endpoint::connect(...) to disable it for that tls session
+         */
+        struct disable_key_verification
+        {};
     }  //  namespace opt
 }  // namespace oxen::quic

--- a/include/oxen/quic/opt.hpp
+++ b/include/oxen/quic/opt.hpp
@@ -272,15 +272,15 @@ namespace oxen::quic
         {};
 
         /** Stateless Reset Tokens:
-            This can be passed on endpoint creation to turn ON stateless reset tokens. This will result in few main
+            This can be passed on endpoint creation to turn OFF stateless reset tokens. This will result in few main
             functional differences:
                 - When processing incoming packets, if both the dcid cannot be matched to an active connection and calls to
-                    `ngtcp2_accept` are unsuccessful, then a stateless reset packet will be sent
-                -
+                    `ngtcp2_accept` are unsuccessful, then a stateless reset packet will NOT be sent
+                - When connection id's are generated, a corresponding stateless reset token will NOT be created
 
             Note: DO NOT ENABLE STATELESS RESET AMONGST ENDPOINTS SHARING THE SAME STATIC KEY
          */
-        struct enable_stateless_reset
+        struct disable_stateless_reset
         {};
     }  //  namespace opt
 }  // namespace oxen::quic

--- a/include/oxen/quic/stream.hpp
+++ b/include/oxen/quic/stream.hpp
@@ -36,6 +36,12 @@ namespace oxen::quic
     void _chunk_sender_trace(const char* file, int lineno, std::string_view message);
     void _chunk_sender_trace(const char* file, int lineno, std::string_view message, size_t val);
 
+    inline namespace concepts
+    {
+        template <typename T>
+        concept stream_derived_type = std::derived_from<T, Stream>;
+    }
+
     class Stream : public IOChannel, public std::enable_shared_from_this<Stream>
     {
         friend class TestHelper;
@@ -137,7 +143,7 @@ namespace oxen::quic
         size_t unsent_impl() const override;
 
       private:
-        // Called if 0-RTT early data was rejected; marks all sent data as unacked
+        // Called if 0-RTT early data was rejected; marks all sent data as unsent
         void revert_stream();
 
         std::vector<ngtcp2_vec> pending() override;

--- a/include/oxen/quic/stream.hpp
+++ b/include/oxen/quic/stream.hpp
@@ -137,6 +137,9 @@ namespace oxen::quic
         size_t unsent_impl() const override;
 
       private:
+        // Called if 0-RTT early data was rejected; marks all sent data as unacked
+        void revert_stream();
+
         std::vector<ngtcp2_vec> pending() override;
 
         size_t _unacked_size{0};

--- a/include/oxen/quic/types.hpp
+++ b/include/oxen/quic/types.hpp
@@ -8,25 +8,6 @@
 
 namespace oxen::quic
 {
-    class Stream;
-    struct Address;
-
-    namespace concepts
-    {
-        template <typename T>
-        concept stream_derived_type = std::derived_from<T, Stream>;
-
-        template <typename T>
-        concept quic_address_type = std::derived_from<T, Address>;
-
-        template <typename T>
-        concept raw_sockaddr_type =
-                std::same_as<T, sockaddr> || std::same_as<T, sockaddr_in> || std::same_as<T, sockaddr_in6>;
-
-        template <typename T>
-        concept gtls_datum_type = std::same_as<T, gnutls_datum_t>;
-    }  // namespace concepts
-
     enum class Direction { OUTBOUND = 0, INBOUND = 1 };
 
     enum class Splitting { NONE = 0, ACTIVE = 1 };

--- a/include/oxen/quic/types.hpp
+++ b/include/oxen/quic/types.hpp
@@ -8,6 +8,21 @@
 
 namespace oxen::quic
 {
+    class Stream;
+
+    namespace concepts
+    {
+        template <typename T>
+        concept stream_derived_type = std::derived_from<T, Stream>;
+
+        template <typename T>
+        concept raw_sockaddr_type =
+                std::same_as<T, sockaddr> || std::same_as<T, sockaddr_in> || std::same_as<T, sockaddr_in6>;
+
+        template <typename T>
+        concept gtls_datum_type = std::same_as<T, gnutls_datum_t>;
+    }  // namespace concepts
+
     enum class Direction { OUTBOUND = 0, INBOUND = 1 };
 
     enum class Splitting { NONE = 0, ACTIVE = 1 };

--- a/include/oxen/quic/types.hpp
+++ b/include/oxen/quic/types.hpp
@@ -9,11 +9,15 @@
 namespace oxen::quic
 {
     class Stream;
+    struct Address;
 
     namespace concepts
     {
         template <typename T>
         concept stream_derived_type = std::derived_from<T, Stream>;
+
+        template <typename T>
+        concept quic_address_type = std::derived_from<T, Address>;
 
         template <typename T>
         concept raw_sockaddr_type =

--- a/include/oxen/quic/udp.hpp
+++ b/include/oxen/quic/udp.hpp
@@ -36,6 +36,7 @@ namespace oxen::quic
         Path path;
         ngtcp2_pkt_info pkt_info{};
         std::vector<std::byte> pkt_data;
+        std::span<const std::byte> data_sp;
 
         size_t size() const { return pkt_data.size(); }
 
@@ -43,14 +44,14 @@ namespace oxen::quic
         template <oxenc::basic_char Char = std::byte>
         std::basic_string_view<Char> data(size_t pos = 0) const
         {
-            return std::basic_string_view<Char>{reinterpret_cast<const Char*>(pkt_data.data() + pos), pkt_data.size()};
+            return std::basic_string_view<Char>{reinterpret_cast<const Char*>(data_sp.data() + pos), data_sp.size() - pos};
         }
 
         /// Constructs a packet from a path and data view:
-        Packet(Path p, bstring_view d) : path{std::move(p)}, pkt_data{d.begin(), d.end()} {}
+        Packet(Path p, bstring_view d) : path{std::move(p)}, data_sp{d.begin(), d.end()} {}
 
         /// Constructs a packet from a path and transferred data:
-        Packet(Path p, bstring&& d) : path{std::move(p)}, pkt_data(d.size())
+        Packet(Path p, bstring&& d) : path{std::move(p)}, pkt_data(d.size()), data_sp{pkt_data.data(), d.size()}
         {
             std::memmove(pkt_data.data(), d.data(), d.size());
         }

--- a/include/oxen/quic/utils.hpp
+++ b/include/oxen/quic/utils.hpp
@@ -112,6 +112,8 @@ namespace oxen::quic
     inline constexpr std::chrono::seconds DEFAULT_HANDSHAKE_TIMEOUT = 10s;
     inline constexpr std::chrono::seconds DEFAULT_IDLE_TIMEOUT = 30s;
 
+    inline constexpr size_t inverse_golden_ratio = sizeof(size_t) >= 8 ? 0x9e37'79b9'7f4a'7c15 : 0x9e37'79b9;
+
     // NGTCP2 sets the path_pmtud_payload to 1200 on connection creation, then discovers upwards
     // to a theoretical max of 1452. In 'lazy' mode, we take in split packets under the current max
     // pmtud size. In 'greedy' mode, we take in up to double the current pmtud size to split amongst
@@ -260,3 +262,19 @@ namespace oxen::quic
     }
 
 }  // namespace oxen::quic
+
+namespace std
+{
+    template <>
+    struct hash<oxen::quic::ustring_view>
+    {
+        size_t operator()(const oxen::quic::ustring_view& sv) const noexcept
+        {
+            return hash<string_view>{}({reinterpret_cast<const char*>(sv.data()), sv.size()});
+        }
+    };
+
+    template <>
+    struct hash<oxen::quic::ustring> : hash<oxen::quic::ustring_view>
+    {};
+}  //  namespace std

--- a/include/oxen/quic/utils.hpp
+++ b/include/oxen/quic/utils.hpp
@@ -33,6 +33,7 @@ extern "C"
 #include <map>
 #include <optional>
 #include <random>
+#include <span>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -147,6 +148,14 @@ namespace oxen::quic
 
     namespace detail
     {
+        struct ustring_hasher
+        {
+            size_t operator()(const ustring_view& sv) const noexcept
+            {
+                return std::hash<std::string_view>{}({reinterpret_cast<const char*>(sv.data()), sv.size()});
+            }
+        };
+
         template <size_t N>
         struct bsv_literal
         {
@@ -262,19 +271,3 @@ namespace oxen::quic
     }
 
 }  // namespace oxen::quic
-
-namespace std
-{
-    template <>
-    struct hash<oxen::quic::ustring_view>
-    {
-        size_t operator()(const oxen::quic::ustring_view& sv) const noexcept
-        {
-            return hash<string_view>{}({reinterpret_cast<const char*>(sv.data()), sv.size()});
-        }
-    };
-
-    template <>
-    struct hash<oxen::quic::ustring> : hash<oxen::quic::ustring_view>
-    {};
-}  //  namespace std

--- a/include/oxen/quic/utils.hpp
+++ b/include/oxen/quic/utils.hpp
@@ -43,6 +43,8 @@ namespace oxen::quic
 {
     class connection_interface;
 
+    using time_point = std::chrono::steady_clock::time_point;
+
     // called when a connection's handshake completes
     // the server will call this when it sends the final handshake packet
     // the client will call this when it receives that final handshake packet
@@ -208,7 +210,7 @@ namespace oxen::quic
         return {reinterpret_cast<const char*>(x.data()), x.size()};
     }
 
-    std::chrono::steady_clock::time_point get_time();
+    time_point get_time();
     std::chrono::nanoseconds get_timestamp();
 
     template <typename unit_t>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(quic
     endpoint.cpp
     error.cpp
     format.cpp
+    gnutls_crypto.cpp
     gnutls_creds.cpp
     gnutls_session.cpp
     iochannel.cpp

--- a/src/address.cpp
+++ b/src/address.cpp
@@ -19,7 +19,7 @@ namespace oxen::quic
             sin6.sin6_port = oxenc::host_to_big(port);
             _addr.addrlen = sizeof(sockaddr_in6);
             if (!addr.empty())
-                parse_addr(sin6.sin6_addr, addr);
+                detail::parse_addr(sin6.sin6_addr, addr);
             else
                 // Otherwise default to all-0 IPv6 address with the dual stack flag enabled
                 dual_stack = true;
@@ -33,7 +33,7 @@ namespace oxen::quic
 #ifdef OXEN_LIBQUIC_ADDRESS_NO_DUAL_STACK
             if (!addr.empty())
 #endif
-                parse_addr(sin4.sin_addr, addr);
+                detail::parse_addr(sin4.sin_addr, addr);
         }
     }
 

--- a/src/btstream.cpp
+++ b/src/btstream.cpp
@@ -138,7 +138,7 @@ namespace oxen::quic
 
         if (auto type = msg.type(); type == message::TYPE_REPLY || type == message::TYPE_ERROR)
         {
-            log::trace(log_cat, "Looking for request with req_id={}", msg.req_id);
+            log::debug(bp_cat, "Looking for request with req_id={}", msg.req_id);
             // Iterate using forward iterators, s.t. we go highest (newest) rids to lowest (oldest) rids.
             // As a result, our comparator checks if the sent request ID is greater thanthan the target rid
             auto itr = std::lower_bound(
@@ -149,7 +149,7 @@ namespace oxen::quic
 
             if (itr != sent_reqs.end())
             {
-                log::debug(bp_cat, "Successfully matched response to sent request!");
+                log::debug(bp_cat, "Successfully matched response (req_id={}) to sent request!", msg.req_id);
                 auto req = std::move(*itr);
                 sent_reqs.erase(itr);
                 try

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -298,6 +298,11 @@ namespace oxen::quic
                     "Received stateless reset for connection ({}) on path: {}; closing immediately!",
                     _ref_id,
                     _path);
+
+            // delete reset token after use
+            _endpoint.reset_token_lookup.erase(it->second);
+            _endpoint.reset_token_map.erase(it);
+
             _endpoint.drop_connection(*this, io_error{CONN_STATELESS_RESET});
         }
         else

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -1588,7 +1588,7 @@ namespace oxen::quic
         if (rv = init(settings, params, callbacks, handshake_timeout); rv != 0)
             log::critical(log_cat, "Error: {} connection not created", d_str);
 
-        tls_session = tls_creds->make_session(*this, alpns);
+        tls_session = tls_creds->make_session(*this, context, alpns);
 
         if (is_outbound())
         {

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -186,6 +186,11 @@ namespace oxen::quic
             log::debug(log_cat, "Activating stateless reset token for new CID from remote: {}", conn->remote());
             ep.activate_cid(cid, token, *conn);
         }
+        else if (type == NGTCP2_CONNECTION_ID_STATUS_TYPE_DEACTIVATE)
+        {
+            log::debug(log_cat, "Deactivating stateless reset token for CID from remote: {}", conn->remote());
+            ep.deactivate_cid(cid, *conn);
+        }
 
         return 0;
     }

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -315,11 +315,10 @@ namespace oxen::quic
             set_remote_addr(path->remote);
             log::debug(log_cat, "Client set new remote ({}) on successful path validation...", _path.remote);
         }
+        else if (success)
+            log::debug(log_cat, "Client path validation succeeded as no address was provided by server...");
         else
-            log::warning(
-                    log_cat,
-                    "Client path validation {}; no address was provided by server...",
-                    success ? "succeeded" : "failed");
+            log::warning(log_cat, "Client path validation failed; no address was provided by server...");
 
         return 0;
     }
@@ -670,7 +669,7 @@ namespace oxen::quic
                 pending_streams.pop_front();
 
                 if (_0rtt_enabled and is_early_stream)
-                    _early_streams.emplace_hint(_early_streams.end(), _id);
+                    _early_streams.emplace_back(_id);
             }
             else
                 return;
@@ -1208,7 +1207,7 @@ namespace oxen::quic
 
         if (uint64_t app_err_code = context->stream_open_cb ? context->stream_open_cb(*stream) : 0; app_err_code != 0)
         {
-            log::warning(log_cat, "stream_open_callback returned error code {}, closing stream {}", app_err_code, id);
+            log::info(log_cat, "stream_open_callback returned error code {}, closing stream {}", app_err_code, id);
             assert(endpoint().in_event_loop());
             stream->close(app_err_code);
             return 0;

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -41,271 +41,265 @@ namespace oxen::quic
         }
     }
 
-    // ngtcp2 internal callback functions (that are deliberately source only, not a published
-    // header); we group them all in this struct to make them slightly easier to manage, but more
-    // importantly, because `Callbacks` is a friend-with-benefits of Endpoint that can touch its
-    // privates.
-    struct Callbacks
+    int connection_callbacks::on_ack_datagram(ngtcp2_conn* /* conn */, uint64_t dgram_id, void* user_data)
     {
+        log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
+        return static_cast<Connection*>(user_data)->ack_datagram(dgram_id);
+    }
 
-        static int on_ack_datagram(ngtcp2_conn* /* conn */, uint64_t dgram_id, void* user_data)
+    int connection_callbacks::on_recv_datagram(
+            ngtcp2_conn* /* conn */, uint32_t flags, const uint8_t* data, size_t datalen, void* user_data)
+    {
+        log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
+        return static_cast<Connection*>(user_data)->recv_datagram(
+                {reinterpret_cast<const std::byte*>(data), datalen}, flags & NGTCP2_STREAM_DATA_FLAG_FIN);
+    }
+
+    int connection_callbacks::on_recv_token(ngtcp2_conn* /* conn */, const uint8_t* token, size_t tokenlen, void* user_data)
+    {
+        log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
+        return static_cast<Connection*>(user_data)->recv_token(token, tokenlen);
+    }
+
+    int connection_callbacks::on_recv_stream_data(
+            ngtcp2_conn* /*conn*/,
+            uint32_t flags,
+            int64_t stream_id,
+            uint64_t /*offset*/,
+            const uint8_t* data,
+            size_t datalen,
+            void* user_data,
+            void* /*stream_user_data*/)
+    {
+        log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
+        return static_cast<Connection*>(user_data)->stream_receive(
+                stream_id, {reinterpret_cast<const std::byte*>(data), datalen}, flags & NGTCP2_STREAM_DATA_FLAG_FIN);
+    }
+
+    int connection_callbacks::on_acked_stream_data_offset(
+            ngtcp2_conn* /*conn_*/,
+            int64_t stream_id,
+            uint64_t offset,
+            uint64_t datalen,
+            void* user_data,
+            void* /*stream_user_data*/)
+    {
+        log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
+        log::trace(log_cat, "Ack [{},{}]", offset, offset + datalen);
+        return static_cast<Connection*>(user_data)->stream_ack(stream_id, datalen);
+    }
+
+    int connection_callbacks::on_stream_open(ngtcp2_conn* /*conn*/, int64_t stream_id, void* user_data)
+    {
+        log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
+        return static_cast<Connection*>(user_data)->stream_opened(stream_id);
+    }
+
+    int connection_callbacks::on_stream_close(
+            ngtcp2_conn* /*conn*/,
+            uint32_t /*flags*/,
+            int64_t stream_id,
+            uint64_t app_error_code,
+            void* user_data,
+            void* /*stream_user_data*/)
+    {
+        log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
+        static_cast<Connection*>(user_data)->stream_closed(stream_id, app_error_code);
+        return 0;
+    }
+
+    int connection_callbacks::on_stream_reset(
+            ngtcp2_conn* /*conn*/,
+            int64_t stream_id,
+            uint64_t /*final_size*/,
+            uint64_t app_error_code,
+            void* user_data,
+            void* /*stream_user_data*/)
+    {
+        log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
+        static_cast<Connection*>(user_data)->stream_closed(stream_id, app_error_code);
+        return 0;
+    }
+
+    int connection_callbacks::on_handshake_completed(ngtcp2_conn*, void* user_data)
+    {
+        auto* conn = static_cast<Connection*>(user_data);
+        auto dir_str = conn->is_inbound() ? "SERVER"s : "CLIENT"s;
+
+        log::trace(log_cat, "HANDSHAKE COMPLETED on {} connection", dir_str);
+
+        int rv = 0;
+
+        if (conn->is_inbound())
         {
-            log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
-            return static_cast<Connection*>(user_data)->ack_datagram(dgram_id);
-        }
-
-        static int on_recv_datagram(
-                ngtcp2_conn* /* conn */, uint32_t flags, const uint8_t* data, size_t datalen, void* user_data)
-        {
-            log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
-            return static_cast<Connection*>(user_data)->recv_datagram(
-                    {reinterpret_cast<const std::byte*>(data), datalen}, flags & NGTCP2_STREAM_DATA_FLAG_FIN);
-        }
-
-        static int on_recv_token(ngtcp2_conn* /* conn */, const uint8_t* token, size_t tokenlen, void* user_data)
-        {
-            log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
-            return static_cast<Connection*>(user_data)->recv_token(token, tokenlen);
-        }
-
-        static int on_recv_stream_data(
-                ngtcp2_conn* /*conn*/,
-                uint32_t flags,
-                int64_t stream_id,
-                uint64_t /*offset*/,
-                const uint8_t* data,
-                size_t datalen,
-                void* user_data,
-                void* /*stream_user_data*/)
-        {
-            log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
-            return static_cast<Connection*>(user_data)->stream_receive(
-                    stream_id, {reinterpret_cast<const std::byte*>(data), datalen}, flags & NGTCP2_STREAM_DATA_FLAG_FIN);
-        }
-
-        static int on_acked_stream_data_offset(
-                ngtcp2_conn* /*conn_*/,
-                int64_t stream_id,
-                uint64_t offset,
-                uint64_t datalen,
-                void* user_data,
-                void* /*stream_user_data*/)
-        {
-            log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
-            log::trace(log_cat, "Ack [{},{}]", offset, offset + datalen);
-            return static_cast<Connection*>(user_data)->stream_ack(stream_id, datalen);
-        }
-
-        static int on_stream_open(ngtcp2_conn* /*conn*/, int64_t stream_id, void* user_data)
-        {
-            log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
-            return static_cast<Connection*>(user_data)->stream_opened(stream_id);
-        }
-
-        static int on_stream_close(
-                ngtcp2_conn* /*conn*/,
-                uint32_t /*flags*/,
-                int64_t stream_id,
-                uint64_t app_error_code,
-                void* user_data,
-                void* /*stream_user_data*/)
-        {
-            log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
-            static_cast<Connection*>(user_data)->stream_closed(stream_id, app_error_code);
-            return 0;
-        }
-
-        static int on_stream_reset(
-                ngtcp2_conn* /*conn*/,
-                int64_t stream_id,
-                uint64_t /*final_size*/,
-                uint64_t app_error_code,
-                void* user_data,
-                void* /*stream_user_data*/)
-        {
-            log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
-            static_cast<Connection*>(user_data)->stream_closed(stream_id, app_error_code);
-            return 0;
-        }
-
-        static int on_handshake_completed(ngtcp2_conn*, void* user_data)
-        {
-            auto* conn = static_cast<Connection*>(user_data);
-            auto dir_str = conn->is_inbound() ? "SERVER"s : "CLIENT"s;
-
-            log::trace(log_cat, "HANDSHAKE COMPLETED on {} connection", dir_str);
-
-            int rv = 0;
-
-            if (conn->is_inbound())
-            {
-                rv = conn->server_handshake_completed();
-
-                if (conn->conn_established_cb)
-                    conn->conn_established_cb(*conn);
-                else
-                    conn->endpoint().connection_established(*conn);
-            }
-            else
-                rv = conn->client_handshake_completed();
-
-            return rv;
-        }
-
-        static int on_handshake_confirmed(ngtcp2_conn*, void* user_data)
-        {
-            auto* conn = static_cast<Connection*>(user_data);
-
-            // server should never call this, as it "confirms" on handshake completed
-            assert(conn->is_outbound());
-            log::trace(log_cat, "HANDSHAKE CONFIRMED on CLIENT connection");
+            rv = conn->server_handshake_completed();
 
             if (conn->conn_established_cb)
                 conn->conn_established_cb(*conn);
             else
                 conn->endpoint().connection_established(*conn);
+        }
+        else
+            rv = conn->client_handshake_completed();
+
+        return rv;
+    }
+
+    int connection_callbacks::on_handshake_confirmed(ngtcp2_conn*, void* user_data)
+    {
+        auto* conn = static_cast<Connection*>(user_data);
+
+        // server should never call this, as it "confirms" on handshake completed
+        assert(conn->is_outbound());
+        log::trace(log_cat, "HANDSHAKE CONFIRMED on CLIENT connection");
+
+        if (conn->conn_established_cb)
+            conn->conn_established_cb(*conn);
+        else
+            conn->endpoint().connection_established(*conn);
+
+        return 0;
+    }
+
+    void connection_callbacks::rand_cb(uint8_t* dest, size_t destlen, const ngtcp2_rand_ctx* rand_ctx)
+    {
+        (void)rand_ctx;
+        (void)gnutls_rnd(GNUTLS_RND_RANDOM, dest, destlen);
+    }
+
+    int connection_callbacks::on_connection_id_status(
+            ngtcp2_conn* /* _conn */,
+            ngtcp2_connection_id_status_type type,
+            uint64_t /* seq */,
+            const ngtcp2_cid* cid,
+            const uint8_t* /* token */,
+            void* user_data)
+    {
+        auto* conn = static_cast<Connection*>(user_data);
+
+        auto dir_str = conn->is_inbound() ? "SERVER"s : "CLIENT"s;
+        auto action = type == NGTCP2_CONNECTION_ID_STATUS_TYPE_ACTIVATE ? "ACTIVATING"s : "DEACTIVATING"s;
+        log::trace(log_cat, "{} {} DCID:{}", dir_str, action, oxenc::to_hex(cid->data, cid->data + cid->datalen));
+
+        // auto& ep = conn->endpoint();
+
+        switch (type)
+        {
+            case NGTCP2_CONNECTION_ID_STATUS_TYPE_ACTIVATE:
+                // ep.associate_cid(cid, *conn);
+                break;
+            case NGTCP2_CONNECTION_ID_STATUS_TYPE_DEACTIVATE:
+                // ep.dissociate_cid(cid, *conn);
+                break;
+            default:
+                break;
+        }
+
+        return 0;
+    }
+
+    int connection_callbacks::get_new_connection_id(
+            ngtcp2_conn* /* _conn */, ngtcp2_cid* cid, uint8_t* token, size_t cidlen, void* user_data)
+    {
+        log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
+
+        if (gnutls_rnd(GNUTLS_RND_RANDOM, cid->data, cidlen) != 0)
+            return NGTCP2_ERR_CALLBACK_FAILURE;
+
+        cid->datalen = cidlen;
+        auto* conn = static_cast<Connection*>(user_data);
+        auto& ep = conn->endpoint();
+
+        if (ngtcp2_crypto_generate_stateless_reset_token(token, ep._static_secret.data(), ep._static_secret.size(), cid) !=
+            0)
+            return NGTCP2_ERR_CALLBACK_FAILURE;
+
+        auto dir_str = conn->is_outbound() ? "CLIENT"s : "SERVER"s;
+        log::trace(log_cat, "{} generated new CID for {}", dir_str, conn->reference_id());
+        ep.associate_cid(cid, *conn);
+
+        // TODO: send new stateless reset token
+        //  write packet using ngtcp2_pkt_write_stateless_reset
+        //  define recv_stateless_reset for client
+        //  set stateless_reset_present in transport params
+
+        return 0;
+    }
+
+    int connection_callbacks::remove_connection_id(ngtcp2_conn* /* _conn */, const ngtcp2_cid* cid, void* user_data)
+    {
+        log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
+
+        auto* conn = static_cast<Connection*>(user_data);
+        auto dir_str = conn->is_outbound() ? "CLIENT"s : "SERVER"s;
+        log::trace(log_cat, "{} dissociating CID for {}", dir_str, conn->reference_id());
+        conn->endpoint().dissociate_cid(cid, *conn);
+
+        return 0;
+    }
+
+    int connection_callbacks::extend_max_local_streams_bidi(
+            [[maybe_unused]] ngtcp2_conn* _conn, uint64_t /*max_streams*/, void* user_data)
+    {
+        log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
+
+        auto& conn = *static_cast<Connection*>(user_data);
+        assert(_conn == conn);
+
+        if (auto remaining = ngtcp2_conn_get_streams_bidi_left(conn); remaining > 0)
+            conn.check_pending_streams(remaining);
+
+        return 0;
+    }
+
+    int connection_callbacks::on_path_validation(
+            ngtcp2_conn* _conn [[maybe_unused]],
+            uint32_t flags,
+            const ngtcp2_path* path,
+            const ngtcp2_path* /* old_path */,
+            ngtcp2_path_validation_result res,
+            void* user_data)
+    {
+        log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
+
+        auto& conn = *static_cast<Connection*>(user_data);
+        assert(_conn == conn);
+
+        if (conn.is_outbound())
+        {
+            log::trace(log_cat, "Client updating remote addr...");
+            conn.set_remote_addr(path->remote);
 
             return 0;
         }
-
-        static void rand_cb(uint8_t* dest, size_t destlen, const ngtcp2_rand_ctx* rand_ctx)
+        else if (res != NGTCP2_PATH_VALIDATION_RESULT_SUCCESS)
         {
-            (void)rand_ctx;
-            (void)gnutls_rnd(GNUTLS_RND_RANDOM, dest, destlen);
-        }
-
-        static int on_connection_id_status(
-                ngtcp2_conn* /* _conn */,
-                ngtcp2_connection_id_status_type type,
-                uint64_t /* seq */,
-                const ngtcp2_cid* cid,
-                const uint8_t* /* token */,
-                void* user_data)
-        {
-            auto* conn = static_cast<Connection*>(user_data);
-
-            auto dir_str = conn->is_inbound() ? "SERVER"s : "CLIENT"s;
-            auto action = type == NGTCP2_CONNECTION_ID_STATUS_TYPE_ACTIVATE ? "ACTIVATING"s : "DEACTIVATING"s;
-            log::trace(log_cat, "{} {} DCID:{}", dir_str, action, oxenc::to_hex(cid->data, cid->data + cid->datalen));
-
-            // auto& ep = conn->endpoint();
-
-            switch (type)
-            {
-                case NGTCP2_CONNECTION_ID_STATUS_TYPE_ACTIVATE:
-                    // ep.associate_cid(cid, *conn);
-                    break;
-                case NGTCP2_CONNECTION_ID_STATUS_TYPE_DEACTIVATE:
-                    // ep.dissociate_cid(cid, *conn);
-                    break;
-                default:
-                    break;
-            }
-
+            log::debug(log_cat, "Path validation unsuccessful!");
             return 0;
         }
-
-        static int get_new_connection_id(
-                ngtcp2_conn* /* _conn */, ngtcp2_cid* cid, uint8_t* token, size_t cidlen, void* user_data)
+        else if (not(flags & NGTCP2_PATH_VALIDATION_FLAG_NEW_TOKEN))
         {
-            log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
-
-            if (gnutls_rnd(GNUTLS_RND_RANDOM, cid->data, cidlen) != 0)
-                return NGTCP2_ERR_CALLBACK_FAILURE;
-
-            cid->datalen = cidlen;
-            auto* conn = static_cast<Connection*>(user_data);
-            auto& ep = conn->endpoint();
-
-            if (ngtcp2_crypto_generate_stateless_reset_token(
-                        token, ep._static_secret.data(), ep._static_secret.size(), cid) != 0)
-                return NGTCP2_ERR_CALLBACK_FAILURE;
-
-            auto dir_str = conn->is_outbound() ? "CLIENT"s : "SERVER"s;
-            log::trace(log_cat, "{} generated new CID for {}", dir_str, conn->reference_id());
-            ep.associate_cid(cid, *conn);
-
-            // TODO: send new stateless reset token
-            //  write packet using ngtcp2_pkt_write_stateless_reset
-            //  define recv_stateless_reset for client
-            //  set stateless_reset_present in transport params
-
+            log::debug(log_cat, "Path validation successful!");
             return 0;
         }
+        else
+            return conn.server_path_validation(path);
+    }
 
-        static int remove_connection_id(ngtcp2_conn* /* _conn */, const ngtcp2_cid* cid, void* user_data)
-        {
-            log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
+    int connection_callbacks::on_early_data_rejected(ngtcp2_conn* _conn, void* user_data)
+    {
+        log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
 
-            auto* conn = static_cast<Connection*>(user_data);
-            auto dir_str = conn->is_outbound() ? "CLIENT"s : "SERVER"s;
-            log::trace(log_cat, "{} dissociating CID for {}", dir_str, conn->reference_id());
-            conn->endpoint().dissociate_cid(cid, *conn);
+        auto& conn = *static_cast<Connection*>(user_data);
+        assert(_conn == conn);
 
-            return 0;
-        }
+        // TODO: close connection
 
-        static int extend_max_local_streams_bidi(
-                [[maybe_unused]] ngtcp2_conn* _conn, uint64_t /*max_streams*/, void* user_data)
-        {
-            log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
+        (void)conn;
+        (void)_conn;
 
-            auto& conn = *static_cast<Connection*>(user_data);
-            assert(_conn == conn);
-
-            if (auto remaining = ngtcp2_conn_get_streams_bidi_left(conn); remaining > 0)
-                conn.check_pending_streams(remaining);
-
-            return 0;
-        }
-
-        static int on_path_validation(
-                ngtcp2_conn* _conn [[maybe_unused]],
-                uint32_t flags,
-                const ngtcp2_path* path,
-                const ngtcp2_path* /* old_path */,
-                ngtcp2_path_validation_result res,
-                void* user_data)
-        {
-            log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
-
-            auto& conn = *static_cast<Connection*>(user_data);
-            assert(_conn == conn);
-
-            if (conn.is_outbound())
-            {
-                log::trace(log_cat, "Client updating remote addr...");
-                conn.set_remote_addr(path->remote);
-
-                return 0;
-            }
-            else if (res != NGTCP2_PATH_VALIDATION_RESULT_SUCCESS)
-            {
-                log::debug(log_cat, "Path validation unsuccessful!");
-                return 0;
-            }
-            else if (not(flags & NGTCP2_PATH_VALIDATION_FLAG_NEW_TOKEN))
-            {
-                log::debug(log_cat, "Path validation successful!");
-                return 0;
-            }
-            else
-                return conn.server_path_validation(path);
-        }
-
-        static int on_early_data_rejected(ngtcp2_conn* _conn, void* user_data)
-        {
-            log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
-
-            auto& conn = *static_cast<Connection*>(user_data);
-            assert(_conn == conn);
-
-            (void)conn;
-            (void)_conn;
-
-            return 0;
-        }
-    };
+        return 0;
+    }
 
     void Connection::set_close_quietly()
     {
@@ -1459,26 +1453,26 @@ namespace oxen::quic
             std::chrono::nanoseconds handshake_timeout)
     {
         callbacks.recv_crypto_data = ngtcp2_crypto_recv_crypto_data_cb;
-        callbacks.path_validation = Callbacks::on_path_validation;
+        callbacks.path_validation = connection_callbacks::on_path_validation;
         callbacks.encrypt = ngtcp2_crypto_encrypt_cb;
         callbacks.decrypt = ngtcp2_crypto_decrypt_cb;
         callbacks.hp_mask = ngtcp2_crypto_hp_mask_cb;
-        callbacks.recv_stream_data = Callbacks::on_recv_stream_data;
-        callbacks.acked_stream_data_offset = Callbacks::on_acked_stream_data_offset;
-        callbacks.stream_close = Callbacks::on_stream_close;
-        callbacks.extend_max_local_streams_bidi = Callbacks::extend_max_local_streams_bidi;
-        callbacks.rand = Callbacks::rand_cb;
-        callbacks.get_new_connection_id = Callbacks::get_new_connection_id;
-        callbacks.remove_connection_id = Callbacks::remove_connection_id;
-        callbacks.dcid_status = Callbacks::on_connection_id_status;
+        callbacks.recv_stream_data = connection_callbacks::on_recv_stream_data;
+        callbacks.acked_stream_data_offset = connection_callbacks::on_acked_stream_data_offset;
+        callbacks.stream_close = connection_callbacks::on_stream_close;
+        callbacks.extend_max_local_streams_bidi = connection_callbacks::extend_max_local_streams_bidi;
+        callbacks.rand = connection_callbacks::rand_cb;
+        callbacks.get_new_connection_id = connection_callbacks::get_new_connection_id;
+        callbacks.remove_connection_id = connection_callbacks::remove_connection_id;
+        callbacks.dcid_status = connection_callbacks::on_connection_id_status;
         callbacks.update_key = ngtcp2_crypto_update_key_cb;
-        callbacks.stream_reset = Callbacks::on_stream_reset;
+        callbacks.stream_reset = connection_callbacks::on_stream_reset;
         callbacks.delete_crypto_aead_ctx = ngtcp2_crypto_delete_crypto_aead_ctx_cb;
         callbacks.delete_crypto_cipher_ctx = ngtcp2_crypto_delete_crypto_cipher_ctx_cb;
         callbacks.get_path_challenge_data = ngtcp2_crypto_get_path_challenge_data_cb;
         callbacks.version_negotiation = ngtcp2_crypto_version_negotiation_cb;
-        callbacks.stream_open = Callbacks::on_stream_open;
-        callbacks.handshake_completed = Callbacks::on_handshake_completed;
+        callbacks.stream_open = connection_callbacks::on_stream_open;
+        callbacks.handshake_completed = connection_callbacks::on_handshake_completed;
 
         ngtcp2_settings_default(&settings);
 
@@ -1519,9 +1513,9 @@ namespace oxen::quic
             params.max_udp_payload_size = NGTCP2_DEFAULT_MAX_RECV_UDP_PAYLOAD_SIZE;  // 65527
             settings.max_tx_udp_payload_size = MAX_PMTUD_UDP_PAYLOAD;                // 1500 - 48 (approximate overhead)
             // settings.no_tx_udp_payload_size_shaping = 1;
-            callbacks.recv_datagram = Callbacks::on_recv_datagram;
+            callbacks.recv_datagram = connection_callbacks::on_recv_datagram;
 #ifndef NDEBUG
-            callbacks.ack_datagram = Callbacks::on_ack_datagram;
+            callbacks.ack_datagram = connection_callbacks::on_ack_datagram;
 #endif
 
             di = _endpoint.make_shared<dgram_interface>(*this);
@@ -1599,9 +1593,9 @@ namespace oxen::quic
         if (is_outbound())
         {
             callbacks.client_initial = ngtcp2_crypto_client_initial_cb;
-            callbacks.handshake_confirmed = Callbacks::on_handshake_confirmed;
+            callbacks.handshake_confirmed = connection_callbacks::on_handshake_confirmed;
             callbacks.recv_retry = ngtcp2_crypto_recv_retry_cb;
-            callbacks.recv_new_token = Callbacks::on_recv_token;
+            callbacks.recv_new_token = connection_callbacks::on_recv_token;
 
             // Clients should be the ones providing a remote pubkey here. This way we can emplace it into
             // the gnutlssession object to be verified. Servers should be verifying via callback

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -1543,9 +1543,8 @@ namespace oxen::quic
         if (_stateless_reset_enabled)
         {
             callbacks.recv_stateless_reset = connection_callbacks::recv_stateless_reset;
-            log::info(log_cat, "Connection configured to watch for stateless reset packets");
             callbacks.dcid_status = connection_callbacks::on_connection_id_status;
-            log::info(log_cat, "Connection configured to monitor activated dcids and stateless reset tokens");
+            log::debug(log_cat, "Connection configured to monitor active dcids and stateless reset packets");
         }
 
         ngtcp2_settings_default(&settings);

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -86,7 +86,7 @@ namespace oxen::quic
 
     void IOContext::handle_ioctx_opt(opt::disable_key_verification)
     {
-        log::warning(
+        log::info(
                 log_cat,
                 "IOContext disabling key verification for {}bound connections!",
                 dir == Direction::INBOUND ? "in" : "out");

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -83,4 +83,13 @@ namespace oxen::quic
         log::trace(log_cat, "IO context stored connection closed callback");
         conn_closed_cb = std::move(func);
     }
+
+    void IOContext::handle_ioctx_opt(opt::disable_key_verification)
+    {
+        log::warning(
+                log_cat,
+                "IOContext disabling key verification for {}bound connections!",
+                dir == Direction::INBOUND ? "in" : "out");
+        disable_key_verification = true;
+    }
 }  // namespace oxen::quic

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -96,7 +96,7 @@ namespace oxen::quic
 
             if (auto it = session_tickets.find(key); it != session_tickets.end())
             {
-                if (auto exp = gnutls_db_check_entry_expire_time(*it->second); current < exp)
+                if (auto exp = gnutls_db_check_entry_expire_time(it->second->datum()); current < exp)
                 {
                     log::debug(log_cat, "Found existing anti-replay ticket for incoming connection; rejecting...");
                     return GNUTLS_E_DB_ENTRY_EXISTS;
@@ -550,15 +550,15 @@ namespace oxen::quic
         }
     }
 
-    int Endpoint::validate_anti_replay(gtls_session_ticket ticket, time_t current)
+    int Endpoint::validate_anti_replay(gtls_ticket_ptr ticket, time_t current)
     {
-        return _validate_0rtt_ticket(gtls_session_ticket::make(std::move(ticket)), current) ? 0 : GNUTLS_E_DB_ENTRY_EXISTS;
+        return _validate_0rtt_ticket(std::move(ticket), current) ? 0 : GNUTLS_E_DB_ENTRY_EXISTS;
     }
 
-    void Endpoint::store_session_ticket(gtls_session_ticket ticket)
+    void Endpoint::store_session_ticket(gtls_ticket_ptr ticket)
     {
         log::trace(log_cat, "Storing session ticket...");
-        return _put_session_ticket(gtls_session_ticket::make(std::move(ticket)), 0);
+        return _put_session_ticket(std::move(ticket), 0);
     }
 
     gtls_ticket_ptr Endpoint::get_session_ticket(const ustring_view& remote_pk)

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -134,6 +134,7 @@ namespace oxen::quic
 
     void Endpoint::handle_ep_opt(opt::disable_stateless_reset /* rst */)
     {
+        log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
         _stateless_reset_enabled = false;
     }
 
@@ -363,7 +364,7 @@ namespace oxen::quic
             }
             else
             {
-                log::info(log_cat, "Dropping packet; unknown connection ID to endpoint not accepting inbound conns");
+                log::info(log_cat, "Received packet with unknown connection ID; local endpoint not accepting inbounds!");
                 return;
             }
         }
@@ -704,16 +705,11 @@ namespace oxen::quic
                     now);
             rv != 0)
         {
-            log::critical(
-                    log_cat,
-                    "Server (local={}) could not verify regular token! path: [local={}, remote={}]",
-                    _local,
-                    pkt.path.local,
-                    pkt.path.remote);
+            log::debug(log_cat, "Server (local={}) could not verify regular token! path: {}", _local, pkt.path);
             return false;
         }
 
-        log::critical(log_cat, "Server successfully verified regular token!");
+        log::debug(log_cat, "Server successfully verified regular token! path: {}", pkt.path);
         return true;
     }
 
@@ -902,7 +898,7 @@ namespace oxen::quic
                 reset_token_lookup.erase(rit->second);
             }
             else
-                log::warning(log_cat, "Received good stateless reset token but no connection exists for it; deleting entry");
+                log::debug(log_cat, "Received good stateless reset token but no connection exists for it; deleting entry");
 
             reset_token_map.erase(rit);
         }

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -191,19 +191,14 @@ namespace oxen::quic
         log::debug(log_cat, "Inbound context ready for incoming connections");
     }
 
-    void Endpoint::_connect(
-            RemoteAddress remote, quic_cid qcid, ConnectionID rid, std::promise<std::shared_ptr<Connection>>& p)
+    std::shared_ptr<Connection> Endpoint::_connect(RemoteAddress remote, quic_cid qcid, ConnectionID rid)
     {
         Address addr{remote};
-        return _connect(std::move(addr), std::move(qcid), std::move(rid), p, std::move(remote).get_remote_key());
+        return _connect(std::move(addr), std::move(qcid), std::move(rid), std::move(remote).get_remote_key());
     }
 
-    void Endpoint::_connect(
-            Address remote,
-            quic_cid qcid,
-            ConnectionID rid,
-            std::promise<std::shared_ptr<Connection>>& p,
-            std::optional<ustring> pk)
+    std::shared_ptr<Connection> Endpoint::_connect(
+            Address remote, quic_cid qcid, ConnectionID rid, std::optional<ustring> pk)
     {
         Path path = Path{_local, std::move(remote)};
 
@@ -227,8 +222,7 @@ namespace oxen::quic
                             handshake_timeout,
                             pk);
 
-                    p.set_value(it_b->second);
-                    return;
+                    return it_b->second;
                 }
             }
         }

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -98,7 +98,7 @@ namespace oxen::quic
             {
                 if (auto exp = gnutls_db_check_entry_expire_time(*it->second); current < exp)
                 {
-                    log::info(log_cat, "Found existing anti-replay ticket for incoming connection; rejecting...");
+                    log::debug(log_cat, "Found existing anti-replay ticket for incoming connection; rejecting...");
                     return GNUTLS_E_DB_ENTRY_EXISTS;
                 }
 

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -759,10 +759,6 @@ namespace oxen::quic
             return;
         }
 
-        // map stateless reset
-        auto [it, _] = reset_token_lookup.emplace(cid, std::move(token));
-        reset_token_map.emplace(it->second, cid);
-
         // ensure we had enough write space
         assert(static_cast<size_t>(nwrite) <= buf.size());
         buf.resize(nwrite);

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -132,9 +132,9 @@ namespace oxen::quic
         };
     }
 
-    void Endpoint::handle_ep_opt(opt::enable_stateless_reset /* rst */)
+    void Endpoint::handle_ep_opt(opt::disable_stateless_reset /* rst */)
     {
-        _stateless_reset_enabled = true;
+        _stateless_reset_enabled = false;
     }
 
     ConnectionID Endpoint::next_reference_id()

--- a/src/gnutls_crypto.cpp
+++ b/src/gnutls_crypto.cpp
@@ -1,0 +1,60 @@
+#include "gnutls_crypto.hpp"
+
+#include "internal.hpp"
+#include "udp.hpp"
+
+namespace oxen::quic
+{
+    gtls_reset_token::gtls_reset_token(const uint8_t* t, const uint8_t* r)
+    {
+        std::memcpy(_tok.data(), t, gtls_reset_token::TOKENSIZE);
+        if (r)
+            std::memcpy(_rand.data(), r, gtls_reset_token::RANDSIZE);
+        else
+            generate_rand(_rand.data());
+    }
+
+    gtls_reset_token::gtls_reset_token(uint8_t* _static_secret, size_t _secret_len, const quic_cid& cid)
+    {
+        generate_token(_tok.data(), _static_secret, _secret_len, cid);
+        generate_rand(_rand.data());
+    }
+
+    void gtls_reset_token::generate_token(uint8_t* buffer, uint8_t* _static_secret, size_t _secret_len, const quic_cid& cid)
+    {
+        if (ngtcp2_crypto_generate_stateless_reset_token(buffer, _static_secret, _secret_len, &cid) != 0)
+            throw std::runtime_error{"Failed to generate stateless reset token!"};
+    }
+
+    void gtls_reset_token::generate_rand(uint8_t* buffer)
+    {
+        if (gnutls_rnd(GNUTLS_RND_RANDOM, buffer, RANDSIZE) != 0)
+            throw std::runtime_error{"Failed to generate stateless reset random"};
+    }
+
+    std::shared_ptr<gtls_reset_token> gtls_reset_token::generate(
+            uint8_t* _static_secret, size_t _secret_len, const quic_cid& cid)
+    {
+        std::shared_ptr<gtls_reset_token> ret = nullptr;
+        try
+        {
+            ret = std::shared_ptr<gtls_reset_token>{new gtls_reset_token{_static_secret, _secret_len, cid}};
+        }
+        catch (const std::exception& e)
+        {
+            log::error(log_cat, "gtls_reset_token exception: {}", e.what());
+        }
+
+        return ret;
+    }
+
+    std::shared_ptr<gtls_reset_token> gtls_reset_token::make_copy(const uint8_t* t, const uint8_t* r)
+    {
+        return std::shared_ptr<gtls_reset_token>{new gtls_reset_token{t, r}};
+    }
+
+    std::shared_ptr<gtls_reset_token> gtls_reset_token::parse_packet(const Packet& pkt)
+    {
+        return gtls_reset_token::make_copy(pkt.data<uint8_t>(pkt.size() - gtls_reset_token::TOKENSIZE).data());
+    }
+}  //  namespace oxen::quic

--- a/src/gnutls_session.cpp
+++ b/src/gnutls_session.cpp
@@ -35,6 +35,7 @@ namespace oxen::quic
     {
         if (htype == GNUTLS_HANDSHAKE_NEW_SESSION_TICKET)
         {
+            log::debug(log_cat, "Client received new session ticket from server!");
             auto* conn = get_connection_from_gnutls(session);
             auto remote_key = conn->remote_key();
             auto& ep = conn->endpoint();

--- a/src/gnutls_session.cpp
+++ b/src/gnutls_session.cpp
@@ -220,6 +220,13 @@ namespace oxen::quic
 
             if (_0rtt_enabled)
             {
+                if (auto rv = gnutls_session_ticket_enable_client(session); rv != 0)
+                {
+                    auto err = "gnutls_session_ticket_enable_client failed: {}"_format(gnutls_strerror(rv));
+                    log::error(log_cat, "{}", err);
+                    throw std::runtime_error{err};
+                }
+
                 log::trace(log_cat, "Setting client session ticket db hook...");
                 gnutls_handshake_set_hook_function(
                         session,

--- a/src/internal.hpp
+++ b/src/internal.hpp
@@ -136,6 +136,8 @@ namespace oxen::quic
                 unsigned when,
                 unsigned int incoming,
                 const gnutls_datum_t* msg);
+
+        static int cert_verify_callback_gnutls(gnutls_session_t session);
     };
 
 }  // namespace oxen::quic

--- a/src/internal.hpp
+++ b/src/internal.hpp
@@ -24,26 +24,118 @@ namespace oxen::quic
             1;
 #endif
 
-    // Wrapper around inet_pton that throws an exception on error
-    inline void parse_addr(int af, void* dest, const std::string& from)
+    namespace detail
     {
-        auto rv = inet_pton(af, from.c_str(), dest);
+        // Wrapper around inet_pton that throws an exception on error
+        inline void parse_addr(int af, void* dest, const std::string& from)
+        {
+            auto rv = inet_pton(af, from.c_str(), dest);
 
-        if (rv == 0)  // inet_pton returns this on invalid input
-            throw std::invalid_argument{"Unable to parse IP address!"};
-        if (rv < 0)
-            throw std::system_error{errno, std::system_category()};
-    }
+            if (rv == 0)  // inet_pton returns this on invalid input
+                throw std::invalid_argument{"Unable to parse IP address!"};
+            if (rv < 0)
+                throw std::system_error{errno, std::system_category()};
+        }
 
-    // Parses an IPv4 address from string
-    inline void parse_addr(in_addr& into, const std::string& from)
+        // Parses an IPv4 address from string
+        inline void parse_addr(in_addr& into, const std::string& from)
+        {
+            parse_addr(AF_INET, &into.s_addr, from);
+        }
+
+        // Parses an IPv6 address from string
+        inline void parse_addr(in6_addr& into, const std::string& from)
+        {
+            parse_addr(AF_INET6, &into, from);
+        }
+    }  // namespace detail
+
+    struct connection_callbacks
     {
-        parse_addr(AF_INET, &into.s_addr, from);
-    }
+        static int on_ack_datagram(ngtcp2_conn* conn, uint64_t dgram_id, void* user_data);
 
-    // Parses an IPv6 address from string
-    inline void parse_addr(in6_addr& into, const std::string& from)
+        static int on_recv_datagram(ngtcp2_conn* conn, uint32_t flags, const uint8_t* data, size_t datalen, void* user_data);
+
+        static int on_recv_token(ngtcp2_conn* conn, const uint8_t* token, size_t tokenlen, void* user_data);
+
+        static int on_recv_stream_data(
+                ngtcp2_conn* conn,
+                uint32_t flags,
+                int64_t stream_id,
+                uint64_t offset,
+                const uint8_t* data,
+                size_t datalen,
+                void* user_data,
+                void* stream_user_data);
+
+        static int on_acked_stream_data_offset(
+                ngtcp2_conn* conn_,
+                int64_t stream_id,
+                uint64_t offset,
+                uint64_t datalen,
+                void* user_data,
+                void* stream_user_data);
+
+        static int on_stream_open(ngtcp2_conn* conn, int64_t stream_id, void* user_data);
+
+        static int on_stream_close(
+                ngtcp2_conn* conn,
+                uint32_t flags,
+                int64_t stream_id,
+                uint64_t app_error_code,
+                void* user_data,
+                void* stream_user_data);
+
+        static int on_stream_reset(
+                ngtcp2_conn* conn,
+                int64_t stream_id,
+                uint64_t final_size,
+                uint64_t app_error_code,
+                void* user_data,
+                void* stream_user_data);
+
+        static int on_handshake_completed(ngtcp2_conn*, void* user_data);
+
+        static int on_handshake_confirmed(ngtcp2_conn*, void* user_data);
+
+        static void rand_cb(uint8_t* dest, size_t destlen, const ngtcp2_rand_ctx* rand_ctx);
+
+        static int on_connection_id_status(
+                ngtcp2_conn* _conn,
+                ngtcp2_connection_id_status_type type,
+                uint64_t seq,
+                const ngtcp2_cid* cid,
+                const uint8_t* token,
+                void* user_data);
+
+        static int get_new_connection_id(
+                ngtcp2_conn* _conn, ngtcp2_cid* cid, uint8_t* token, size_t cidlen, void* user_data);
+
+        static int remove_connection_id(ngtcp2_conn* _conn, const ngtcp2_cid* cid, void* user_data);
+
+        static int extend_max_local_streams_bidi(ngtcp2_conn* _conn, uint64_t max_streams, void* user_data);
+
+        static int on_path_validation(
+                ngtcp2_conn* _conn [[maybe_unused]],
+                uint32_t flags,
+                const ngtcp2_path* path,
+                const ngtcp2_path* old_path,
+                ngtcp2_path_validation_result res,
+                void* user_data);
+
+        static int on_early_data_rejected(ngtcp2_conn* _conn, void* user_data);
+    };
+
+    struct gtls_session_callbacks
     {
-        parse_addr(AF_INET6, &into, from);
-    }
+        static int server_anti_replay_cb(void* dbf, time_t exp_time, const gnutls_datum_t* key, const gnutls_datum_t* data);
+
+        static int client_session_cb(
+                gnutls_session_t session,
+                unsigned int htype,
+                unsigned when,
+                unsigned int incoming,
+                const gnutls_datum_t* msg);
+    };
+
 }  // namespace oxen::quic

--- a/src/internal.hpp
+++ b/src/internal.hpp
@@ -124,6 +124,8 @@ namespace oxen::quic
                 void* user_data);
 
         static int on_early_data_rejected(ngtcp2_conn* _conn, void* user_data);
+
+        static int recv_stateless_reset(ngtcp2_conn* conn, const ngtcp2_pkt_stateless_reset* sr, void* user_data);
     };
 
     struct gtls_session_callbacks

--- a/src/ip.cpp
+++ b/src/ip.cpp
@@ -7,7 +7,7 @@ namespace oxen::quic
     ipv4::ipv4(const std::string& str)
     {
         in_addr sin;
-        parse_addr(sin, str);
+        detail::parse_addr(sin, str);
         addr = oxenc::big_to_host(sin.s_addr);
     }
 
@@ -43,7 +43,7 @@ namespace oxen::quic
     ipv6::ipv6(const std::string& str)
     {
         in6_addr sin6;
-        parse_addr(sin6, str);
+        detail::parse_addr(sin6, str);
 
         hi = oxenc::load_big_to_host<uint64_t>(&sin6.s6_addr[0]);
         lo = oxenc::load_big_to_host<uint64_t>(&sin6.s6_addr[8]);

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -53,7 +53,7 @@ namespace oxen::quic
 
         if (event_add(ev.get(), &interval) != 0)
         {
-            log::critical(log_cat, "EventHandler failed to start repeating event!");
+            log::warning(log_cat, "EventHandler failed to start repeating event!");
             return false;
         }
 
@@ -69,7 +69,7 @@ namespace oxen::quic
 
         if (event_del(ev.get()) != 0)
         {
-            log::critical(log_cat, "EventHandler failed to pause repeating event!");
+            log::warning(log_cat, "EventHandler failed to pause repeating event!");
             return false;
         }
 
@@ -104,7 +104,7 @@ namespace oxen::quic
                         auto* self = reinterpret_cast<Ticker*>(s);
                         if (not self->f)
                         {
-                            log::critical(log_cat, "Ticker does not have a callback to execute!");
+                            log::warning(log_cat, "Ticker does not have a callback to execute!");
                             return;
                         }
                         // execute callback
@@ -112,13 +112,13 @@ namespace oxen::quic
                     }
                     catch (const std::exception& e)
                     {
-                        log::critical(log_cat, "Ticker caught exception: {}", e.what());
+                        log::warning(log_cat, "Ticker caught exception: {}", e.what());
                     }
                 },
                 this));
 
         if ((one_off or start_immediately) and not start())
-            log::critical(log_cat, "Failed to immediately start one-off event!");
+            log::warning(log_cat, "Failed to immediately start one-off event!");
     }
 
     Ticker::~Ticker()

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -39,7 +39,7 @@ namespace oxen::quic
                 - this is an equally annoying typedef for `suseconds_t`
         Alas, yet again another mac idiosyncrasy...
      */
-    timeval loop_time_to_timeval(std::chrono::microseconds t)
+    static timeval loop_time_to_timeval(std::chrono::microseconds t)
     {
         return timeval{
                 .tv_sec = static_cast<decltype(timeval::tv_sec)>(t / 1s),

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -177,7 +177,7 @@ namespace oxen::quic
 
         ev_loop = std::shared_ptr<event_base>{event_base_new_with_config(ev_conf.get()), event_base_free};
 
-        log::info(log_cat, "Started libevent loop with backend {}", event_base_get_method(ev_loop.get()));
+        log::debug(log_cat, "Started libevent loop with backend {}", event_base_get_method(ev_loop.get()));
 
         setup_job_waker();
 
@@ -194,12 +194,12 @@ namespace oxen::quic
         p.get_future().get();
 
         running.store(true);
-        log::info(log_cat, "loop is started");
+        log::info(log_cat, "libevent loop is started");
     }
 
     Loop::~Loop()
     {
-        log::info(log_cat, "Shutting down loop...");
+        log::debug(log_cat, "Shutting down loop...");
 
         stop_thread();
 
@@ -223,6 +223,8 @@ namespace oxen::quic
 
     void Loop::stop_thread(bool immediate)
     {
+        log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
+
         if (loop_thread)
             immediate ? event_base_loopbreak(ev_loop.get()) : event_base_loopexit(ev_loop.get(), nullptr);
 

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -23,7 +23,7 @@ namespace oxen::quic
 
     Network::~Network()
     {
-        log::info(log_cat, "Shutting down network...");
+        log::debug(log_cat, "Shutting down network...");
 
         if (not shutdown_immediate)
             close_gracefully();
@@ -45,7 +45,7 @@ namespace oxen::quic
 
     void Network::close_gracefully()
     {
-        log::info(log_cat, "{} called", __PRETTY_FUNCTION__);
+        log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
 
         std::promise<void> pr;
         auto ft = pr.get_future();

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -308,7 +308,7 @@ namespace oxen::quic
         assert(endpoint.in_event_loop());
         log::trace(log_cat, "Stream (ID:{}) reverting after early data rejected...", _stream_id);
         _unacked_size = 0;
-        log::debug(log_cat, "Stream (ID:{}) has {}B in buffer, 0B unacacked...", _stream_id, size());
+        log::debug(log_cat, "Stream (ID:{}) has {}B in buffer, 0B unacked...", _stream_id, size());
     }
 
     std::vector<ngtcp2_vec> Stream::pending()

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -303,6 +303,14 @@ namespace oxen::quic
         return std::make_pair(std::move(it), offset);
     }
 
+    void Stream::revert_stream()
+    {
+        assert(endpoint.in_event_loop());
+        log::trace(log_cat, "Stream (ID:{}) reverting after early data rejected...", _stream_id);
+        _unacked_size = 0;
+        log::debug(log_cat, "Stream (ID:{}) has {}B in buffer, 0B unacacked...", _stream_id, size());
+    }
+
     std::vector<ngtcp2_vec> Stream::pending()
     {
         log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -31,7 +31,7 @@ namespace oxen::quic
 
         if (!close_callback)
             close_callback = [](Stream&, uint64_t error_code) {
-                log::info(log_cat, "Default stream close callback called ({})", quic_strerror(error_code));
+                log::debug(log_cat, "Default stream close callback called ({})", quic_strerror(error_code));
             };
 
         log::trace(log_cat, "Stream object created");
@@ -70,7 +70,7 @@ namespace oxen::quic
 
             _is_watermarked = true;
 
-            log::info(log_cat, "Stream set watermarks!");
+            log::trace(log_cat, "Stream set watermarks!");
         });
     }
 
@@ -90,7 +90,7 @@ namespace oxen::quic
             if (_high_water)
                 _high_water.clear();
             _is_watermarked = false;
-            log::info(log_cat, "Stream cleared currently set watermarks!");
+            log::trace(log_cat, "Stream cleared currently set watermarks!");
         });
     }
 
@@ -163,9 +163,9 @@ namespace oxen::quic
             log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
 
             if (_is_shutdown)
-                log::info(log_cat, "Stream is already shutting down");
+                log::trace(log_cat, "Stream is already shutting down");
             else if (_is_closing)
-                log::debug(log_cat, "Stream is already closing");
+                log::trace(log_cat, "Stream is already closing");
             else
             {
                 _is_closing = _is_shutdown = true;
@@ -215,7 +215,7 @@ namespace oxen::quic
         if (_ready)
             _conn->packet_io_ready();
         else
-            log::info(log_cat, "Stream not ready for broadcast yet, data appended to buffer and on deck");
+            log::debug(log_cat, "Stream not ready for broadcast yet, data appended to buffer and on deck");
     }
 
     void Stream::acknowledge(size_t bytes)
@@ -250,11 +250,11 @@ namespace oxen::quic
             if (unsent >= _high_mark)
             {
                 _low_primed = true;
-                log::info(log_cat, "Low water hook primed!");
+                log::trace(log_cat, "Low water hook primed!");
 
                 if (_high_water and _high_primed)
                 {
-                    log::info(log_cat, "Executing high watermark hook!");
+                    log::debug(log_cat, "Executing high watermark hook!");
                     _high_primed = false;
                     return _high_water(*this);
                 }
@@ -264,11 +264,11 @@ namespace oxen::quic
             else if (unsent <= _low_mark)
             {
                 _high_primed = true;
-                log::info(log_cat, "High water hook primed!");
+                log::trace(log_cat, "High water hook primed!");
 
                 if (_low_water and _low_primed)
                 {
-                    log::info(log_cat, "Executing low watermark hook!");
+                    log::debug(log_cat, "Executing low watermark hook!");
                     _low_primed = false;
                     return _low_water(*this);
                 }

--- a/src/udp.cpp
+++ b/src/udp.cpp
@@ -792,7 +792,7 @@ namespace oxen::quic
                  {static_cast<const sockaddr*>(hdr.msg_name), hdr.msg_namelen}
 #endif
             },
-            pkt_data{data}
+            pkt_data{data.begin(), data.end()}
     {
         assert(path.remote.is_ipv4() || path.remote.is_ipv6());
 

--- a/src/udp.cpp
+++ b/src/udp.cpp
@@ -792,7 +792,7 @@ namespace oxen::quic
                  {static_cast<const sockaddr*>(hdr.msg_name), hdr.msg_namelen}
 #endif
             },
-            pkt_data{data.begin(), data.end()}
+            data_sp{data.begin(), data.end()}
     {
         assert(path.remote.is_ipv4() || path.remote.is_ipv6());
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -27,7 +27,7 @@ namespace oxen::quic
         }
     }
 
-    std::chrono::steady_clock::time_point get_time()
+    time_point get_time()
     {
         return std::chrono::steady_clock::now();
     }

--- a/tests/001-handshake.cpp
+++ b/tests/001-handshake.cpp
@@ -340,7 +340,7 @@ namespace oxen::quic::test
         auto server_endpoint = test_net.endpoint(server_local, server_established);
         CHECK_NOTHROW(server_endpoint->listen(server_tls));
 
-        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
         SECTION("Incorrect pubkey in remote")
         {
@@ -352,7 +352,7 @@ namespace oxen::quic::test
 
             auto client_endpoint = test_net.endpoint(client_local, client_established_2, client_closed);
 
-            RemoteAddress bad_client_remote{defaults::CLIENT_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+            RemoteAddress bad_client_remote{defaults::CLIENT_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
             auto client_ci = client_endpoint->connect(bad_client_remote, client_tls);
 
@@ -368,7 +368,7 @@ namespace oxen::quic::test
 
             auto short_key = defaults::SERVER_PUBKEY.substr(0, 31);
 
-            RemoteAddress bad_client_remote{short_key, "127.0.0.1"s, server_endpoint->local().port()};
+            RemoteAddress bad_client_remote{short_key, LOCALHOST, server_endpoint->local().port()};
 
             REQUIRE_THROWS(client_endpoint->connect(bad_client_remote, client_tls));
         }
@@ -378,7 +378,7 @@ namespace oxen::quic::test
             // If uncommented, this line will not compile! Remote addresses must pass a remote pubkey to be
             // verified upon the client successfully establishing connection with a remote.
 
-            // RemoteAddress client_remote{"127.0.0.1"s, server_endpoint->local().port()};
+            // RemoteAddress client_remote{LOCALHOST, server_endpoint->local().port()};
             CHECK(true);
         }
 
@@ -411,7 +411,7 @@ namespace oxen::quic::test
         auto server_endpoint = test_net.endpoint(server_local, server_established);
         CHECK_NOTHROW(server_endpoint->listen(server_tls));
 
-        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
         auto client_endpoint = test_net.endpoint(client_local, client_established);
 
@@ -457,7 +457,7 @@ namespace oxen::quic::test
         CHECK_NOTHROW(server_endpoint->listen(server_tls));
 
         auto client_endpoint = test_net.endpoint(client_local, client_established);
-        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
         auto client_ci = client_endpoint->connect(client_remote, client_tls);
 
@@ -515,7 +515,7 @@ namespace oxen::quic::test
         auto server_endpoint = test_net.endpoint(server_local, server_established);
         CHECK_NOTHROW(server_endpoint->listen(server_tls));
 
-        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
         auto client_endpoint = test_net.endpoint(client_local, client_established);
         auto client_ci = client_endpoint->connect(client_remote, client_tls);
@@ -552,7 +552,7 @@ namespace oxen::quic::test
         auto server_endpoint = test_net.endpoint(server_local, server_established);
         CHECK_NOTHROW(server_endpoint->listen(server_tls));
 
-        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
         auto client_endpoint = test_net.endpoint(client_local, client_established);
         auto client_ci = client_endpoint->connect(client_remote, client_tls);
@@ -685,11 +685,11 @@ namespace oxen::quic::test
 
             auto server_endpoint = test_net.endpoint(server_local, server_established, server_closed_ep_level);
 
-            RemoteAddress client_remote{S_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+            RemoteAddress client_remote{S_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
             auto client_endpoint = test_net.endpoint(client_local, client_established);
 
-            RemoteAddress server_remote{C_PUBKEY, "127.0.0.1"s, client_endpoint->local().port()};
+            RemoteAddress server_remote{C_PUBKEY, LOCALHOST, client_endpoint->local().port()};
 
             server_endpoint->listen(server_tls);
             client_endpoint->listen(client_tls);
@@ -718,11 +718,11 @@ namespace oxen::quic::test
 
             auto server_endpoint = test_net.endpoint(server_local, server_established);
 
-            RemoteAddress client_remote{S_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+            RemoteAddress client_remote{S_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
             auto client_endpoint = test_net.endpoint(client_local, client_established);
 
-            RemoteAddress server_remote{C_PUBKEY, "127.0.0.1"s, client_endpoint->local().port()};
+            RemoteAddress server_remote{C_PUBKEY, LOCALHOST, client_endpoint->local().port()};
 
             server_endpoint->listen(server_tls);
             client_endpoint->listen(client_tls);
@@ -772,7 +772,7 @@ namespace oxen::quic::test
         auto server_endpoint = net.endpoint(server_local, server_conn_closed);
         auto client_endpoint = net.endpoint(client_local, client_conn_closed);
 
-        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
         SECTION("Client fast timeout")
         {
@@ -817,9 +817,9 @@ namespace oxen::quic::test
         server_tls->set_key_verify_callback([](const ustring_view&, const ustring_view&) {
             // This stalls the entire network object; this is a really terrible thing to do outside
             // of test code, but will let us simulate a slow handshake.
-            log::critical(log_cat, "key verify sleeping...");
+            log::critical(test_cat, "key verify sleeping...");
             std::this_thread::sleep_for(30s);
-            log::critical(log_cat, "key verify done sleeping");
+            log::critical(test_cat, "key verify done sleeping");
             return true;
         });
 #endif
@@ -834,7 +834,7 @@ namespace oxen::quic::test
         std::shared_ptr<connection_interface> client_ci;
 
         auto server_endpoint = net1->endpoint(server_local);
-        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
         server_endpoint.reset();
         net1.reset();  // kill the server
@@ -883,7 +883,7 @@ namespace oxen::quic::test
         std::shared_ptr<connection_interface> client_ci;
 
         auto server_endpoint = net1->endpoint(server_local);
-        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
         server_endpoint.reset();
         net1.reset();  // kill the server

--- a/tests/003-multiclient.cpp
+++ b/tests/003-multiclient.cpp
@@ -50,7 +50,7 @@ namespace oxen::quic::test
         auto p_itr = stream_promises.begin();
 
         stream_data_callback server_data_cb = [&](Stream&, bstring_view) {
-            log::debug(log_cat, "Calling server stream data callback... data received...");
+            log::debug(test_cat, "Calling server stream data callback... data received...");
             data_check += 1;
             p_itr->set_value();
             ++p_itr;
@@ -63,10 +63,10 @@ namespace oxen::quic::test
         auto server_endpoint = test_net.endpoint(server_local);
         REQUIRE_NOTHROW(server_endpoint->listen(server_tls, server_data_cb));
 
-        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
         std::thread async_thread_a{[&]() {
-            log::debug(log_cat, "Async thread A called");
+            log::debug(test_cat, "Async thread A called");
 
             // client A
             auto client_a = test_net.endpoint(client_a_local);
@@ -86,7 +86,7 @@ namespace oxen::quic::test
         }};
 
         std::thread async_thread_b{[&]() {
-            log::debug(log_cat, "Async thread B called");
+            log::debug(test_cat, "Async thread B called");
 
             // client C
             auto client_c = test_net.endpoint(client_c_local);

--- a/tests/004-streams.cpp
+++ b/tests/004-streams.cpp
@@ -27,7 +27,7 @@ namespace oxen::quic::test
         auto server_endpoint = test_net.endpoint(server_local);
         REQUIRE_NOTHROW(server_endpoint->listen(server_tls, max_streams));
 
-        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
         auto client_endpoint = test_net.endpoint(client_local, client_established);
         auto conn_interface = client_endpoint->connect(client_remote, client_tls, max_streams);
@@ -49,7 +49,7 @@ namespace oxen::quic::test
         Address client_local{};
 
         stream_data_callback server_data_cb = [&](Stream&, bstring_view) {
-            log::debug(log_cat, "Calling server stream data callback... data received...");
+            log::debug(test_cat, "Calling server stream data callback... data received...");
             data_promise.set_value();
         };
 
@@ -58,7 +58,7 @@ namespace oxen::quic::test
         auto server_endpoint = test_net.endpoint(server_local);
         REQUIRE_NOTHROW(server_endpoint->listen(server_tls, max_streams, server_data_cb));
 
-        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
         auto client_endpoint = test_net.endpoint(client_local);
         auto conn_interface = client_endpoint->connect(client_remote, client_tls, max_streams);
@@ -87,7 +87,7 @@ namespace oxen::quic::test
         Address client_local{};
 
         stream_data_callback server_data_cb = [&](Stream&, bstring_view) {
-            log::debug(log_cat, "Calling server stream data callback... data received...");
+            log::debug(test_cat, "Calling server stream data callback... data received...");
             data_promise.set_value();
         };
 
@@ -96,7 +96,7 @@ namespace oxen::quic::test
         auto server_endpoint = test_net.endpoint(server_local);
         REQUIRE_NOTHROW(server_endpoint->listen(server_tls, server_config, server_data_cb));
 
-        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
         auto client_endpoint = test_net.endpoint(client_local, client_established);
         auto client_ci = client_endpoint->connect(client_remote, client_tls, client_config);
@@ -152,7 +152,7 @@ namespace oxen::quic::test
         send_futures[n_sends - 1] = send_promises[n_sends - 1].get_future();
 
         stream_data_callback server_data_cb = [&](Stream&, bstring_view) {
-            log::debug(log_cat, "Calling server stream data callback... data received... incrementing counter...");
+            log::debug(test_cat, "Calling server stream data callback... data received... incrementing counter...");
 
             try
             {
@@ -170,7 +170,7 @@ namespace oxen::quic::test
         auto server_endpoint = test_net.endpoint(server_local);
         REQUIRE_NOTHROW(server_endpoint->listen(server_tls, max_streams, server_data_cb));
 
-        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
         auto client_endpoint = test_net.endpoint(client_local, client_established);
         auto conn_interface = client_endpoint->connect(client_remote, client_tls, max_streams);
@@ -237,7 +237,7 @@ namespace oxen::quic::test
 
         void receive(bstring_view) override
         {
-            log::debug(log_cat, "Calling custom stream data callback... data received...");
+            log::debug(test_cat, "Calling custom stream data callback... data received...");
             p.set_value();
         }
     };
@@ -250,7 +250,7 @@ namespace oxen::quic::test
 
         void receive(bstring_view) override
         {
-            log::debug(log_cat, "Calling custom stream data callback... data received...");
+            log::debug(test_cat, "Calling custom stream data callback... data received...");
             p.set_value();
         }
     };
@@ -265,14 +265,14 @@ namespace oxen::quic::test
                           cc_f = cc_p.get_future();
 
         stream_data_callback standard_server_cb = [&](Stream& s, bstring_view dat) {
-            log::debug(log_cat, "Calling standard stream data callback... data received...");
+            log::debug(test_cat, "Calling standard stream data callback... data received...");
             REQUIRE(msg == dat);
             ss_p.set_value();
             s.send(msg);
         };
 
         stream_data_callback standard_client_cb = [&](Stream& s, bstring_view dat) {
-            log::debug(log_cat, "Calling standard stream data callback... data received...");
+            log::debug(test_cat, "Calling standard stream data callback... data received...");
             REQUIRE(msg == dat);
             cs_p.set_value();
             s.send(msg);
@@ -286,7 +286,7 @@ namespace oxen::quic::test
         auto server_endpoint = test_net.endpoint(server_local);
         REQUIRE_NOTHROW(server_endpoint->listen(server_tls, standard_server_cb));
 
-        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
         auto client_endpoint = test_net.endpoint(client_local);
         auto conn_interface = client_endpoint->connect(client_remote, client_tls, standard_client_cb);
@@ -331,7 +331,7 @@ namespace oxen::quic::test
         auto server_endpoint = test_net.endpoint(server_local);
         REQUIRE_NOTHROW(server_endpoint->listen(server_tls, server_constructor));
 
-        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
         auto client_endpoint = test_net.endpoint(client_local);
         auto conn_interface = client_endpoint->connect(client_remote, client_tls, client_constructor);
@@ -351,7 +351,7 @@ namespace oxen::quic::test
 
         void receive(bstring_view m) override
         {
-            log::info(log_cat, "Custom stream received data:\n{}", buffer_printer{m});
+            log::info(test_cat, "Custom stream received data:\n{}", buffer_printer{m});
             p.set_value(std::string{convert_sv<char>(m)});
         }
     };
@@ -389,7 +389,7 @@ namespace oxen::quic::test
         auto server_closed = callback_waiter{[](connection_interface&, uint64_t) {}};
 
         stream_data_callback server_generic_data_cb = [&](Stream&, bstring_view m) {
-            log::debug(log_cat, "Server generic data callback called");
+            log::debug(test_cat, "Server generic data callback called");
             sp4.set_value(std::string{convert_sv<char>(m)});
         };
 
@@ -420,7 +420,7 @@ namespace oxen::quic::test
             server_endpoint = test_net.endpoint(server_local, server_open_all_cb, server_closed);
             REQUIRE_NOTHROW(server_endpoint->listen(server_tls, server_generic_data_cb));
 
-            RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+            RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
             client_endpoint = test_net.endpoint(client_local, client_established);
             client_ci = client_endpoint->connect(client_remote, client_tls);
@@ -459,7 +459,7 @@ namespace oxen::quic::test
             server_endpoint = test_net.endpoint(server_local, server_closed);
             REQUIRE_NOTHROW(server_endpoint->listen(server_tls, server_constructor, server_generic_data_cb));
 
-            RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+            RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
             client_endpoint = test_net.endpoint(client_local, client_established);
             client_ci = client_endpoint->connect(client_remote, client_tls);
@@ -505,7 +505,7 @@ namespace oxen::quic::test
             server_endpoint = test_net.endpoint(server_local, server_closed);
             REQUIRE_NOTHROW(server_endpoint->listen(server_tls, server_constructor, server_open_cb, server_generic_data_cb));
 
-            RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+            RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
             client_endpoint = test_net.endpoint(client_local, client_established);
             client_ci = client_endpoint->connect(client_remote, client_tls);
@@ -555,7 +555,7 @@ namespace oxen::quic::test
         server_endpoint->listen(server_tls);
 
         auto client_endpoint = test_net.endpoint(client_local);
-        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
         auto client_ci = client_endpoint->connect(client_remote, client_tls);
 
         auto a = client_ci->open_stream<CustomStreamA>(std::promise<std::string>{});
@@ -650,11 +650,11 @@ namespace oxen::quic::test
         };
 
         auto client_generic_data_cb = [&](Stream&, bstring_view data) {
-            log::debug(log_cat, "Client generic data callback called");
+            log::debug(test_cat, "Client generic data callback called");
             cp4.set_value(std::string{convert_sv<char>(data)});
         };
 
-        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
         auto client_endpoint = test_net.endpoint(client_local, client_established);
         auto client_ci = client_endpoint->connect(client_remote, client_tls, client_generic_data_cb, client_stream_ctor);
@@ -718,7 +718,7 @@ namespace oxen::quic::test
 
         auto client_established = callback_waiter{[&](connection_interface& ci) {
             client_extracted = ci.open_stream<BTRequestStream>();
-            client_extracted->register_handler("test_endpoint"s, client_handler);
+            client_extracted->register_handler(TEST_ENDPOINT, client_handler);
         }};
 
         auto server_established = callback_waiter{[&](connection_interface&) {}};
@@ -731,7 +731,7 @@ namespace oxen::quic::test
                 {
                     log::trace(test_cat, "Server constructing BTRequestStream!");
                     server_extracted = e.make_shared<BTRequestStream>(c, e);
-                    server_extracted->register_handler("test_endpoint"s, server_handler);
+                    server_extracted->register_handler(TEST_ENDPOINT, server_handler);
                     return server_extracted;
                 }
                 else
@@ -748,7 +748,7 @@ namespace oxen::quic::test
         server_endpoint->listen(server_tls, server_established, server_constructor);
 
         auto client_endpoint = test_net.endpoint(client_local, client_established);
-        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
         auto client_ci = client_endpoint->connect(client_remote, client_tls);
 
@@ -763,7 +763,7 @@ namespace oxen::quic::test
         std::shared_ptr<BTRequestStream> early_access = server_ci->maybe_stream<BTRequestStream>(0);
         REQUIRE_FALSE(early_access);
 
-        client_extracted->command("test_endpoint"s, "hi"s);
+        client_extracted->command(TEST_ENDPOINT, "hi"s);
         REQUIRE(server_handler.wait());
 
         std::shared_ptr<BTRequestStream> server_bt = server_ci->maybe_stream<BTRequestStream>(0);
@@ -772,7 +772,7 @@ namespace oxen::quic::test
         REQUIRE(server_extracted->stream_id() == server_bt->stream_id());
         REQUIRE(server_extracted == server_bt);
 
-        server_extracted->command("test_endpoint"s, "hi"s);
+        server_extracted->command(TEST_ENDPOINT, "hi"s);
         REQUIRE(client_handler.wait());
     }
 
@@ -793,7 +793,7 @@ namespace oxen::quic::test
 
         auto server_established = callback_waiter{[&](connection_interface& ci) {
             server_bt = ci.queue_incoming_stream<BTRequestStream>();
-            server_bt->register_handler("test_endpoint"s, server_handler);
+            server_bt->register_handler(TEST_ENDPOINT, server_handler);
         }};
 
         auto client_established = callback_waiter{[&](connection_interface&) {}};
@@ -802,7 +802,7 @@ namespace oxen::quic::test
         server_endpoint->listen(server_tls, server_established);
 
         auto client_endpoint = test_net.endpoint(client_local);
-        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
         auto client_ci = client_endpoint->connect(client_remote, client_tls, client_established);
 
@@ -810,7 +810,7 @@ namespace oxen::quic::test
         REQUIRE(server_established.wait());
 
         client_bt = client_ci->open_stream<BTRequestStream>();
-        client_bt->register_handler("test_endpoint"s, client_handler);
+        client_bt->register_handler(TEST_ENDPOINT, client_handler);
         REQUIRE(client_bt->stream_id() == 0);
 
         server_ci = server_endpoint->get_all_conns(Direction::INBOUND).front();
@@ -819,10 +819,10 @@ namespace oxen::quic::test
         REQUIRE(server_extracted);
         REQUIRE(server_bt == server_extracted);
 
-        client_bt->command("test_endpoint"s, "hi"s);
+        client_bt->command(TEST_ENDPOINT, "hi"s);
         REQUIRE(server_handler.wait());
 
-        server_bt->command("test_endpoint"s, "hi"s);
+        server_bt->command(TEST_ENDPOINT, "hi"s);
         REQUIRE(client_handler.wait());
     }
 
@@ -846,17 +846,17 @@ namespace oxen::quic::test
             REQUIRE(msg.body() == TEST_BODY);
             server_counter += 1;
 
-            log::debug(log_cat, "Server received request {} of {}", server_counter.load(), n_reqs);
+            log::debug(test_cat, "Server received request {} of {}", server_counter.load(), n_reqs);
 
             if (server_counter == n_reqs)
             {
-                log::debug(log_cat, "Server responding to client with new request");
+                log::debug(test_cat, "Server responding to client with new request");
                 server_bt->command(TEST_ENDPOINT, TEST_BODY);
             }
         };
 
         auto client_handler = callback_waiter{[](message msg) {
-            log::debug(log_cat, "Client received server request!");
+            log::debug(test_cat, "Client received server request!");
             REQUIRE(msg.body() == TEST_BODY);
         }};
 
@@ -890,7 +890,7 @@ namespace oxen::quic::test
         server_endpoint->listen(server_tls, server_established);
 
         auto client_endpoint = test_net.endpoint(client_local);
-        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
         client_ci = client_endpoint->connect(client_remote, client_tls, client_established);
         client_ci_ready.set_value();
@@ -924,13 +924,13 @@ namespace oxen::quic::test
         auto server_endpoint = test_net.endpoint(server_local);
         server_endpoint->listen(server_tls, [&](Stream& s, bstring_view data) {
             count += data.size();
-            log::debug(log_cat, "Got some data {}, replying with '{}'", to_sv(data), count);
+            log::debug(test_cat, "Got some data {}, replying with '{}'", to_sv(data), count);
             s.send("{}"_format(count));
         });
 
         TestHelper::increment_ref_id(*server_endpoint, 100);
 
-        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
         auto client_endpoint = test_net.endpoint(client_local);
 
@@ -938,7 +938,7 @@ namespace oxen::quic::test
         std::shared_ptr<Stream> stream;
         {
             auto conn_closed = [&](connection_interface& conn, uint64_t ec) {
-                log::info(log_cat, "conn {} closed (ec={})", conn.reference_id(), ec);
+                log::info(test_cat, "conn {} closed (ec={})", conn.reference_id(), ec);
             };
 
             auto conn = client_endpoint->connect(client_remote, client_tls, conn_closed);
@@ -950,7 +950,7 @@ namespace oxen::quic::test
             stream = conn->open_stream<Stream>(stream_data_cb, stream_close_cb);
             stream->send("hello world"s);
             require_future(got_reply.get_future());
-            log::debug(log_cat, "closing connection");
+            log::debug(test_cat, "closing connection");
             conn->close_connection();
         }
 
@@ -975,7 +975,7 @@ namespace oxen::quic::test
         auto server_endpoint = test_net.endpoint(server_local);
         server_endpoint->listen(server_tls, [&](Stream& s, bstring_view data) { s.send(data); });
 
-        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
         auto client_endpoint = test_net.endpoint(client_local);
 
         std::promise<void> got_data;
@@ -1021,7 +1021,7 @@ namespace oxen::quic::test
         auto server_endpoint = test_net.endpoint(server_local, [](connection_interface& ci) { ci.close_connection(123); });
         server_endpoint->listen(server_tls);
 
-        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
         auto client_endpoint = test_net.endpoint(client_local, client_established);
         auto conn = client_endpoint->connect(client_remote, client_tls, client_closed);
@@ -1065,7 +1065,7 @@ namespace oxen::quic::test
         auto server_endpoint = test_net.endpoint(server_local, [](connection_interface& ci) { ci.close_connection(123); });
         server_endpoint->listen(server_tls);
 
-        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
         auto client_endpoint = test_net.endpoint(client_local, client_established);
         auto conn = client_endpoint->connect(client_remote, client_tls, client_closed);

--- a/tests/005-chunked-sender.cpp
+++ b/tests/005-chunked-sender.cpp
@@ -43,7 +43,7 @@ namespace oxen::quic::test
         auto server_endpoint = test_net.endpoint(server_local);
         REQUIRE_NOTHROW(server_endpoint->listen(server_tls, server_data_cb));
 
-        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
         auto client_endpoint = test_net.endpoint(client_local);
         auto conn_interface = client_endpoint->connect(client_remote, client_tls);
@@ -57,7 +57,7 @@ namespace oxen::quic::test
 
         stream->send_chunks(
                 [&](const Stream& s) {
-                    log::info(log_cat, "getting next chunk ({}) for stream {}", i, s.stream_id());
+                    log::info(test_cat, "getting next chunk ({}) for stream {}", i, s.stream_id());
                     if (i++ < 3)
                         return fmt::format("[CHUNK-{}]", i);
                     i--;
@@ -65,7 +65,7 @@ namespace oxen::quic::test
                 },
                 [&](Stream& s) {
                     auto pointer_chunks = [&](const Stream& s) -> std::vector<char>* {
-                        log::info(log_cat, "getting next chunk ({}) for stream {}", i, s.stream_id());
+                        log::info(test_cat, "getting next chunk ({}) for stream {}", i, s.stream_id());
                         if (i++ < 6)
                         {
                             auto& vec = bufs[i % parallel_chunks];
@@ -81,7 +81,7 @@ namespace oxen::quic::test
                             pointer_chunks,
                             [&](Stream& s) {
                                 auto smart_ptr_chunks = [&](const Stream& s) -> std::unique_ptr<std::vector<char>> {
-                                    log::info(log_cat, "getting next chunk ({}) for stream {}", i, s.stream_id());
+                                    log::info(test_cat, "getting next chunk ({}) for stream {}", i, s.stream_id());
                                     if (i++ >= 10)
                                         return nullptr;
                                     auto vec = std::make_unique<std::vector<char>>();
@@ -92,7 +92,7 @@ namespace oxen::quic::test
                                         smart_ptr_chunks,
                                         [&](Stream& s) {
                                             // (Lokinet RPC was here)
-                                            log::info(log_cat, "All chunks done!");
+                                            log::info(test_cat, "All chunks done!");
                                             s.send("Goodbye."s);
                                         },
                                         parallel_chunks);

--- a/tests/006-server-send.cpp
+++ b/tests/006-server-send.cpp
@@ -21,20 +21,20 @@ namespace oxen::quic::test
                           stream_future = stream_promise.get_future();
 
         stream_open_callback server_io_open_cb = [&](IOChannel& s) {
-            log::debug(log_cat, "Calling server stream open callback... stream opened...");
+            log::debug(test_cat, "Calling server stream open callback... stream opened...");
             server_stream = s.get_stream();
             stream_promise.set_value();
             return 0;
         };
 
         stream_data_callback server_io_data_cb = [&](IOChannel&, bstring_view) {
-            log::debug(log_cat, "Calling server stream data callback... data received... incrementing counter...");
+            log::debug(test_cat, "Calling server stream data callback... data received... incrementing counter...");
             data_check += 1;
             server_promise.set_value();
         };
 
         stream_data_callback client_io_data_cb = [&](IOChannel&, bstring_view) {
-            log::debug(log_cat, "Calling client stream data callback... data received... incrementing counter...");
+            log::debug(test_cat, "Calling client stream data callback... data received... incrementing counter...");
             data_check += 1;
             client_promise.set_value();
         };
@@ -47,7 +47,7 @@ namespace oxen::quic::test
         auto server_endpoint = test_net.endpoint(server_local);
         REQUIRE_NOTHROW(server_endpoint->listen(server_tls, server_io_open_cb, server_io_data_cb));
 
-        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
         auto client_endpoint = test_net.endpoint(client_local);
         auto conn_interface = client_endpoint->connect(client_remote, client_tls, client_io_data_cb);
@@ -86,7 +86,7 @@ namespace oxen::quic::test
         }
 
         stream_open_callback server_io_open_cb = [&](Stream& s) {
-            log::debug(log_cat, "Calling server stream open callback... stream opened...");
+            log::debug(test_cat, "Calling server stream open callback... stream opened...");
             server_extracted_stream = s.get_stream();
             try
             {
@@ -101,7 +101,7 @@ namespace oxen::quic::test
         };
 
         stream_open_callback client_io_open_cb = [&](Stream& s) {
-            log::debug(log_cat, "Calling client stream open callback... stream opened...");
+            log::debug(test_cat, "Calling client stream open callback... stream opened...");
             client_extracted_stream = s.get_stream();
             try
             {
@@ -116,7 +116,7 @@ namespace oxen::quic::test
         };
 
         stream_data_callback server_io_data_cb = [&](Stream&, bstring_view) {
-            log::debug(log_cat, "Calling server stream data callback... data received... incrementing counter...");
+            log::debug(test_cat, "Calling server stream data callback... data received... incrementing counter...");
             data_check += 1;
             try
             {
@@ -130,7 +130,7 @@ namespace oxen::quic::test
         };
 
         stream_data_callback client_io_data_cb = [&](Stream&, bstring_view) {
-            log::debug(log_cat, "Calling client stream data callback... data received... incrementing counter...");
+            log::debug(test_cat, "Calling client stream data callback... data received... incrementing counter...");
             data_check += 1;
             try
             {
@@ -151,7 +151,7 @@ namespace oxen::quic::test
         auto server_endpoint = test_net.endpoint(server_local);
         REQUIRE_NOTHROW(server_endpoint->listen(server_tls, server_io_data_cb, server_io_open_cb));
 
-        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
         auto client_endpoint = test_net.endpoint(client_local);
         auto client_ci = client_endpoint->connect(client_remote, client_tls, client_io_data_cb, client_io_open_cb);

--- a/tests/007-datagrams.cpp
+++ b/tests/007-datagrams.cpp
@@ -76,7 +76,7 @@ namespace oxen::quic::test
         auto server_endpoint = test_net.endpoint(server_local);
         REQUIRE_NOTHROW(server_endpoint->listen(server_tls));
 
-        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
         auto client_endpoint = test_net.endpoint(client_local, client_established);
         auto conn_interface = client_endpoint->connect(client_remote, client_tls);
@@ -104,7 +104,7 @@ namespace oxen::quic::test
         auto server_endpoint = test_net.endpoint(server_local, default_gram);
         REQUIRE_NOTHROW(server_endpoint->listen(server_tls));
 
-        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
         auto client_endpoint = test_net.endpoint(client_local, default_gram, client_established);
         auto conn_interface = client_endpoint->connect(client_remote, client_tls);
@@ -133,7 +133,7 @@ namespace oxen::quic::test
         auto server_endpoint = test_net.endpoint(server_local, split_dgram);
         REQUIRE_NOTHROW(server_endpoint->listen(server_tls));
 
-        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
         auto client_endpoint = test_net.endpoint(client_local, split_dgram, client_established);
         auto conn_interface = client_endpoint->connect(client_remote, client_tls);
@@ -159,13 +159,13 @@ namespace oxen::quic::test
             std::future<void> data_future = data_promise.get_future();
 
             dgram_data_callback recv_dgram_cb = [&](dgram_interface&, bstring) {
-                log::debug(log_cat, "Calling endpoint receive datagram callback... data received...");
+                log::debug(test_cat, "Calling endpoint receive datagram callback... data received...");
 
                 data_promise.set_value();
             };
             std::atomic<bool> bad_call = false;
             dgram_data_callback overridden_dgram_cb = [&](dgram_interface&, bstring) {
-                log::critical(log_cat, "Wrong dgram callback invoked!");
+                log::critical(test_cat, "Wrong dgram callback invoked!");
                 bad_call = true;
             };
 
@@ -179,7 +179,7 @@ namespace oxen::quic::test
             auto server_endpoint = test_net.endpoint(server_local, default_gram, overridden_dgram_cb);
             REQUIRE_NOTHROW(server_endpoint->listen(server_tls, recv_dgram_cb));
 
-            RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+            RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
             auto client = test_net.endpoint(client_local, default_gram, client_established);
             auto conn_interface = client->connect(client_remote, client_tls);
@@ -215,7 +215,7 @@ namespace oxen::quic::test
             std::future<void> data_future = data_promise.get_future();
 
             dgram_data_callback recv_dgram_cb = [&](dgram_interface&, bstring data) {
-                log::debug(log_cat, "Calling endpoint receive datagram callback... data received...");
+                log::debug(test_cat, "Calling endpoint receive datagram callback... data received...");
                 ++data_counter;
                 if (data == "final"_bs)
                     data_promise.set_value();
@@ -231,7 +231,7 @@ namespace oxen::quic::test
             auto server_endpoint = test_net.endpoint(server_local, split_dgram);
             REQUIRE_NOTHROW(server_endpoint->listen(server_tls, recv_dgram_cb));
 
-            RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+            RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
             auto client = test_net.endpoint(client_local, split_dgram, client_established);
             auto conn_interface = client->connect(client_remote, client_tls);
@@ -287,7 +287,7 @@ namespace oxen::quic::test
 
         SECTION("Simple oversized datagram transmission - Clear first row")
         {
-            log::trace(log_cat, "Beginning the unit test from hell");
+            log::trace(test_cat, "Beginning the unit test from hell");
             auto client_established = callback_waiter{[](connection_interface&) {}};
 
             Network test_net{};
@@ -303,7 +303,7 @@ namespace oxen::quic::test
                 data_futures[i] = data_promises[i].get_future();
 
             dgram_data_callback recv_dgram_cb = [&](dgram_interface&, bstring) {
-                log::debug(log_cat, "Calling endpoint receive datagram callback... data received...");
+                log::debug(test_cat, "Calling endpoint receive datagram callback... data received...");
 
                 try
                 {
@@ -327,7 +327,7 @@ namespace oxen::quic::test
             auto server_endpoint = test_net.endpoint(server_local, split_dgram, recv_dgram_cb);
             REQUIRE_NOTHROW(server_endpoint->listen(server_tls));
 
-            RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+            RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
             auto client = test_net.endpoint(client_local, split_dgram, client_established);
             auto conn_interface = client->connect(client_remote, client_tls);
@@ -371,7 +371,7 @@ namespace oxen::quic::test
 
         SECTION("Simple datagram transmission - mixed sizes")
         {
-            log::trace(log_cat, "Beginning the unit test from hell");
+            log::trace(test_cat, "Beginning the unit test from hell");
             auto client_established = callback_waiter{[](connection_interface&) {}};
 
             Network test_net{};
@@ -387,7 +387,7 @@ namespace oxen::quic::test
                 data_futures[i] = data_promises[i].get_future();
 
             dgram_data_callback recv_dgram_cb = [&](dgram_interface&, bstring) {
-                log::debug(log_cat, "Calling endpoint receive datagram callback... data received...");
+                log::debug(test_cat, "Calling endpoint receive datagram callback... data received...");
 
                 try
                 {
@@ -411,7 +411,7 @@ namespace oxen::quic::test
             auto server_endpoint = test_net.endpoint(server_local, split_dgram, recv_dgram_cb);
             REQUIRE_NOTHROW(server_endpoint->listen(server_tls));
 
-            RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+            RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
             auto client = test_net.endpoint(client_local, split_dgram, client_established);
             auto conn_interface = client->connect(client_remote, client_tls);
@@ -455,7 +455,7 @@ namespace oxen::quic::test
             SKIP("Rotating buffer testing not enabled for this test iteration!");
         SECTION("Simple datagram transmission - induced loss")
         {
-            log::trace(log_cat, "Beginning the unit test from hell");
+            log::trace(test_cat, "Beginning the unit test from hell");
             auto client_established = callback_waiter{[](connection_interface&) {}};
 
             Network test_net{};
@@ -473,7 +473,7 @@ namespace oxen::quic::test
             bstring received{};
 
             dgram_data_callback recv_dgram_cb = [&](dgram_interface&, bstring data) {
-                log::debug(log_cat, "Calling endpoint receive datagram callback... data received...");
+                log::debug(test_cat, "Calling endpoint receive datagram callback... data received...");
 
                 counter += 1;
                 received.swap(data);
@@ -499,7 +499,7 @@ namespace oxen::quic::test
             auto server_endpoint = test_net.endpoint(server_local, split_dgram, recv_dgram_cb);
             REQUIRE_NOTHROW(server_endpoint->listen(server_tls));
 
-            RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+            RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
             auto client = test_net.endpoint(client_local, split_dgram, client_established);
             auto conn_interface = client->connect(client_remote, client_tls);
@@ -545,7 +545,7 @@ namespace oxen::quic::test
     {
         SECTION("Simple datagram transmission - flip flop ordering")
         {
-            log::trace(log_cat, "Beginning the unit test from hell");
+            log::trace(test_cat, "Beginning the unit test from hell");
             auto client_established = callback_waiter{[](connection_interface&) {}};
 
             Network test_net{};
@@ -561,12 +561,12 @@ namespace oxen::quic::test
                 data_futures[i] = data_promises[i].get_future();
 
             dgram_data_callback recv_dgram_cb = [&](dgram_interface&, bstring) {
-                log::debug(log_cat, "Calling endpoint receive datagram callback... data received...");
+                log::debug(test_cat, "Calling endpoint receive datagram callback... data received...");
 
                 try
                 {
                     data_counter += 1;
-                    log::trace(log_cat, "Data counter: {}", data_counter.load());
+                    log::trace(test_cat, "Data counter: {}", data_counter.load());
                     data_promises.at(index).set_value();
                     index += 1;
                 }
@@ -586,7 +586,7 @@ namespace oxen::quic::test
             auto server_endpoint = test_net.endpoint(server_local, split_dgram, recv_dgram_cb);
             REQUIRE_NOTHROW(server_endpoint->listen(server_tls));
 
-            RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+            RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
             auto client = test_net.endpoint(client_local, split_dgram, client_established);
             auto conn_interface = client->connect(client_remote, client_tls);

--- a/tests/008-conn_hooks.cpp
+++ b/tests/008-conn_hooks.cpp
@@ -30,7 +30,7 @@ namespace oxen::quic::test
             auto server_endpoint = test_net.endpoint(server_local, server_established, server_closed);
             REQUIRE_NOTHROW(server_endpoint->listen(server_tls));
 
-            RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+            RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
             auto client_endpoint = test_net.endpoint(client_local, client_established, client_closed);
             auto conn_interface = client_endpoint->connect(client_remote, client_tls);
@@ -46,7 +46,7 @@ namespace oxen::quic::test
             auto server_endpoint = test_net.endpoint(server_local);
             REQUIRE_NOTHROW(server_endpoint->listen(server_tls, server_established, server_closed));
 
-            RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+            RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
             auto client_endpoint = test_net.endpoint(client_local);
             auto conn_interface = client_endpoint->connect(client_remote, client_tls, client_established, client_closed);

--- a/tests/009-alpns.cpp
+++ b/tests/009-alpns.cpp
@@ -32,7 +32,7 @@ namespace oxen::quic::test
             auto server_endpoint = test_net.endpoint(server_local, timeout);
             REQUIRE_NOTHROW(server_endpoint->listen(server_tls));
 
-            RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+            RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
             auto client_endpoint = test_net.endpoint(client_local, client_established, timeout);
 
@@ -48,7 +48,7 @@ namespace oxen::quic::test
             auto server_endpoint = test_net.endpoint(server_local, timeout);
             REQUIRE_NOTHROW(server_endpoint->listen(server_tls));
 
-            RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+            RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
             auto client_endpoint = test_net.endpoint(client_local, client_established, client_closed, client_alpns, timeout);
 
@@ -64,7 +64,7 @@ namespace oxen::quic::test
             auto server_endpoint = test_net.endpoint(server_local, server_alpns, timeout);
             REQUIRE_NOTHROW(server_endpoint->listen(server_tls));
 
-            RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+            RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
             auto client_endpoint = test_net.endpoint(client_local, client_established, client_closed, timeout);
 
@@ -81,7 +81,7 @@ namespace oxen::quic::test
             auto server_endpoint = test_net.endpoint(server_local, server_alpns, timeout);
             REQUIRE_NOTHROW(server_endpoint->listen(server_tls));
 
-            RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+            RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
             auto client_endpoint = test_net.endpoint(client_local, client_established, client_closed, client_alpns, timeout);
 
@@ -99,7 +99,7 @@ namespace oxen::quic::test
             auto server_endpoint = test_net.endpoint(server_local, server_alpns, timeout);
             REQUIRE_NOTHROW(server_endpoint->listen(server_tls));
 
-            RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+            RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
             auto client_endpoint = test_net.endpoint(client_local, client_established, client_alpns, timeout);
 
@@ -121,7 +121,7 @@ namespace oxen::quic::test
             auto server_endpoint = test_net.endpoint(server_local, server_alpns, timeout);
             REQUIRE_NOTHROW(server_endpoint->listen(server_tls));
 
-            RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+            RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
             opt::outbound_alpns client_alpns{{"foobar"_us}};
             auto client_endpoint = test_net.endpoint(client_local, client_established, client_closed, client_alpns, timeout);
@@ -138,7 +138,7 @@ namespace oxen::quic::test
             auto server_endpoint = test_net.endpoint(server_local, server_alpns, timeout);
             REQUIRE_NOTHROW(server_endpoint->listen(server_tls));
 
-            RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+            RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
             opt::alpns client_alpns{"special-alpn"};
             auto client_endpoint = test_net.endpoint(client_local, client_established, client_alpns, timeout);

--- a/tests/010-migration.cpp
+++ b/tests/010-migration.cpp
@@ -31,18 +31,18 @@ namespace oxen::quic::test
         std::shared_ptr<connection_interface> server_ci;
 
         stream_data_callback server_data_cb = [&](Stream&, bstring_view dat) {
-            log::debug(log_cat, "Calling server stream data callback... data received...");
+            log::debug(test_cat, "Calling server stream data callback... data received...");
             REQUIRE(good_msg == dat);
             d_promise.set_value();
         };
 
         auto server_established = callback_waiter{[](connection_interface&) {}};
-        auto client_established_b = callback_waiter{[](connection_interface&) { log::trace(log_cat, "LOOK ME UP BRO"); }};
+        auto client_established_b = callback_waiter{[](connection_interface&) { log::trace(test_cat, "LOOK ME UP BRO"); }};
 
         auto server_endpoint = test_net.endpoint(server_local, server_established);
         server_endpoint->listen(server_tls, server_data_cb);
 
-        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
         auto client_established = [&](connection_interface& ci) mutable {
             if (not address_flipped)
@@ -72,7 +72,7 @@ namespace oxen::quic::test
             {
                 if (not secondary_connected)
                 {
-                    log::trace(log_cat, "Skipping address flip!");
+                    log::trace(test_cat, "Skipping address flip!");
                     secondary_connected = true;
                     conn_promise_b.set_value();
                 }
@@ -100,7 +100,7 @@ namespace oxen::quic::test
         server_ci = server_endpoint->get_all_conns(Direction::INBOUND).front();
 
         std::this_thread::sleep_for(5ms);
-        RemoteAddress client_remote_b{defaults::CLIENT_PUBKEY, "127.0.0.1"s, client_ci->local().port()};
+        RemoteAddress client_remote_b{defaults::CLIENT_PUBKEY, LOCALHOST, client_ci->local().port()};
 
         REQUIRE_FALSE(original_addr == client_ci->local());
 

--- a/tests/010-migration.cpp
+++ b/tests/010-migration.cpp
@@ -60,10 +60,10 @@ namespace oxen::quic::test
                 }
 
                 // Uncomment this when NGTCP2 releases v1.2.0
-                // SECTION("Immediate migration")
-                // {
-                // TestHelper::migrate_connection_immediate(conn, client_secondary);
-                // }
+                SECTION("Immediate migration")
+                {
+                    TestHelper::migrate_connection_immediate(conn, client_secondary);
+                }
 
                 address_flipped = true;
                 conn_promise_a.set_value();

--- a/tests/011-manual_transmission.cpp
+++ b/tests/011-manual_transmission.cpp
@@ -109,7 +109,7 @@ namespace oxen::quic::test
         REQUIRE_NOTHROW(vanilla_server->listen(server_tls));
         REQUIRE_NOTHROW(manual_server->listen(server_tls));
 
-        RemoteAddress vanilla_client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, vanilla_server->local().port()};
+        RemoteAddress vanilla_client_remote{defaults::SERVER_PUBKEY, LOCALHOST, vanilla_server->local().port()};
 
         vanilla_client_ci = vanilla_client->connect(vanilla_client_remote, client_tls);
 

--- a/tests/012-watermarks.cpp
+++ b/tests/012-watermarks.cpp
@@ -23,7 +23,7 @@ namespace oxen::quic::test
         auto server_endpoint = test_net.endpoint(server_local, server_established);
         REQUIRE_NOTHROW(server_endpoint->listen(server_tls));
 
-        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
         auto client_endpoint = test_net.endpoint(client_local, client_established);
         auto conn_interface = client_endpoint->connect(client_remote, client_tls);
@@ -64,13 +64,13 @@ namespace oxen::quic::test
                     2000,
                     opt::watermark{
                             [&](const Stream&) {
-                                log::debug(log_cat, "Executing low hook!");
+                                log::debug(test_cat, "Executing low hook!");
                                 low_count += 1;
                             },
                             true},
                     opt::watermark{
                             [&](const Stream&) {
-                                log::debug(log_cat, "Executing high hook!");
+                                log::debug(test_cat, "Executing high hook!");
                                 high_count += 1;
                             },
                             true});
@@ -107,13 +107,13 @@ namespace oxen::quic::test
                     2000,
                     opt::watermark{
                             [&](const Stream&) {
-                                log::debug(log_cat, "Executing low hook!");
+                                log::debug(test_cat, "Executing low hook!");
                                 low_count += 1;
                             },
                             true},
                     opt::watermark{
                             [&](const Stream&) {
-                                log::debug(log_cat, "Executing high hook!");
+                                log::debug(test_cat, "Executing high hook!");
                                 high_count += 1;
                             },
                             true});

--- a/tests/013-eventhandler.cpp
+++ b/tests/013-eventhandler.cpp
@@ -44,7 +44,7 @@ namespace oxen::quic::test
         auto server_endpoint = test_net.endpoint(server_local);
         REQUIRE_NOTHROW(server_endpoint->listen(server_tls, server_data_cb));
 
-        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
         auto client_endpoint = test_net.endpoint(client_local);
         auto conn_interface = client_endpoint->connect(client_remote, client_tls);

--- a/tests/014-0rtt-resets.cpp
+++ b/tests/014-0rtt-resets.cpp
@@ -46,12 +46,12 @@ namespace oxen::quic::test
         Address server_local{};
         Address client_local{};
 
-        auto server_endpoint = test_net.endpoint(server_local, server_established, opt::enable_stateless_reset{});
+        auto server_endpoint = test_net.endpoint(server_local, server_established, opt::disable_stateless_reset{});
         CHECK_NOTHROW(server_endpoint->listen(server_tls));
 
         RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
 
-        auto client_endpoint = test_net.endpoint(client_local, client_established, opt::enable_stateless_reset{});
+        auto client_endpoint = test_net.endpoint(client_local, client_established, opt::disable_stateless_reset{});
         auto client_ci = client_endpoint->connect(client_remote, client_tls);
 
         CHECK(client_established.wait());

--- a/tests/014-0rtt-resets.cpp
+++ b/tests/014-0rtt-resets.cpp
@@ -1,0 +1,61 @@
+#include <catch2/catch_test_macros.hpp>
+#include <oxen/quic.hpp>
+#include <oxen/quic/gnutls_crypto.hpp>
+#include <thread>
+
+#include "utils.hpp"
+
+namespace oxen::quic::test
+{
+    using namespace std::literals;
+
+    TEST_CASE("014 - 0rtt", "[014][0rtt]")
+    {
+        auto client_established = callback_waiter{[](connection_interface&) {}};
+        auto server_established = callback_waiter{[](connection_interface&) {}};
+
+        Network test_net{};
+
+        auto [client_tls, server_tls] = defaults::tls_creds_from_ed_keys();
+
+        Address server_local{};
+        Address client_local{};
+
+        auto server_endpoint = test_net.endpoint(server_local, server_established, opt::enable_0rtt_ticketing{});
+        CHECK_NOTHROW(server_endpoint->listen(server_tls));
+
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+
+        auto client_endpoint = test_net.endpoint(client_local, client_established, opt::enable_0rtt_ticketing{});
+        auto client_ci = client_endpoint->connect(client_remote, client_tls);
+
+        CHECK(client_established.wait());
+        CHECK(server_established.wait());
+        CHECK(client_ci->is_validated());
+    }
+
+    TEST_CASE("069 - stateless reset", "[069][reset]")
+    {
+        auto client_established = callback_waiter{[](connection_interface&) {}};
+        auto server_established = callback_waiter{[](connection_interface&) {}};
+
+        Network test_net{};
+
+        auto [client_tls, server_tls] = defaults::tls_creds_from_ed_keys();
+
+        Address server_local{};
+        Address client_local{};
+
+        auto server_endpoint = test_net.endpoint(server_local, server_established, opt::enable_stateless_reset{});
+        CHECK_NOTHROW(server_endpoint->listen(server_tls));
+
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+
+        auto client_endpoint = test_net.endpoint(client_local, client_established, opt::enable_stateless_reset{});
+        auto client_ci = client_endpoint->connect(client_remote, client_tls);
+
+        CHECK(client_established.wait());
+        CHECK(server_established.wait());
+        CHECK(client_ci->is_validated());
+    }
+}  //  namespace oxen::quic::test

--- a/tests/014-0rtt-resets.cpp
+++ b/tests/014-0rtt-resets.cpp
@@ -48,10 +48,13 @@ namespace oxen::quic::test
 
         auto server_endpoint = test_net.endpoint(server_local, server_established, opt::disable_stateless_reset{});
         CHECK_NOTHROW(server_endpoint->listen(server_tls));
+        REQUIRE_FALSE(server_endpoint->stateless_reset_enabled());
 
         RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
         auto client_endpoint = test_net.endpoint(client_local, client_established, opt::disable_stateless_reset{});
+        REQUIRE_FALSE(client_endpoint->stateless_reset_enabled());
+
         auto client_ci = client_endpoint->connect(client_remote, client_tls);
 
         CHECK(client_established.wait());

--- a/tests/014-0rtt-resets.cpp
+++ b/tests/014-0rtt-resets.cpp
@@ -24,7 +24,7 @@ namespace oxen::quic::test
         auto server_endpoint = test_net.endpoint(server_local, server_established, opt::enable_0rtt_ticketing{});
         CHECK_NOTHROW(server_endpoint->listen(server_tls));
 
-        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
         auto client_endpoint = test_net.endpoint(client_local, client_established, opt::enable_0rtt_ticketing{});
         auto client_ci = client_endpoint->connect(client_remote, client_tls);
@@ -49,7 +49,7 @@ namespace oxen::quic::test
         auto server_endpoint = test_net.endpoint(server_local, server_established, opt::disable_stateless_reset{});
         CHECK_NOTHROW(server_endpoint->listen(server_tls));
 
-        RemoteAddress client_remote{defaults::SERVER_PUBKEY, "127.0.0.1"s, server_endpoint->local().port()};
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
 
         auto client_endpoint = test_net.endpoint(client_local, client_established, opt::disable_stateless_reset{});
         auto client_ci = client_endpoint->connect(client_remote, client_tls);

--- a/tests/015-bt-encoding.cpp
+++ b/tests/015-bt-encoding.cpp
@@ -57,13 +57,13 @@ namespace oxen::quic::test
         Address client_local{};
 
         auto server_bp_cb = callback_waiter{[&](message msg) {
-            log::info(test_cat, "Server bparser received: {}", msg.view());
+            log::debug(test_cat, "Server bparser received: {}", msg.view());
             CHECK(bt_decode(msg.body()));
             msg.respond(msg.body());
         }};
 
         auto client_bp_cb = callback_waiter{[&](message msg) {
-            log::info(test_cat, "Client bparser received: {}", msg.view());
+            log::debug(test_cat, "Client bparser received: {}", msg.view());
             CHECK(bt_decode(msg.body()));
         }};
 
@@ -117,36 +117,36 @@ namespace oxen::quic::test
         std::shared_ptr<BTRequestStream> node_a_bp, node_b_bp, node_c_bp;
 
         auto node_a_response_cb = callback_waiter{[&](message msg) {
-            log::info(test_cat, "Node A received response from Node B: {}", msg.view());
+            log::debug(test_cat, "Node A received response from Node B: {}", msg.view());
             CHECK(bt_decode(msg.body()));
         }};
 
         auto node_a_bp_cb = [&](message msg) {
-            log::info(test_cat, "Node A received request from Node C: {}", msg.view());
+            log::debug(test_cat, "Node A received request from Node C: {}", msg.view());
             CHECK(bt_decode(msg.body()));
             msg.respond(msg.body());
         };
 
         auto node_b_bp_cb = [&](message msg) {
-            log::info(test_cat, "Node B received request from Node A: {}", msg.view());
+            log::debug(test_cat, "Node B received request from Node A: {}", msg.view());
             CHECK(bt_decode(msg.body()));
 
-            log::info(test_cat, "Node B chaining request to Node C", msg.view());
+            log::debug(test_cat, "Node B chaining request to Node C", msg.view());
             auto body = msg.body_str();
             node_b_bp->command(TEST_ENDPOINT, std::move(body), [prev = std::move(msg)](message msg) mutable {
-                log::info(test_cat, "Node B received response from Node C: {}", msg.view());
+                log::debug(test_cat, "Node B received response from Node C: {}", msg.view());
                 prev.respond(msg.body());
             });
         };
 
         auto node_c_bp_cb = [&](message msg) {
-            log::info(test_cat, "Node C received request from Node B: {}", msg.view());
+            log::debug(test_cat, "Node C received request from Node B: {}", msg.view());
             CHECK(bt_decode(msg.body()));
 
-            log::info(test_cat, "Node C chaining request to Node A", msg.view());
+            log::debug(test_cat, "Node C chaining request to Node A", msg.view());
             auto body = msg.body_str();
             node_c_bp->command(TEST_ENDPOINT, std::move(body), [prev = std::move(msg)](message msg) mutable {
-                log::info(test_cat, "Node C received response from Node A: {}", msg.view());
+                log::debug(test_cat, "Node C received response from Node A: {}", msg.view());
                 prev.respond(msg.body());
             });
         };

--- a/tests/015-bt-encoding.cpp
+++ b/tests/015-bt-encoding.cpp
@@ -1,0 +1,197 @@
+#include <catch2/catch_test_macros.hpp>
+#include <oxen/quic.hpp>
+#include <oxen/quic/gnutls_crypto.hpp>
+#include <thread>
+
+#include "utils.hpp"
+
+namespace oxen::quic::test
+{
+    using namespace std::literals;
+
+    static constexpr auto _a = "apple pie"sv;
+    static constexpr auto _b = "tell me a good story"sv;
+    static constexpr auto _c = 476938;
+    static constexpr auto _n = "good night"sv;
+
+    static bool bt_decode(std::string_view arg)
+    {
+        auto ret = true;
+
+        try
+        {
+            oxenc::bt_dict_consumer btdc{arg};
+            ret &= btdc.require<std::string_view>("a") == _a;
+            ret &= btdc.require<std::string_view>("b") == _b;
+            ret &= btdc.require<int>("c") == _c;
+            ret &= btdc.require<std::string_view>("n") == _n;
+        }
+        catch (const std::exception& e)
+        {
+            log::warning(test_cat, "BT decode exception: {}", e.what());
+            ret = false;
+        }
+
+        return ret;
+    }
+
+    static std::string bt_encode()
+    {
+        oxenc::bt_dict_producer btdp;
+
+        btdp.append("a", _a);
+        btdp.append("b", _b);
+        btdp.append("c", _c);
+        btdp.append("n", _n);
+
+        return std::move(btdp).str();
+    }
+
+    TEST_CASE("015 - Bt-encoding; Messaging", "[015][bt][messaging]")
+    {
+        Network test_net{};
+
+        auto [client_tls, server_tls] = defaults::tls_creds_from_ed_keys();
+
+        Address server_local{};
+        Address client_local{};
+
+        auto server_bp_cb = callback_waiter{[&](message msg) {
+            log::info(test_cat, "Server bparser received: {}", msg.view());
+            CHECK(bt_decode(msg.body()));
+            msg.respond(msg.body());
+        }};
+
+        auto client_bp_cb = callback_waiter{[&](message msg) {
+            log::info(test_cat, "Client bparser received: {}", msg.view());
+            CHECK(bt_decode(msg.body()));
+        }};
+
+        auto server_conn_established = [&](connection_interface& c) {
+            auto s = c.queue_incoming_stream<BTRequestStream>();
+            s->register_handler(TEST_ENDPOINT, server_bp_cb);
+        };
+
+        stream_constructor_callback client_constructor = [&](Connection& c, Endpoint& e, std::optional<int64_t>) {
+            return e.make_shared<BTRequestStream>(c, e);
+        };
+
+        auto server_endpoint = test_net.endpoint(server_local);
+        REQUIRE_NOTHROW(server_endpoint->listen(server_tls, server_conn_established));
+
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
+
+        auto client_endpoint = test_net.endpoint(client_local);
+        auto conn_interface = client_endpoint->connect(client_remote, client_tls, client_constructor);
+
+        std::shared_ptr<BTRequestStream> client_bp = conn_interface->open_stream<BTRequestStream>();
+
+        client_bp->command(TEST_ENDPOINT, bt_encode(), client_bp_cb);
+
+        REQUIRE(server_bp_cb.wait());
+        REQUIRE(client_bp_cb.wait());
+    }
+
+    TEST_CASE("015 - Bt-encoding; Message Chaining", "[015][bt][chaining]")
+    {
+        // clang-format off
+        /** 
+                Node A              Node B              Node C
+                req(A)      ->      recv(A)                         1) Node A dispatches req-A to Node B
+                                    chain(B)    ->      recv(B)     2) Node B chains req-B to Node C; Node C receives req-B from Node B
+                recv(C)     <-          <-      <-      chain(C)    3) Node C chains req-C to Node A; Node A receives req-A from Node C
+                reply(C)    ->          ->      ->      recv(C)     4) Node A replies to req-C; Node C receives req-C reply from Node A
+                                    recv(B)     <-      reply(B)    5) Node C replies to req-B; Node B receives req-B reply from Node B
+                recv(A)     <-      reply(A)                        6) Node B replies to req-A; Node A receives req-A reply from Node B
+        */
+        // clang-format on
+
+        Network test_net{};
+
+        auto [client_tls, server_tls] = defaults::tls_creds_from_ed_keys();
+
+        Address node_a_local{};
+        Address node_b_local{};
+        Address node_c_local{};
+
+        std::shared_ptr<BTRequestStream> node_a_bp, node_b_bp, node_c_bp;
+
+        auto node_a_response_cb = callback_waiter{[&](message msg) {
+            log::info(test_cat, "Node A received response from Node B: {}", msg.view());
+            CHECK(bt_decode(msg.body()));
+        }};
+
+        auto node_a_bp_cb = [&](message msg) {
+            log::info(test_cat, "Node A received request from Node C: {}", msg.view());
+            CHECK(bt_decode(msg.body()));
+            msg.respond(msg.body());
+        };
+
+        auto node_b_bp_cb = [&](message msg) {
+            log::info(test_cat, "Node B received request from Node A: {}", msg.view());
+            CHECK(bt_decode(msg.body()));
+
+            log::info(test_cat, "Node B chaining request to Node C", msg.view());
+            auto body = msg.body_str();
+            node_b_bp->command(TEST_ENDPOINT, std::move(body), [prev = std::move(msg)](message msg) mutable {
+                log::info(test_cat, "Node B received response from Node C: {}", msg.view());
+                prev.respond(msg.body());
+            });
+        };
+
+        auto node_c_bp_cb = [&](message msg) {
+            log::info(test_cat, "Node C received request from Node B: {}", msg.view());
+            CHECK(bt_decode(msg.body()));
+
+            log::info(test_cat, "Node C chaining request to Node A", msg.view());
+            auto body = msg.body_str();
+            node_c_bp->command(TEST_ENDPOINT, std::move(body), [prev = std::move(msg)](message msg) mutable {
+                log::info(test_cat, "Node C received response from Node A: {}", msg.view());
+                prev.respond(msg.body());
+            });
+        };
+
+        auto inbound_conn_established_a = [&](connection_interface& c) {
+            auto s = c.queue_incoming_stream<BTRequestStream>();
+            s->register_handler(TEST_ENDPOINT, node_a_bp_cb);
+        };
+
+        auto inbound_conn_established_b = [&](connection_interface& c) {
+            auto s = c.queue_incoming_stream<BTRequestStream>();
+            s->register_handler(TEST_ENDPOINT, node_b_bp_cb);
+        };
+
+        auto inbound_conn_established_c = [&](connection_interface& c) {
+            auto s = c.queue_incoming_stream<BTRequestStream>();
+            s->register_handler(TEST_ENDPOINT, node_c_bp_cb);
+        };
+
+        stream_constructor_callback outbound_stream_ctor = [&](Connection& c, Endpoint& e, std::optional<int64_t>) {
+            return e.make_shared<BTRequestStream>(c, e);
+        };
+
+        auto node_a = test_net.endpoint(node_a_local);
+        auto node_b = test_net.endpoint(node_b_local);
+        auto node_c = test_net.endpoint(node_c_local);
+
+        REQUIRE_NOTHROW(node_a->listen(server_tls, inbound_conn_established_a));
+        REQUIRE_NOTHROW(node_b->listen(server_tls, inbound_conn_established_b));
+        REQUIRE_NOTHROW(node_c->listen(server_tls, inbound_conn_established_c));
+
+        RemoteAddress node_a_remote{defaults::SERVER_PUBKEY, LOCALHOST, node_b->local().port()};
+        RemoteAddress node_b_remote{defaults::SERVER_PUBKEY, LOCALHOST, node_c->local().port()};
+        RemoteAddress node_c_remote{defaults::SERVER_PUBKEY, LOCALHOST, node_a->local().port()};
+
+        auto node_a_ci = node_a->connect(node_a_remote, client_tls, outbound_stream_ctor);
+        auto node_b_ci = node_b->connect(node_b_remote, client_tls, outbound_stream_ctor);
+        auto node_c_ci = node_c->connect(node_c_remote, client_tls, outbound_stream_ctor);
+
+        node_a_bp = node_a_ci->open_stream<BTRequestStream>();
+        node_b_bp = node_b_ci->open_stream<BTRequestStream>();
+        node_c_bp = node_c_ci->open_stream<BTRequestStream>();
+
+        node_a_bp->command(TEST_ENDPOINT, bt_encode(), node_a_response_cb);
+
+        REQUIRE(node_a_response_cb.wait());
+    }
+}  //  namespace oxen::quic::test

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,6 +40,7 @@ if(LIBQUIC_BUILD_TESTS)
         011-manual_transmission.cpp
         012-watermarks.cpp
         013-eventhandler.cpp
+        014-0rtt-resets.cpp
 
         main.cpp
         case_logger.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -50,9 +50,10 @@ if(LIBQUIC_BUILD_TESTS)
 
 endif()
 
+
 if(LIBQUIC_BUILD_SPEEDTEST)
     set(LIBQUIC_SPEEDTEST_PREFIX "" CACHE STRING "Binary prefix for speedtest binaries")
-    set(speedtests speedtest-client speedtest-server dgram-speed-client dgram-speed-server)
+    set(speedtests speedtest-client speedtest-server dgram-speed-client dgram-speed-server ping-client ping-server)
     foreach(x ${speedtests})
         add_executable(${x} ${x}.cpp)
         target_link_libraries(${x} PRIVATE tests_common)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -41,6 +41,7 @@ if(LIBQUIC_BUILD_TESTS)
         012-watermarks.cpp
         013-eventhandler.cpp
         014-0rtt-resets.cpp
+        015-bt-encoding.cpp
 
         main.cpp
         case_logger.cpp

--- a/tests/ping-client.cpp
+++ b/tests/ping-client.cpp
@@ -1,0 +1,143 @@
+/*
+    Ping client binary
+*/
+
+#include <gnutls/gnutls.h>
+#include <oxenc/endian.h>
+#include <oxenc/hex.h>
+
+#include <CLI/Validators.hpp>
+#include <future>
+#include <oxen/quic.hpp>
+#include <oxen/quic/gnutls_crypto.hpp>
+#include <thread>
+
+#include "utils.hpp"
+
+using namespace oxen::quic;
+
+constexpr auto client_msg = "good morning"_bsv;
+
+int main(int argc, char* argv[])
+{
+    CLI::App cli{"libQUIC ping client"};
+
+    std::string log_file, log_level;
+    add_log_opts(cli, log_file, log_level);
+
+    std::string remote_addr = "127.0.0.1:5500";
+    cli.add_option("--remote", remote_addr, "Remove address to connect to")->type_name("IP:PORT")->capture_default_str();
+
+    std::string remote_pubkey;
+    cli.add_option("-p,--remote-pubkey", remote_pubkey, "Remote server pubkey (not needed with verification disabled)")
+            ->type_name("PUBKEY_HEX_OR_B64")
+            ->transform([](const std::string& val) -> std::string {
+                if (auto pk = decode_bytes(val))
+                    return std::move(*pk);
+                throw CLI::ValidationError{
+                        "Invalid value passed to --remote-pubkey: expected value encoded as hex or base64"};
+            });
+
+    std::string local_addr = "";
+    cli.add_option("--local", local_addr, "Local bind address (optional)")->type_name("IP:PORT")->capture_default_str();
+
+    bool no_verify = false;
+    cli.add_flag(
+            "-V,--no-verify", no_verify, "Disable key verification on incoming connections (cannot be disabled with 0-RTT)");
+
+    bool enable_0rtt = false;
+    cli.add_flag(
+            "-Z,--enable-0rtt",
+            enable_0rtt,
+            "Enable 0-RTT and early data for this endpoint (cannot be used without key verification)");
+
+    try
+    {
+        cli.parse(argc, argv);
+
+        if (no_verify and enable_0rtt)
+            throw std::invalid_argument{"0-RTT must be used with key verification!"};
+
+        if (enable_0rtt and remote_pubkey.empty())
+            throw std::invalid_argument{"0-RTT must be used with remote key!"};
+
+        if (not no_verify and remote_pubkey.empty())
+            throw std::invalid_argument{"If remote key is provided, key verification must be turned OFF"};
+    }
+    catch (const CLI::ParseError& e)
+    {
+        return cli.exit(e);
+    }
+
+    setup_logging(log_file, log_level);
+
+    Network client_net{};
+
+    auto [seed, pubkey] = generate_ed25519();
+    auto client_tls = GNUTLSCreds::make_from_ed_keys(seed, pubkey);
+
+    Address client_local{};
+    if (!local_addr.empty())
+    {
+        auto [a, p] = parse_addr(local_addr);
+        client_local = Address{a, p};
+    }
+
+    std::promise<void> all_done;
+    std::atomic<bool> first_data{false};
+
+    /**     0: start connecting
+            1: connection established
+            2: send data down stream
+            3: recv (first) stream response
+            4: connection closed
+     */
+    std::array<uint64_t, 5> timing;
+
+    auto conn_established = [&](connection_interface& ci) {
+        timing[1] = get_timestamp<std::chrono::milliseconds>().count();
+        log::critical(test_cat, "Connection established to {}", ci.remote());
+    };
+
+    auto conn_closed = [&](connection_interface& ci, uint64_t) {
+        timing[4] = get_timestamp<std::chrono::milliseconds>().count();
+        log::critical(test_cat, "Connection closed to {}", ci.remote());
+        all_done.set_value();
+    };
+
+    auto stream_recv = [&](Stream& s, bstring_view) {
+        // get the time first, then do ops
+        auto t = get_timestamp<std::chrono::milliseconds>().count();
+        if (not first_data.exchange(true))
+        {
+            timing[3] = t;
+            log::critical(test_cat, "Received first data on connection to {}", s.remote());
+        }
+    };
+
+    auto [server_a, server_p] = parse_addr(remote_addr);
+    Address server_addr{server_a, server_p};
+
+    log::info(test_cat, "Constructing endpoint on {}", client_local);
+
+    auto client = enable_0rtt
+                        ? client_net.endpoint(client_local, conn_established, conn_closed, opt::enable_0rtt_ticketing{})
+                        : client_net.endpoint(client_local, conn_established, conn_closed);
+
+    log::info(test_cat, "Connecting to {}...", server_addr);
+
+    timing[0] = get_timestamp<std::chrono::milliseconds>().count();
+    auto client_conn = no_verify ? client->connect(server_addr, client_tls, stream_recv, opt::disable_key_verification{})
+                                 : client->connect(RemoteAddress{remote_pubkey, server_addr}, stream_recv, client_tls);
+    auto client_stream = client_conn->open_stream();
+    timing[2] = get_timestamp<std::chrono::milliseconds>().count();
+    client_stream->send(client_msg);
+
+    all_done.get_future().wait();
+
+    log::critical(test_cat, "\n\tConnection started: {}.{}ms", timing[0] / 1'000'000, timing[0] % 1000);
+    log::critical(test_cat, "\n\tConnection established: {}.{}ms", timing[1] / 1'000'000, timing[1] % 1000);
+    log::critical(test_cat, "\n\tFirst stream data sent: {}.{}ms", timing[2] / 1'000'000, timing[2] % 1000);
+    log::critical(test_cat, "\n\tFirst stream data received: {}.{}ms", timing[3] / 1'000'000, timing[3] % 1000);
+    log::critical(test_cat, "\n\tConnection closed: {}.{}ms", timing[4] / 1'000'000, timing[4] % 1000);
+}

--- a/tests/ping-server.cpp
+++ b/tests/ping-server.cpp
@@ -1,0 +1,128 @@
+/*
+    Ping server binary
+*/
+
+#include <gnutls/gnutls.h>
+#include <oxenc/endian.h>
+#include <oxenc/hex.h>
+
+#include <CLI/Validators.hpp>
+#include <future>
+#include <oxen/quic.hpp>
+#include <oxen/quic/gnutls_crypto.hpp>
+#include <thread>
+
+#include "utils.hpp"
+
+using namespace oxen::quic;
+
+int main(int argc, char* argv[])
+{
+    CLI::App cli{"libQUIC ping server"};
+
+    std::string log_file, log_level;
+    add_log_opts(cli, log_file, log_level);
+
+    std::string server_addr = "127.0.0.1:5500";
+
+    cli.add_option("--listen", server_addr, "Server address to listen on")->type_name("IP:PORT")->capture_default_str();
+
+    bool no_verify = false;
+    cli.add_flag(
+            "-V,--no-verify", no_verify, "Disable key verification on incoming connections (cannot be disabled with 0-RTT)");
+
+    bool enable_0rtt = false;
+    cli.add_flag(
+            "-Z,--enable-0rtt",
+            enable_0rtt,
+            "Enable 0-RTT and early data for this endpoint (cannot be used without key verification)");
+
+    try
+    {
+        cli.parse(argc, argv);
+
+        if (no_verify and enable_0rtt)
+            throw std::invalid_argument{"0-RTT must be used with key verification!"};
+    }
+    catch (const CLI::ParseError& e)
+    {
+        return cli.exit(e);
+    }
+
+    setup_logging(log_file, log_level);
+
+    auto [seed, pubkey] = generate_ed25519();
+    auto server_tls = GNUTLSCreds::make_from_ed_keys(seed, pubkey);
+
+    Network server_net{};
+
+    auto [listen_addr, listen_port] = parse_addr(server_addr, 5500);
+    Address server_local{listen_addr, listen_port};
+
+    std::shared_ptr<Endpoint> server;
+
+    std::atomic<bool> first_data{false};
+
+    /**     0: connection established
+            1: stream opened
+            2: recv (first) stream data / close conn
+            3: connection closed
+     */
+    std::array<uint64_t, 4> timing;
+
+    auto conn_established = [&](connection_interface& ci) {
+        timing[0] = get_timestamp<std::chrono::milliseconds>().count();
+        log::critical(test_cat, "Connection established to {}", ci.remote());
+    };
+
+    auto conn_closed = [&](connection_interface& ci, uint64_t) {
+        timing[3] = get_timestamp<std::chrono::milliseconds>().count();
+        log::critical(test_cat, "Connection closed to {}", ci.remote());
+
+        log::critical(test_cat, "\n\tConnection established: {}.{}ms", timing[0] / 1'000'000, timing[0] % 1000);
+        log::critical(test_cat, "\n\tFirst stream opened: {}.{}ms", timing[1] / 1'000'000, timing[1] % 1000);
+        log::critical(
+                test_cat, "\n\tFirst stream data received/close sent: {}.{}ms", timing[2] / 1'000'000, timing[2] % 1000);
+        log::critical(test_cat, "\n\tConnection closed: {}.{}ms", timing[3] / 1'000'000, timing[3] % 1000);
+
+        first_data = false;
+    };
+
+    auto stream_opened = [&](Stream& s) {
+        timing[1] = get_timestamp<std::chrono::milliseconds>().count();
+        log::critical(test_cat, "Stream {} opened!", s.stream_id());
+        return 0;
+    };
+
+    auto stream_recv = [&](Stream& s, bstring_view) {
+        // get the time first, then do ops
+        auto t = get_timestamp<std::chrono::milliseconds>().count();
+        if (not first_data.exchange(true))
+        {
+            timing[2] = t;
+            log::critical(test_cat, "Received first data on connection to {}", s.remote());
+            s.send("good afternoon"_bsv);
+            server->get_conn(s.reference_id)->close_connection();
+        }
+    };
+
+    try
+    {
+        log::info(test_cat, "Starting up endpoint...");
+        server = server_net.endpoint(server_local, conn_established, conn_closed);
+        server->listen(server_tls, stream_opened, stream_recv);
+        log::critical(
+                test_cat,
+                "Server listening on: {}{}awaiting connections...",
+                server_local,
+                no_verify ? ", " : " with pubkey: \n\n\t{}\n\n"_format(oxenc::to_base64(pubkey)));
+    }
+    catch (const std::exception& e)
+    {
+        log::critical(test_cat, "Failed to start server: {}!", e.what());
+        return 1;
+    }
+
+    for (;;)
+        std::this_thread::sleep_for(10min);
+}

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -19,7 +19,7 @@ namespace oxen::quic
 
         current_sock.swap(new_sock);
         auto rv = ngtcp2_conn_initiate_migration(conn, conn._path, get_timestamp().count());
-        log::trace(log_cat, "{}", ngtcp2_strerror(rv));
+        log::trace(test_cat, "{}", ngtcp2_strerror(rv));
     }
 
     void TestHelper::migrate_connection_immediate(Connection& conn, Address new_bind)
@@ -37,7 +37,7 @@ namespace oxen::quic
 
         current_sock.swap(new_sock);
         auto rv = ngtcp2_conn_initiate_immediate_migration(conn, conn._path, get_timestamp().count());
-        log::trace(log_cat, "{}", ngtcp2_strerror(rv));
+        log::trace(test_cat, "{}", ngtcp2_strerror(rv));
     }
 
     void TestHelper::nat_rebinding(Connection& conn, Address new_bind)

--- a/tests/utils.hpp
+++ b/tests/utils.hpp
@@ -14,6 +14,7 @@
 #include <oxen/quic/network.hpp>
 #include <oxen/quic/utils.hpp>
 #include <string>
+#include <type_traits>
 
 namespace oxen::quic
 {

--- a/tests/utils.hpp
+++ b/tests/utils.hpp
@@ -22,7 +22,7 @@ namespace oxen::quic
 
     namespace log = oxen::log;
     using namespace log::literals;
-    inline auto test_cat = log::Cat("test");
+    inline auto test_cat = log::Cat("quic-test");
 
     // Borrowing these from src/internal.hpp:
     void logger_config(std::string out = "stderr", log::Type type = log::Type::Print, log::Level reset = log::Level::trace);
@@ -30,6 +30,7 @@ namespace oxen::quic
 
     using namespace oxenc::literals;
 
+    inline const std::string LOCALHOST = "127.0.0.1"s;
     inline const std::string TEST_ENDPOINT = "test_endpoint"s;
     inline const std::string TEST_BODY = "test_body"s;
 


### PR DESCRIPTION
Scope:
- 0rtt/early data: Can be enabled with `opt::enable_0rtt_ticketing` at the endpoint level, and will apply for all connections in/out of that endpoint.
- Session ticketing storage mode: Enabled through the same struct by passing the optional verify/put/get callbacks. The default mode is internal storage managed by libquic, but the application can take responsibility by providing all of the callbacks
- Key verification on/off: Can be disabled with `opt::disable_key_verification` at the connection level by passing the struct to calls to `Endpoint::{listen,connect}(...)`
- Stateless reset can be disabled with `opt::disable_stateless_verification` at the endpoint level