### PR TITLE
Make ngtcp2_cid internal to quic_cid

### DIFF
--- a/include/oxen/quic/connection_ids.hpp
+++ b/include/oxen/quic/connection_ids.hpp
@@ -38,28 +38,43 @@ namespace oxen::quic
     };
 
     // Wrapper for ngtcp2_cid with helper functionalities to make it passable
-    struct alignas(size_t) quic_cid final : ngtcp2_cid
+    struct quic_cid
     {
+      private:
+        ngtcp2_cid _ngtcp2_cid{};
+
+      public:
         quic_cid() = default;
         quic_cid(const quic_cid& c) = default;
-        quic_cid(ngtcp2_cid c) : quic_cid(c.data, c.datalen) {}
+        quic_cid(const ngtcp2_cid& c) : _ngtcp2_cid{c} {}
         quic_cid(const uint8_t* cid, size_t length)
         {
             assert(length <= NGTCP2_MAX_CIDLEN);
-            datalen = length;
-            std::memmove(data, cid, datalen);
+            _ngtcp2_cid.datalen = length;
+            std::memcpy(_ngtcp2_cid.data, cid, length);
         }
+
+        const ngtcp2_cid* ngtcp2() const { return &_ngtcp2_cid; }
 
         quic_cid& operator=(const quic_cid& c) = default;
 
         inline bool operator==(const quic_cid& other) const
         {
-            return datalen == other.datalen && std::memcmp(data, other.data, datalen) == 0;
+            return _ngtcp2_cid.datalen == other._ngtcp2_cid.datalen &&
+                   std::memcmp(_ngtcp2_cid.data, other._ngtcp2_cid.data, _ngtcp2_cid.datalen) == 0;
         }
 
-        inline bool operator!=(const quic_cid& other) const { return !(*this == other); }
+        inline bool operator!=(const quic_cid& other) const = default;
 
         static quic_cid random();
+
+        inline size_t _hashed() const noexcept
+        {
+            static_assert(
+                    alignof(quic_cid) >= alignof(size_t) && offsetof(quic_cid, _ngtcp2_cid) % sizeof(size_t) == 0 &&
+                    offsetof(ngtcp2_cid, data) % sizeof(size_t) == 0);
+            return *reinterpret_cast<const size_t*>(_ngtcp2_cid.data);
+        }
 
         std::string to_string() const;
         constexpr static bool to_string_formattable = true;
@@ -73,13 +88,7 @@ namespace std
     template <>
     struct hash<oxen::quic::quic_cid>
     {
-        size_t operator()(const oxen::quic::quic_cid& cid) const noexcept
-        {
-            static_assert(
-                    alignof(oxen::quic::quic_cid) >= alignof(size_t) &&
-                    offsetof(oxen::quic::quic_cid, data) % sizeof(size_t) == 0);
-            return *reinterpret_cast<const size_t*>(cid.data);
-        }
+        size_t operator()(const oxen::quic::quic_cid& cid) const noexcept { return cid._hashed(); }
     };
 
     template <>

--- a/include/oxen/quic/endpoint.hpp
+++ b/include/oxen/quic/endpoint.hpp
@@ -268,13 +268,13 @@ namespace oxen::quic
 
         void dissociate_reset(const uint8_t* token, Connection& conn);
 
-        void associate_cid(quic_cid qcid, Connection& conn, bool weakly = false);
+        void associate_cid(const quic_cid& qcid, Connection& conn, bool weakly = false);
 
         void associate_cid(const ngtcp2_cid* cid, Connection& conn);
 
         void dissociate_cid(const ngtcp2_cid* cid, Connection& conn);
 
-        void dissociate_cid(quic_cid qcid, Connection& conn);
+        void dissociate_cid(const quic_cid& qcid, Connection& conn);
 
         const std::vector<unsigned char>& static_secret() const { return _static_secret; }
 
@@ -354,7 +354,7 @@ namespace oxen::quic
         void send_or_queue_packet(
                 const Path& p, std::vector<std::byte> buf, uint8_t ecn, std::function<void(io_result)> callback = nullptr);
 
-        void send_stateless_reset(const Packet& pkt, quic_cid& cid);
+        void send_stateless_reset(const Packet& pkt, const quic_cid& cid);
 
         void send_version_negotiation(const ngtcp2_version_cid& vid, Path p);
 

--- a/src/btstream.cpp
+++ b/src/btstream.cpp
@@ -49,7 +49,7 @@ namespace oxen::quic
         if (auto ptr = return_sender.lock())
             ptr->respond(req_id, body, error);
         else
-            log::warning(log_cat, "BTRequestStream unable to send response: stream has gone away");
+            log::debug(log_cat, "Dropping response: stream has gone away");
     }
 
     void BTRequestStream::handle_bp_opt(std::function<void(Stream&, uint64_t)> close_cb)

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -1864,8 +1864,8 @@ namespace oxen::quic
 
             conn_new_rv = ngtcp2_conn_client_new(
                     &connptr,
-                    &_dest_cid,
-                    &_source_cid,
+                    _dest_cid.ngtcp2(),
+                    _source_cid.ngtcp2(),
                     path,
                     NGTCP2_PROTO_VER_V1,
                     &callbacks,
@@ -1909,8 +1909,8 @@ namespace oxen::quic
 
             conn_new_rv = ngtcp2_conn_server_new(
                     &connptr,
-                    &_dest_cid,
-                    &_source_cid,
+                    _dest_cid.ngtcp2(),
+                    _source_cid.ngtcp2(),
                     path,
                     NGTCP2_PROTO_VER_V1,
                     &callbacks,

--- a/src/connection_ids.cpp
+++ b/src/connection_ids.cpp
@@ -17,14 +17,14 @@ namespace oxen::quic
 
     std::string quic_cid::to_string() const
     {
-        return oxenc::to_hex(data, data + datalen);
+        return oxenc::to_hex(_ngtcp2_cid.data, _ngtcp2_cid.data + _ngtcp2_cid.datalen);
     }
 
     quic_cid quic_cid::random()
     {
         quic_cid cid;
-        cid.datalen = static_cast<size_t>(NGTCP2_MAX_CIDLEN);
-        gnutls_rnd(GNUTLS_RND_RANDOM, cid.data, cid.datalen);
+        cid._ngtcp2_cid.datalen = static_cast<size_t>(NGTCP2_MAX_CIDLEN);
+        gnutls_rnd(GNUTLS_RND_RANDOM, cid._ngtcp2_cid.data, cid._ngtcp2_cid.datalen);
         return cid;
     }
 

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -137,8 +137,9 @@ namespace oxen::quic
         if (not _manual_routing)
         {
             log::debug(log_cat, "Starting new UDP socket on {}", _local);
-            socket = std::make_unique<UDPSocket>(
-                    loop.get_event_base(), _local, _allow_gso, [this](auto&& packet) { handle_packet(std::move(packet)); });
+            socket = std::make_unique<UDPSocket>(loop.get_event_base(), _local, _allow_gso, [this]<typename T>(T&& packet) {
+                handle_packet(std::forward<T>(packet));
+            });
 
             _local = socket->address();
         }
@@ -458,7 +459,7 @@ namespace oxen::quic
             log::warning(
                     log_cat,
                     "Error: Failed to write connection close packet: {}",
-                    (written < 0) ? ngtcp2_strerror(written) : "[Error Unknown: closing pkt is 0 bytes?]"s);
+                    written < 0 ? ngtcp2_strerror(static_cast<int>(written)) : "[Error Unknown: closing pkt is 0 bytes?]"s);
 
             delete_connection(conn);
             return;
@@ -496,10 +497,7 @@ namespace oxen::quic
         const auto& cids = conn.associated_cids();
         log::debug(log_cat, "Deleting {} associated CIDs for connection {}", cids.size(), rid);
         while (not cids.empty())
-        {
-            auto itr = cids.begin();
-            dissociate_cid(&*itr, conn);
-        }
+            dissociate_cid(*cids.begin(), conn);
 
         const auto& resets = conn.associated_reset_tokens();
         log::debug(log_cat, "Deleting {} associated reset tokens for connection {}", resets.size(), rid);
@@ -593,7 +591,7 @@ namespace oxen::quic
         }
     }
 
