### PR TITLE
Updated oxen-encoding, patch GnuTLS for NDK 27+, fixes for NDK 26

### DIFF
--- a/cmake/StaticBuild.cmake
+++ b/cmake/StaticBuild.cmake
@@ -353,7 +353,14 @@ build_external(nettle
 add_static_target(nettle::nettle nettle_external libnettle.a gmp::gmp)
 add_static_target(hogweed::hogweed nettle_external libhogweed.a nettle::nettle)
 
+# The Android NDK defines `timezone_t` but not a number of related types and GnuTLS assumes if `timezone_t` is defined then all the others will be defined as well (resulting in build errors), so we need to patch GnuTLS to think `HAVE_TIMEZONE_T` is not defined and rename it's internal `timezone_t` so there isn't a name collision
+set(gnutls_patch_commands "")
+if(ANDROID)
+    set(gnutls_patch_commands PATCH_COMMAND patch -p0 -i ${PROJECT_SOURCE_DIR}/utils/build_scripts/gnutls-android-timezone-t.patch)
+endif()
+
 build_external(gnutls
+    ${gnutls_patch_commands}
     CONFIGURE_COMMAND ./configure ${build_host} --disable-shared --prefix=${DEPS_DESTDIR} --with-pic
         --without-p11-kit --disable-libdane --disable-cxx --without-tpm --without-tpm2 --disable-doc
         --without-zlib --without-brotli --without-zstd --without-libintl-prefix --disable-tests

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -87,7 +87,7 @@ oxen_logging_add_source_dir("${PROJECT_SOURCE_DIR}")
 
 # oxenc
 if (NOT TARGET oxenc)
-    system_or_submodule(OXENC oxenc liboxenc>=1.3.0 oxen-encoding)
+    system_or_submodule(OXENC oxenc liboxenc>=1.4.0 oxen-encoding)
 endif()
 
 # libevent

--- a/include/oxen/quic/address.hpp
+++ b/include/oxen/quic/address.hpp
@@ -339,36 +339,10 @@ namespace oxen::quic
         RemoteAddress(RemoteAddress&& other) = default;
         RemoteAddress& operator=(RemoteAddress&& other) = default;
 
-        auto operator<=>(const RemoteAddress& other) const
-        {
-#if defined(__ANDROID__) && __NDK_MAJOR__ < 27
-            auto ret = std::strong_ordering::equal;
-
-            if (_remote_pubkey.size() != other._remote_pubkey.size())
-            {
-                ret = _remote_pubkey.size() < other._remote_pubkey.size() ? std::strong_ordering::less
-                                                                          : std::strong_ordering::greater;
-            }
-            else
-            {
-                for (size_t i = 0; i < _remote_pubkey.size(); ++i)
-                {
-                    if (_remote_pubkey[i] != other._remote_pubkey[i])
-                    {
-                        ret = _remote_pubkey[i] < other._remote_pubkey[i] ? std::strong_ordering::less
-                                                                          : std::strong_ordering::greater;
-                        break;
-                    }
-                }
-            }
-#else
-            auto ret = _remote_pubkey <=> other._remote_pubkey;
-#endif
-            if (ret == 0)
-                ret = Address::operator<=>(other);
-            return ret;
+        auto operator<=>(const RemoteAddress& other) const = delete;
+        auto operator==(const RemoteAddress& other) const {
+            return Address::operator==(other) && _remote_pubkey == other._remote_pubkey;
         }
-        auto operator==(const RemoteAddress& other) const { return (*this <=> other) == 0; }
     };
 
     // Wrapper for ngtcp2_path with remote/local components. Implicitly convertible

--- a/include/oxen/quic/address.hpp
+++ b/include/oxen/quic/address.hpp
@@ -341,7 +341,29 @@ namespace oxen::quic
 
         auto operator<=>(const RemoteAddress& other) const
         {
+#if defined(__ANDROID__) && __NDK_MAJOR__ < 27
+            auto ret = std::strong_ordering::equal;
+
+            if (_remote_pubkey.size() != other._remote_pubkey.size())
+            {
+                ret = _remote_pubkey.size() < other._remote_pubkey.size() ? std::strong_ordering::less
+                                                                          : std::strong_ordering::greater;
+            }
+            else
+            {
+                for (size_t i = 0; i < _remote_pubkey.size(); ++i)
+                {
+                    if (_remote_pubkey[i] != other._remote_pubkey[i])
+                    {
+                        ret = _remote_pubkey[i] < other._remote_pubkey[i] ? std::strong_ordering::less
+                                                                          : std::strong_ordering::greater;
+                        break;
+                    }
+                }
+            }
+#else
             auto ret = _remote_pubkey <=> other._remote_pubkey;
+#endif
             if (ret == 0)
                 ret = Address::operator<=>(other);
             return ret;

--- a/include/oxen/quic/address.hpp
+++ b/include/oxen/quic/address.hpp
@@ -340,7 +340,8 @@ namespace oxen::quic
         RemoteAddress& operator=(RemoteAddress&& other) = default;
 
         auto operator<=>(const RemoteAddress& other) const = delete;
-        auto operator==(const RemoteAddress& other) const {
+        auto operator==(const RemoteAddress& other) const
+        {
             return Address::operator==(other) && _remote_pubkey == other._remote_pubkey;
         }
     };

--- a/include/oxen/quic/format.hpp
+++ b/include/oxen/quic/format.hpp
@@ -8,8 +8,6 @@
 #include "formattable.hpp"
 #include "utils.hpp"
 
-#include <oxenc/span.h>
-
 #include <fmt/format.h>
 
 #include <version>
@@ -44,7 +42,7 @@ namespace oxen::quic
         explicit buffer_printer(std::basic_string<T>&& buf) = delete;
 
         // Constructed from any type of span
-        template <oxenc::const_span_type T>
+        template <oxenc::bt_input_string T>
         explicit buffer_printer(const T& data) : buffer_printer{data.data(), data.size()}
         {}
 

--- a/include/oxen/quic/utils.hpp
+++ b/include/oxen/quic/utils.hpp
@@ -159,13 +159,13 @@ namespace oxen::quic
         }
     }  // namespace detail
 
-    template <oxenc::string_like T>
+    template <oxenc::bt_input_string T>
     inline bspan str_to_bspan(const T& sv)
     {
         return detail::to_span<std::byte>(sv.data(), sv.size());
     }
 
-    template <oxenc::string_like T>
+    template <oxenc::bt_input_string T>
     inline uspan str_to_uspan(const T& sv)
     {
         return detail::to_span<unsigned char>(sv.data(), sv.size());

--- a/src/btstream.cpp
+++ b/src/btstream.cpp
@@ -204,7 +204,7 @@ namespace oxen::quic
                     "Handler for {} threw an uncaught exception ({}); returning a generic error message",
                     ep,
                     e.what());
-            respond(req_id, "An error occurred while processing the request"_bsp, true);
+            respond(req_id, str_to_bspan("An error occurred while processing the request"sv), true);
         }
     }
 