-    void Endpoint::associate_cid(quic_cid qcid, Connection& conn, bool weakly)
+    void Endpoint::associate_cid(const quic_cid& qcid, Connection& conn, bool weakly)
     {
         assert(loop.inside());
         log::trace(
@@ -611,7 +609,7 @@ namespace oxen::quic
             return associate_cid(quic_cid{*cid}, conn);
     }
 
-    void Endpoint::dissociate_cid(quic_cid qcid, Connection& conn)
+    void Endpoint::dissociate_cid(const quic_cid& qcid, Connection& conn)
     {
         assert(loop.inside());
         log::trace(
@@ -692,7 +690,7 @@ namespace oxen::quic
         return true;
     }
 
-    void Endpoint::send_stateless_reset(const Packet& pkt, quic_cid& cid)
+    void Endpoint::send_stateless_reset(const Packet& pkt, const quic_cid& cid)
     {
         if (pkt.size() <= MIN_STATELESS_RESET_SIZE)
         {
@@ -1051,9 +1049,8 @@ namespace oxen::quic
             // non-error on *partial* success).
             return io_result{EAGAIN};
         }
-        else
-            n_pkts = 0;
 
+        n_pkts = 0;
         return ret;
     }
 
@@ -1107,7 +1104,10 @@ namespace oxen::quic
                 versions.size());
         if (nwrite <= 0)
         {
-            log::warning(log_cat, "Error: Failed to construct version negotiation packet: {}", ngtcp2_strerror(nwrite));
+            log::warning(
+                    log_cat,
+                    "Error: Failed to construct version negotiation packet: {}",
+                    ngtcp2_strerror(static_cast<int>(nwrite)));
             return;
         }
 

--- a/src/gnutls_crypto.cpp
+++ b/src/gnutls_crypto.cpp
@@ -77,7 +77,7 @@ namespace oxen::quic
             const quic_cid& cid,
             std::span<uint8_t, NGTCP2_STATELESS_RESET_TOKENLEN> out)
     {
-        generate_reset_token(static_secret, &cid, out);
+        generate_reset_token(static_secret, cid.ngtcp2(), out);
     }
     std::array<uint8_t, NGTCP2_STATELESS_RESET_TOKENLEN> generate_reset_token(
             std::span<const uint8_t> static_secret, const ngtcp2_cid* cid)
@@ -89,7 +89,7 @@ namespace oxen::quic
     std::array<uint8_t, NGTCP2_STATELESS_RESET_TOKENLEN> generate_reset_token(
             std::span<const uint8_t> static_secret, const quic_cid& cid)
     {
-        return generate_reset_token(static_secret, &cid);
+        return generate_reset_token(static_secret, cid.ngtcp2());
     }
 
     static constexpr auto STATELESS_HASH_PREFIX = "quic stateless reset hash"sv;


### PR DESCRIPTION
Directly exposing the inheritance is questionable and leads to confusing code.  This uses composition instead of inheritance, and makes the conversion to `const ngtcp2_cid*` explicit where needed via a `ngtcp2()` method.