--- a/src/internal.hpp
+++ b/src/internal.hpp
@@ -19,7 +19,6 @@ namespace oxen::quic
     namespace log = oxen::log;
 
     using namespace log::literals;
-    using namespace oxenc::literals;
 
     inline constexpr size_t MAX_BATCH =
 #if defined(OXEN_LIBQUIC_UDP_SENDMMSG) || defined(OXEN_LIBQUIC_UDP_GSO)

--- a/tests/002-send-receive.cpp
+++ b/tests/002-send-receive.cpp
@@ -7,14 +7,15 @@ namespace oxen::quic::test
     TEST_CASE("002 - Simple client to server transmission", "[002][simple][execute]")
     {
         Network test_net{};
-        constexpr auto good_msg = "hello from the other siiiii-iiiiide"_bsp;
+        auto good_msg_str = "hello from the other siiiii-iiiiide"sv;
+        auto good_msg = to_span<std::byte>(good_msg_str);
 
         std::promise<bool> d_promise;
         std::future<bool> d_future = d_promise.get_future();
 
         stream_data_callback server_data_cb = [&](Stream&, bspan dat) {
             log::debug(test_cat, "Calling server stream data callback... data received...");
-            REQUIRE_THAT(dat, EqualsSpan(good_msg));
+            REQUIRE(view(dat) == view(good_msg));
             d_promise.set_value(true);
         };
 
@@ -42,7 +43,8 @@ namespace oxen::quic::test
     TEST_CASE("002 - Simple client to server transmission", "[002][simple][bidirectional]")
     {
         Network test_net{};
-        constexpr auto good_msg = "hello from the other siiiii-iiiiide"_bsp;
+        auto good_msg_str = "hello from the other siiiii-iiiiide"sv;
+        auto good_msg = to_span<std::byte>(good_msg_str);
 
         std::vector<std::promise<void>> d_promises{2};
         std::vector<std::future<void>> d_futures{2};
@@ -54,7 +56,7 @@ namespace oxen::quic::test
 
         stream_data_callback server_data_cb = [&](Stream&, bspan dat) {
             log::debug(test_cat, "Calling server stream data callback... data received...");
-            REQUIRE_THAT(dat, EqualsSpan(good_msg));
+            REQUIRE(view(dat) == view(good_msg));
             d_promises.at(index).set_value();
             index += 1;
         };
@@ -94,7 +96,8 @@ namespace oxen::quic::test
     TEST_CASE("002 - Simple client to server transmission", "[002][simple][2x2]")
     {
         Network test_net{};
-        constexpr auto good_msg = "hello from the other siiiii-iiiiide"_bsp;
+        auto good_msg_str = "hello from the other siiiii-iiiiide"sv;
+        auto good_msg = to_span<std::byte>(good_msg_str);
 
         std::vector<std::promise<void>> d_promises{2};
         std::vector<std::future<void>> d_futures{2};
@@ -106,7 +109,7 @@ namespace oxen::quic::test
 
         stream_data_callback server_data_cb = [&](Stream&, bspan dat) {
             log::debug(test_cat, "Calling server stream data callback... data received...");
-            REQUIRE_THAT(dat, EqualsSpan(good_msg));
+            REQUIRE(view(dat) == view(good_msg));
             d_promises.at(index).set_value();
             index += 1;
         };

--- a/tests/003-multiclient.cpp
+++ b/tests/003-multiclient.cpp
@@ -28,7 +28,8 @@ namespace oxen::quic::test
     TEST_CASE("003 - Multi-client to server transmission: Execution", "[003][multi-client][execute]")
     {
         Network test_net{};
-        constexpr auto msg = "hello from the other siiiii-iiiiide"_bsp;
+        auto msg_str = "hello from the other siiiii-iiiiide"sv;
+        auto msg = to_span<std::byte>(msg_str);
 
         std::atomic<int> data_check{0};
         std::vector<std::promise<void>> stream_promises{4};

--- a/tests/004-streams.cpp
+++ b/tests/004-streams.cpp
@@ -32,7 +32,8 @@ namespace oxen::quic::test
     TEST_CASE("004 - Multiple pending streams: streams available", "[004][streams][pending][config]")
     {
         Network test_net{};
-        constexpr auto msg = "hello from the other siiiii-iiiiide"_bsp;
+        auto msg_str = "hello from the other siiiii-iiiiide"sv;
+        auto msg = to_span<std::byte>(msg_str);
 
         std::promise<void> data_promise;
         std::future<void> data_future = data_promise.get_future();
@@ -68,7 +69,8 @@ namespace oxen::quic::test
         auto client_established = callback_waiter{[](connection_interface&) {}};
 
         Network test_net{};
-        constexpr auto msg = "hello from the other siiiii-iiiiide"_bsp;
+        auto msg_str = "hello from the other siiiii-iiiiide"sv;
+        auto msg = to_span<std::byte>(msg_str);
 
         std::promise<void> data_promise;
         std::future<void> data_future = data_promise.get_future();
@@ -122,7 +124,8 @@ namespace oxen::quic::test
         auto client_established = callback_waiter{[](connection_interface&) {}};
 
         Network test_net{};
-        constexpr auto msg = "hello from the other siiiii-iiiiide"_bsp;
+        auto msg_str = "hello from the other siiiii-iiiiide"sv;
+        auto msg = to_span<std::byte>(msg_str);
 
         std::atomic<size_t> index{0};
         std::atomic<size_t> data_check{0};
@@ -251,7 +254,8 @@ namespace oxen::quic::test
     TEST_CASE("004 - Subclassing quic::stream, custom to standard", "[004][customstream][cross]")
     {
         Network test_net{};
-        constexpr auto msg = "hello from the other siiiii-iiiiide"_bsp;
+        auto msg_str = "hello from the other siiiii-iiiiide"sv;
+        auto msg = to_span<std::byte>(msg_str);
 
         std::promise<void> ss_p, sc_p, cs_p, cc_p;
         std::future<void> ss_f = ss_p.get_future(), sc_f = sc_p.get_future(), cs_f = cs_p.get_future(),
@@ -259,14 +263,14 @@ namespace oxen::quic::test
 
         stream_data_callback standard_server_cb = [&](Stream& s, bspan dat) {
             log::debug(test_cat, "Calling standard stream data callback... data received...");
-            REQUIRE_THAT(dat, EqualsSpan(msg));
+            REQUIRE(view(dat) == view(msg));
             ss_p.set_value();
             s.send(msg, nullptr);
         };
 
         stream_data_callback standard_client_cb = [&](Stream& s, bspan dat) {
             log::debug(test_cat, "Calling standard stream data callback... data received...");
-            REQUIRE_THAT(dat, EqualsSpan(msg));
+            REQUIRE(view(dat) == view(msg));
             cs_p.set_value();
             s.send(msg, nullptr);
         };
@@ -303,7 +307,8 @@ namespace oxen::quic::test
     TEST_CASE("004 - Subclassing quic::stream, custom to custom", "[004][customstream][subclass]")
     {
         Network test_net{};
-        constexpr auto msg = "hello from the other siiiii-iiiiide"_bsp;
+        auto msg_str = "hello from the other siiiii-iiiiide"sv;
+        auto msg = to_span<std::byte>(msg_str);
 
         std::promise<void> server_promise, client_promise;
         std::future<void> server_future = server_promise.get_future();
@@ -517,24 +522,24 @@ namespace oxen::quic::test
         client_a = client_ci->open_stream<CustomStreamA>(std::move(cp1));
         REQUIRE_NOTHROW(client_a->send("Stream A!"s));
         require_future(sf1);
-        CHECK_THAT(sf1.get(), EqualsSpan("Stream A!"_bsp));
+        CHECK(view(sf1.get()) == view(to_span<std::byte>("Stream A!")));
 
         log::info(test_cat, "Client opening Custom Stream B!");
         client_b = client_ci->open_stream<CustomStreamB>(std::move(cp2));
         REQUIRE_NOTHROW(client_b->send("Stream B!"s));
         require_future(sf2);
-        CHECK_THAT(sf2.get(), EqualsSpan("Stream B!"_bsp));
+        CHECK(view(sf2.get()) == view(to_span<std::byte>("Stream B!")));
 
         log::info(test_cat, "Client opening Custom Stream C!");
         client_c = client_ci->open_stream<CustomStreamC>(std::move(cp3));
         REQUIRE_NOTHROW(client_c->send("Stream C!"s));
         require_future(sf3);
-        CHECK_THAT(sf3.get(), EqualsSpan("Stream C!"_bsp));
+        CHECK(view(sf3.get()) == view(to_span<std::byte>("Stream C!")));
 
         client_d = client_ci->open_stream();
         client_d->send("Stream D!"s);
         require_future(sf4);
-        CHECK_THAT(sf4.get(), EqualsSpan("Stream D!"_bsp));
+        CHECK(view(sf4.get()) == view(to_span<std::byte>("Stream D!")));
 
         client_ci->close_connection();
         REQUIRE(server_closed.wait());
@@ -942,7 +947,7 @@ namespace oxen::quic::test
 
             auto conn = client_endpoint->connect(client_remote, client_tls, conn_closed);
             auto stream_data_cb = [&](Stream&, bspan data) {
-                REQUIRE_THAT(data, EqualsSpan("11"_bsp));
+                REQUIRE(view(data) == view(to_span<std::byte>("11")));
                 got_reply.set_value();
             };
             auto stream_close_cb = [&](Stream&, uint64_t) { got_closed.set_value(); };

--- a/tests/006-server-send.cpp
+++ b/tests/006-server-send.cpp
@@ -7,7 +7,8 @@ namespace oxen::quic::test
     TEST_CASE("006 - Server streams: Direct creation and transmission", "[006][server][streams][send][execute]")
     {
         Network test_net{};
-        constexpr auto msg = "hello from the other siiiii-iiiiide"_bsp;
+        auto msg_str = "hello from the other siiiii-iiiiide"sv;
+        auto msg = to_span<std::byte>(msg_str);
 
         std::atomic<int> data_check{0};
 
@@ -64,8 +65,10 @@ namespace oxen::quic::test
     TEST_CASE("006 - Server streams: Remote initiation, server send", "[006][server][streams][send][execute]")
     {
         Network test_net{};
-        constexpr auto msg = "hello from the other siiiii-iiiiide"_bsp;
-        constexpr auto response = "okay okay i get it already"_bsp;
+        auto msg_str = "hello from the other siiiii-iiiiide"sv;
+        auto response_str = "okay okay i get it already"sv;
+        auto msg = to_span<std::byte>(msg_str);
+        auto response = to_span<std::byte>(response_str);
 
         std::atomic<int> ci{0}, si{0};
         std::atomic<int> data_check{0};

--- a/tests/007-datagrams.cpp
+++ b/tests/007-datagrams.cpp
@@ -140,7 +140,8 @@ namespace oxen::quic::test
         auto client_established = callback_waiter{[](connection_interface&) {}};
 
         Network test_net{};
-        constexpr auto msg = "hello from the other siiiii-iiiiide"_bsp;
+        auto msg_str = "hello from the other siiiii-iiiiide"sv;
+        auto msg = to_span<std::byte>(msg_str);
 
         std::promise<void> data_promise;
         std::future<void> data_future = data_promise.get_future();
@@ -200,7 +201,7 @@ namespace oxen::quic::test
         dgram_data_callback recv_dgram_cb = [&](dgram_interface&, std::vector<std::byte> data) {
             log::debug(test_cat, "Calling endpoint receive datagram callback... data received...");
             ++data_counter;
-            if (data == "final"_bsp)
+            if (view(data) == view(to_span<std::byte>("final")))
                 data_promise.set_value();
         };
 

--- a/tests/010-migration.cpp
+++ b/tests/010-migration.cpp
@@ -5,7 +5,8 @@ namespace oxen::quic::test
     TEST_CASE("010 - Migration", "[010][migration]")
     {
         Network test_net{};
-        constexpr auto good_msg = "hello from the other siiiii-iiiiide"_bsp;
+        auto good_msg_str = "hello from the other siiiii-iiiiide"sv;
+        auto good_msg = to_span<std::byte>(good_msg_str);
 
         auto [client_tls, server_tls] = defaults::tls_creds_from_ed_keys();
 
@@ -27,7 +28,7 @@ namespace oxen::quic::test
 
         stream_data_callback server_data_cb = [&](Stream&, bspan dat) {
             log::debug(test_cat, "Calling server stream data callback... data received...");
-            REQUIRE_THAT(dat, EqualsSpan(good_msg));
+            REQUIRE(view(dat) == view(good_msg));
             d_promise.set_value();
         };
 

--- a/tests/011-manual_transmission.cpp
+++ b/tests/011-manual_transmission.cpp
@@ -8,13 +8,14 @@ namespace oxen::quic::test
         auto server_established = callback_waiter{[](connection_interface&) {}};
 
         Network test_net{};
-        constexpr auto good_msg = "hello from the other siiiii-iiiiide"_bsp;
+        auto good_msg_str = "hello from the other siiiii-iiiiide"sv;
+        auto good_msg = to_span<std::byte>(good_msg_str);
 
         std::promise<bool> d_promise;
         std::future<bool> d_future = d_promise.get_future();
 
         stream_data_callback server_data_cb = [&](Stream&, bspan dat) {
-            REQUIRE_THAT(dat, EqualsSpan(good_msg));
+            REQUIRE(view(dat) == view(good_msg));
             d_promise.set_value(true);
         };
 

--- a/tests/013-eventhandler.cpp
+++ b/tests/013-eventhandler.cpp
@@ -12,7 +12,8 @@ namespace oxen::quic::test
     TEST_CASE("013 - EventHandler event repeater: EventHandler managed lifetime", "[013][repeater][managed]")
     {
         Network test_net{};
-        constexpr auto msg = "hello from the other siiiii-iiiiide"_bsp;
+        auto msg_str = "hello from the other siiiii-iiiiide"sv;
+        auto msg = to_span<std::byte>(msg_str);
 
         std::promise<void> prom_a, prom_b;
         std::future<void> fut_a = prom_a.get_future(), fut_b = prom_b.get_future();

--- a/tests/dgram-speed-client.cpp
+++ b/tests/dgram-speed-client.cpp
@@ -8,6 +8,17 @@
 
 using namespace oxen::quic;
 
+inline std::string_view view(std::span<const std::byte> x)
+{
+    return {reinterpret_cast<const char*>(x.data()), x.size()};
+}
+
+template <oxenc::basic_char Char>
+std::span<const Char> to_span(std::string_view x)
+{
+    return {reinterpret_cast<const Char*>(x.data()), x.size()};
+}
+
 int main(int argc, char* argv[])
 {
     CLI::App cli{"libQUIC datagram speedtest client"};
@@ -100,7 +111,7 @@ int main(int argc, char* argv[])
             log::error(test_cat, "Got unexpected data from the other side: {}B != 5B", data.size());
             dgram_data->failed = true;
         }
-        else if (data != "DONE!"_bsp)
+        else if (view(data) != view(to_span<std::byte>("DONE!")))
         {
             log::error(
                     test_cat,

--- a/tests/dgram-speed-server.cpp
+++ b/tests/dgram-speed-server.cpp
@@ -6,6 +6,11 @@
 
 using namespace oxen::quic;
 
+inline std::string_view view(std::span<const std::byte> x)
+{
+    return {reinterpret_cast<const char*>(x.data()), x.size()};
+}
+
 int main(int argc, char* argv[])
 {
     CLI::App cli{"libQUIC datagram speedtest server"};
@@ -115,7 +120,7 @@ int main(int argc, char* argv[])
                 bad = true;
                 log::error(log_cat, "Datagram {} verification found invalid first byte value {}", info.n_received, offset);
             }
-            else if (data != std::span{dgram_rainbow}.subspan(offset, data.size()))
+            else if (view(data) != view(std::span{dgram_rainbow}.subspan(offset, data.size())))
             {
                 bad = true;
             }

--- a/tests/speedtest-client.cpp
+++ b/tests/speedtest-client.cpp
@@ -12,6 +12,11 @@
 
 using namespace oxen::quic;
 
+inline std::string_view view(std::span<const std::byte> x)
+{
+    return {reinterpret_cast<const char*>(x.data()), x.size()};
+}
+
 int main(int argc, char* argv[])
 {
     CLI::App cli{"libQUIC stream speedtest client"};
@@ -154,7 +159,7 @@ int main(int argc, char* argv[])
             log::error(test_cat, "Got unexpected data from the other side: {}B != 32B", data.size());
             sd.failed = true;
         }
-        else if (auto first = data.first(32); first != sd.hash)
+        else if (auto first = data.first(32); view(first) != view(sd.hash))
         {
             log::critical(
                     test_cat,

--- a/tests/unit_test.hpp
+++ b/tests/unit_test.hpp
@@ -4,10 +4,9 @@
 
 #include "utils.hpp"
 
-#include <oxenc/span.h>
+#include <oxenc/common.h>
 
 // keep above Catch2 includes to get comparators
-using namespace oxenc::operators;
 
 #include <catch2/catch_test_case_info.hpp>
 #include <catch2/catch_test_macros.hpp>
@@ -21,24 +20,21 @@ using namespace oxenc::operators;
 
 namespace oxen::quic
 {
-    template <oxenc::const_span_type SpanT>
-    struct SpanEqualsMatcher : Catch::Matchers::MatcherGenericBase
+    template <oxenc::basic_char Char>
+    std::span<const Char> to_span(std::string_view x)
     {
-      private:
-        const SpanT& s;
-
-      public:
-        SpanEqualsMatcher(const SpanT& _s) : s{_s} {}
-
-        bool match(const SpanT& other) const { return std::ranges::equal(s, other); }
-
-        std::string describe() const override { return "Equals: {}"_format(sp_to_sv(s)); }
-    };
-
-    template <oxenc::const_span_type SpanT>
-    auto EqualsSpan(const SpanT& T) -> SpanEqualsMatcher<SpanT>
-    {
-        return SpanEqualsMatcher<SpanT>{T};
+        return {reinterpret_cast<const Char*>(x.data()), x.size()};
     }
-
+    inline std::string_view view(std::span<const unsigned char> x)
+    {
+        return {reinterpret_cast<const char*>(x.data()), x.size()};
+    }
+    inline std::string_view view(std::span<const std::byte> x)
+    {
+        return {reinterpret_cast<const char*>(x.data()), x.size()};
+    }
+    inline std::string_view view(std::span<const char> x)
+    {
+        return {x.data(), x.size()};
+    }
 }  // namespace oxen::quic

--- a/tests/utils.hpp
+++ b/tests/utils.hpp
@@ -8,7 +8,6 @@
 #include <oxen/quic/gnutls_crypto.hpp>
 #include <oxenc/base64.h>
 #include <oxenc/hex.h>
-#include <oxenc/span.h>
 
 #include <CLI/CLI.hpp>
 #include <CLI/Error.hpp>
@@ -53,7 +52,6 @@ namespace oxen::quic
     inline auto log_cat = log::Cat("quic");
 
     using namespace oxenc::literals;
-    using namespace oxenc::operators;
 
     inline const std::string LOCALHOST = "127.0.0.1"s;
     inline const std::string TEST_ENDPOINT = "test_endpoint"s;
@@ -116,8 +114,8 @@ namespace oxen::quic
     // of the given seed, if non-empty, and otherwise will generate a random value.
     opt::static_secret generate_static_secret(std::string_view seed_string = ""sv);
 
-    template <oxenc::const_span_type T>
-    inline std::string_view sp_to_sv(const T& sp)
+    template <typename InChar>
+    inline std::string_view sp_to_sv(std::span<const InChar> sp)
     {
         return {reinterpret_cast<const char*>(sp.data()), sp.size()};
     }

--- a/utils/build_scripts/gnutls-android-timezone-t.patch
+++ b/utils/build_scripts/gnutls-android-timezone-t.patch
@@ -1,0 +1,406 @@
+--- configure	2024-01-16 20:17:02
++++ patch-configure.sh	2025-03-26 08:23:34
+@@ -55684,19 +55684,19 @@
+ 
+   fi
+ 
+-  ac_fn_c_check_type "$LINENO" "timezone_t" "ac_cv_type_timezone_t" "#include <time.h>
+-"
+-if test "x$ac_cv_type_timezone_t" = xyes
+-then :
++#   ac_fn_c_check_type "$LINENO" "timezone_t" "ac_cv_type_timezone_t" "#include <time.h>
++# "
++# if test "x$ac_cv_type_timezone_t" = xyes
++# then :
+ 
+-printf "%s\n" "#define HAVE_TIMEZONE_T 1" >>confdefs.h
++# printf "%s\n" "#define HAVE_TIMEZONE_T 1" >>confdefs.h
++
+ 
++# fi
+ 
+-fi
+-
+-  if test "$ac_cv_type_timezone_t" = yes; then
+-    HAVE_TIMEZONE_T=1
+-  fi
++#   if test "$ac_cv_type_timezone_t" = yes; then
++#     HAVE_TIMEZONE_T=1
++#   fi
+ 
+ 
+      if test $HAVE_TIMEZONE_T = 0; then
+
+--- src/gl/time.in.h	2025-03-26 08:33:34
++++ src/gl/patch-time.in.h	2025-03-26 08:34:22
+@@ -369,8 +369,8 @@
+    Inspired by NetBSD.  */
+ 
+ /* Represents a time zone.
+-   (timezone_t) NULL stands for UTC.  */
+-typedef struct tm_zone *timezone_t;
++   (rpl_timezone_t) NULL stands for UTC.  */
++typedef struct tm_zone *rpl_timezone_t;
+ 
+ /* tzalloc (name)
+    Returns a time zone object for the given time zone NAME.  This object
+@@ -380,14 +380,14 @@
+    would use it the TZ environment variable was unset.
+    May return NULL if NAME is invalid (this is platform dependent) or
+    upon memory allocation failure.  */
+-_GL_FUNCDECL_SYS (tzalloc, timezone_t, (char const *__name));
+-_GL_CXXALIAS_SYS (tzalloc, timezone_t, (char const *__name));
++_GL_FUNCDECL_SYS (tzalloc, rpl_timezone_t, (char const *__name));
++_GL_CXXALIAS_SYS (tzalloc, rpl_timezone_t, (char const *__name));
+ 
+ /* tzfree (tz)
+    Frees a time zone object.
+    The argument must have been returned by tzalloc().  */
+-_GL_FUNCDECL_SYS (tzfree, void, (timezone_t __tz));
+-_GL_CXXALIAS_SYS (tzfree, void, (timezone_t __tz));
++_GL_FUNCDECL_SYS (tzfree, void, (rpl_timezone_t __tz));
++_GL_CXXALIAS_SYS (tzfree, void, (rpl_timezone_t __tz));
+ 
+ /* localtime_rz (tz, &t, &result)
+    Converts an absolute time T to a broken-down time RESULT, assuming the
+@@ -395,10 +395,10 @@
+    This function is like 'localtime_r', but relies on the argument TZ instead
+    of an implicit global time zone.  */
+ _GL_FUNCDECL_SYS (localtime_rz, struct tm *,
+-                  (timezone_t __tz, time_t const *restrict __timer,
++                  (rpl_timezone_t __tz, time_t const *restrict __timer,
+                    struct tm *restrict __result) _GL_ARG_NONNULL ((2, 3)));
+ _GL_CXXALIAS_SYS (localtime_rz, struct tm *,
+-                  (timezone_t __tz, time_t const *restrict __timer,
++                  (rpl_timezone_t __tz, time_t const *restrict __timer,
+                    struct tm *restrict __result));
+ 
+ /* mktime_z (tz, &tm)
+@@ -407,16 +407,16 @@
+    This function is like 'mktime', but relies on the argument TZ instead
+    of an implicit global time zone.  */
+ _GL_FUNCDECL_SYS (mktime_z, time_t,
+-                  (timezone_t __tz, struct tm *restrict __tm)
++                  (rpl_timezone_t __tz, struct tm *restrict __tm)
+                   _GL_ARG_NONNULL ((2)));
+ _GL_CXXALIAS_SYS (mktime_z, time_t,
+-                  (timezone_t __tz, struct tm *restrict __tm));
++                  (rpl_timezone_t __tz, struct tm *restrict __tm));
+ 
+ /* Time zone abbreviation strings (returned by 'localtime_rz' or 'mktime_z'
+    in the 'tm_zone' member of 'struct tm') are valid as long as
+      - the 'struct tm' argument is not destroyed or overwritten,
+    and
+-     - the 'timezone_t' argument is not freed through tzfree().  */
++     - the 'rpl_timezone_t' argument is not freed through tzfree().  */
+ 
+ # endif
+
+--- src/gl/nstrftime.c	2024-01-16 20:16:15
++++ src/gl/patch-nstrftime.c	2025-03-26 08:35:38
+@@ -388,7 +388,7 @@
+ 
+ #ifdef my_strftime
+ # define extra_args , tz, ns
+-# define extra_args_spec , timezone_t tz, int ns
++# define extra_args_spec , rpl_timezone_t tz, int ns
+ #else
+ # if defined COMPILE_WIDE
+ #  define my_strftime wcsftime
+
+--- src/gl/parse-datetime.h	2024-01-16 20:16:15
++++ src/gl/patch-parse-datetime.h	2025-03-26 08:38:48
+@@ -27,4 +27,4 @@
+ /* same as above, supporting additional flags */
+ bool parse_datetime2 (struct timespec *restrict,
+                       char const *, struct timespec const *,
+-                      unsigned int flags, timezone_t, char const *);
++                      unsigned int flags, rpl_timezone_t, char const *);
+
+--- src/gl/parse-datetime.c	2024-01-16 20:19:14
++++ src/gl/patch-parse-datetime.c	2025-03-26 08:37:55
+@@ -3262,7 +3262,7 @@
+ static bool
+ parse_datetime_body (struct timespec *result, char const *p,
+                      struct timespec const *now, unsigned int flags,
+-                     timezone_t tzdefault, char const *tzstring)
++                     rpl_timezone_t tzdefault, char const *tzstring)
+ {
+   struct tm tm;
+   struct tm tm0;
+@@ -3291,7 +3291,7 @@
+   while (c = *p, c_isspace (c))
+     p++;
+ 
+-  timezone_t tz = tzdefault;
++  rpl_timezone_t tz = tzdefault;
+ 
+   /* Store a local copy prior to first "goto".  Without this, a prior use
+      below of RELATIVE_TIME_0 on the RHS might translate to an assignment-
+@@ -3313,7 +3313,7 @@
+           }
+         else if (*s == '"')
+           {
+-            timezone_t tz1;
++            rpl_timezone_t tz1;
+             char *tz1string = tz1buf;
+             char *z;
+             if (TZBUFSIZE < tzsize)
+@@ -3597,7 +3597,7 @@
+               char tz2buf[sizeof "XXX" - 1 + TIME_ZONE_BUFSIZE];
+               tz2buf[0] = tz2buf[1] = tz2buf[2] = 'X';
+               time_zone_str (pc.time_zone, &tz2buf[3]);
+-              timezone_t tz2 = tzalloc (tz2buf);
++              rpl_timezone_t tz2 = tzalloc (tz2buf);
+               if (!tz2)
+                 {
+                   if (debugging (&pc))
+@@ -3935,7 +3935,7 @@
+ bool
+ parse_datetime2 (struct timespec *result, char const *p,
+                  struct timespec const *now, unsigned int flags,
+-                 timezone_t tzdefault, char const *tzstring)
++                 rpl_timezone_t tzdefault, char const *tzstring)
+ {
+   return parse_datetime_body (result, p, now, flags, tzdefault, tzstring);
+ }
+@@ -3948,7 +3948,7 @@
+                 struct timespec const *now)
+ {
+   char const *tzstring = getenv ("TZ");
+-  timezone_t tz = tzalloc (tzstring);
++  rpl_timezone_t tz = tzalloc (tzstring);
+   if (!tz)
+     return false;
+   bool ok = parse_datetime_body (result, p, now, 0, tz, tzstring);
+
+--- src/gl/parse-datetime.y	2024-01-16 20:16:15
++++ src/gl/patch-parse-datetime.y	2025-03-26 08:39:42
+@@ -1707,7 +1707,7 @@
+ static bool
+ parse_datetime_body (struct timespec *result, char const *p,
+                      struct timespec const *now, unsigned int flags,
+-                     timezone_t tzdefault, char const *tzstring)
++                     rpl_timezone_t tzdefault, char const *tzstring)
+ {
+   struct tm tm;
+   struct tm tm0;
+@@ -1736,7 +1736,7 @@
+   while (c = *p, c_isspace (c))
+     p++;
+ 
+-  timezone_t tz = tzdefault;
++  rpl_timezone_t tz = tzdefault;
+ 
+   /* Store a local copy prior to first "goto".  Without this, a prior use
+      below of RELATIVE_TIME_0 on the RHS might translate to an assignment-
+@@ -1758,7 +1758,7 @@
+           }
+         else if (*s == '"')
+           {
+-            timezone_t tz1;
++            rpl_timezone_t tz1;
+             char *tz1string = tz1buf;
+             char *z;
+             if (TZBUFSIZE < tzsize)
+@@ -2042,7 +2042,7 @@
+               char tz2buf[sizeof "XXX" - 1 + TIME_ZONE_BUFSIZE];
+               tz2buf[0] = tz2buf[1] = tz2buf[2] = 'X';
+               time_zone_str (pc.time_zone, &tz2buf[3]);
+-              timezone_t tz2 = tzalloc (tz2buf);
++              rpl_timezone_t tz2 = tzalloc (tz2buf);
+               if (!tz2)
+                 {
+                   if (debugging (&pc))
+@@ -2380,7 +2380,7 @@
+ bool
+ parse_datetime2 (struct timespec *result, char const *p,
+                  struct timespec const *now, unsigned int flags,
+-                 timezone_t tzdefault, char const *tzstring)
++                 rpl_timezone_t tzdefault, char const *tzstring)
+ {
+   return parse_datetime_body (result, p, now, flags, tzdefault, tzstring);
+ }
+@@ -2393,7 +2393,7 @@
+                 struct timespec const *now)
+ {
+   char const *tzstring = getenv ("TZ");
+-  timezone_t tz = tzalloc (tzstring);
++  rpl_timezone_t tz = tzalloc (tzstring);
+   if (!tz)
+     return false;
+   bool ok = parse_datetime_body (result, p, now, 0, tz, tzstring);
+
+--- src/gl/strftime.h	2024-01-16 20:16:15
++++ src/gl/patch-strftime.h	2025-03-26 08:40:38
+@@ -31,7 +31,7 @@
+    if the number is 0.  This errno behavior is in draft POSIX 202x
+    plus some requested changes to POSIX.  */
+ size_t nstrftime (char *restrict, size_t, char const *, struct tm const *,
+-                  timezone_t __tz, int __ns);
++                  rpl_timezone_t __tz, int __ns);
+ 
+ #ifdef __cplusplus
+ }
+
+--- src/gl/time_rz.c	2024-01-16 20:16:17
++++ src/gl/patch-time_rz.c	2025-03-26 08:42:14
+@@ -19,7 +19,7 @@
+ 
+ /* Although this module is not thread-safe, any races should be fairly
+    rare and reasonably benign.  For complete thread-safety, use a C
+-   library with a working timezone_t type, so that this module is not
++   library with a working rpl_timezone_t type, so that this module is not
+    needed.  */
+ 
+ #include <config.h>
+@@ -44,10 +44,10 @@
+    used.  */
+ enum { ABBR_SIZE_MIN = DEFAULT_MXFAST - offsetof (struct tm_zone, abbrs) };
+ 
+-/* Magic cookie timezone_t value, for local time.  It differs from
+-   NULL and from all other timezone_t values.  Only the address
++/* Magic cookie rpl_timezone_t value, for local time.  It differs from
++   NULL and from all other rpl_timezone_t values.  Only the address
+    matters; the pointer is never dereferenced.  */
+-static timezone_t const local_tz = (timezone_t) 1;
++static rpl_timezone_t const local_tz = (rpl_timezone_t) 1;
+ 
+ /* Copy to ABBRS the abbreviation at ABBR with size ABBR_SIZE (this
+    includes its trailing null byte).  Append an extra null byte to
+@@ -61,12 +61,12 @@
+ 
+ /* Return a newly allocated time zone for NAME, or NULL on failure.
+    A null NAME stands for wall clock time (which is like unset TZ).  */
+-timezone_t
++rpl_timezone_t
+ tzalloc (char const *name)
+ {
+   size_t name_size = name ? strlen (name) + 1 : 0;
+   size_t abbr_size = name_size < ABBR_SIZE_MIN ? ABBR_SIZE_MIN : name_size + 1;
+-  timezone_t tz = malloc (FLEXSIZEOF (struct tm_zone, abbrs, abbr_size));
++  rpl_timezone_t tz = malloc (FLEXSIZEOF (struct tm_zone, abbrs, abbr_size));
+   if (tz)
+     {
+       tz->next = NULL;
+@@ -86,7 +86,7 @@
+    !HAVE_STRUCT_TM_TM_ZONE && HAVE_TZNAME) if they use the abbreviation.
+    Return true if successful, false (setting errno) otherwise.  */
+ static bool
+-save_abbr (timezone_t tz, struct tm *tm)
++save_abbr (rpl_timezone_t tz, struct tm *tm)
+ {
+ #if HAVE_STRUCT_TM_TM_ZONE || HAVE_TZNAME
+   char const *zone = NULL;
+@@ -157,12 +157,12 @@
+ 
+ /* Free a time zone.  */
+ void
+-tzfree (timezone_t tz)
++tzfree (rpl_timezone_t tz)
+ {
+   if (tz != local_tz)
+     while (tz)
+       {
+-        timezone_t next = tz->next;
++        rpl_timezone_t next = tz->next;
+         free (tz);
+         tz = next;
+       }
+@@ -187,10 +187,10 @@
+ }
+ #endif
+ 
+-/* Change the environment to match the specified timezone_t value.
++/* Change the environment to match the specified rpl_timezone_t value.
+    Return true if successful, false (setting errno) otherwise.  */
+ static bool
+-change_env (timezone_t tz)
++change_env (rpl_timezone_t tz)
+ {
+   if (setenv_TZ (tz->tz_is_set ? tz->abbrs : NULL) != 0)
+     return false;
+@@ -202,8 +202,8 @@
+    Return LOCAL_TZ if the time zone setting is already correct.
+    Otherwise return a newly allocated time zone representing the old
+    setting, or NULL (setting errno) on failure.  */
+-static timezone_t
+-set_tz (timezone_t tz)
++static rpl_timezone_t
++set_tz (rpl_timezone_t tz)
+ {
+   char *env_tz = getenv_TZ ();
+   if (env_tz
+@@ -212,7 +212,7 @@
+     return local_tz;
+   else
+     {
+-      timezone_t old_tz = tzalloc (env_tz);
++      rpl_timezone_t old_tz = tzalloc (env_tz);
+       if (!old_tz)
+         return old_tz;
+       if (! change_env (tz))
+@@ -230,7 +230,7 @@
+    Return true (preserving errno) if successful, false (setting errno)
+    otherwise.  */
+ static bool
+-revert_tz (timezone_t tz)
++revert_tz (rpl_timezone_t tz)
+ {
+   if (tz == local_tz)
+     return true;
+@@ -248,7 +248,7 @@
+ 
+ /* Use time zone TZ to compute localtime_r (T, TM).  */
+ struct tm *
+-localtime_rz (timezone_t tz, time_t const *t, struct tm *tm)
++localtime_rz (rpl_timezone_t tz, time_t const *t, struct tm *tm)
+ {
+ #ifdef HAVE_LOCALTIME_INFLOOP_BUG
+   /* The -67768038400665599 comes from:
+@@ -269,7 +269,7 @@
+     return gmtime_r (t, tm);
+   else
+     {
+-      timezone_t old_tz = set_tz (tz);
++      rpl_timezone_t old_tz = set_tz (tz);
+       if (old_tz)
+         {
+           bool abbr_saved = localtime_r (t, tm) && save_abbr (tz, tm);
+@@ -282,13 +282,13 @@
+ 
+ /* Use time zone TZ to compute mktime (TM).  */
+ time_t
+-mktime_z (timezone_t tz, struct tm *tm)
++mktime_z (rpl_timezone_t tz, struct tm *tm)
+ {
+   if (!tz)
+     return timegm (tm);
+   else
+     {
+-      timezone_t old_tz = set_tz (tz);
++      rpl_timezone_t old_tz = set_tz (tz);
+       if (old_tz)
+         {
+           struct tm tm_1;
+
+--- src/gl/tests/test-nstrftime.c	2024-01-16 20:16:17
++++ src/gl/tests/patch-test-nstrftime.c	2025-03-26 08:43:33
+@@ -86,7 +86,7 @@
+ 
+ struct tzalloc_test
+ {
+-  timezone_t tz;
++  rpl_timezone_t tz;
+   char const *setting;
+ };
+ 
+@@ -161,7 +161,7 @@
+     {
+       struct tzalloc_test *tza = LT[i].tza;
+       long lt = LT[i].t;
+-      timezone_t tz = tza->tz;
++      rpl_timezone_t tz = tza->tz;
+       char const *setting;
+       static char const format[] = "%Y-%m-%d %H:%M:%S %z (%Z)";
+       char buf[1000];


### PR DESCRIPTION
With version `27` and above the Android NDK includes definitions for `timezone_t` and a various other time-with-timezone functions but locks everything except `timezone_t` behind an API level 35 check - this results in build errors with GnuTLS when building for Android because it assumes if `timezone_t` is available then the other functions are as well.

To resolve this I've added a `patch` which gets applied for Android builds that forces the `HAVE_TIMESTAMP_T` value to `0` (so that it includes `time_rz.c` in the build) and renames the internal GnuTLS definition of `timezone_t` to `rpl_timezone_t` (to avoid the name collision) which resolves the build issue for NDK 27+.

For NDK 26 the `lexicographical_compare` for `std::vector` doesn't exist so we need to use custom logic in that case to support building for NDK 26.

This PR also updates `oxen-encoding` to the latest version which cleans up some `span` logic (and makes the changes needed to build using the updated version).