### PR TITLE
Downgrade some log warnings

### DIFF
--- a/src/datagram.cpp
+++ b/src/datagram.cpp
@@ -88,7 +88,7 @@ namespace oxen::quic
         loop.call([this, data, keep_alive = std::move(keep_alive)]() mutable {
             if (!_conn)
             {
-                log::warning(log_cat, "Unable to send datagram: connection has gone away");
+                log::debug(log_cat, "Unable to send datagram: connection has gone away");
                 return;
             }
 

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -457,9 +457,12 @@ namespace oxen::quic
 
         if (written <= 0)
         {
-            log::warning(
+            // This error comes up rather frequently under normal operations, as ngtcp2 can decide
+            // that we aren't allowed to send anything right now, so keep it at merely debug log
+            // level.
+            log::debug(
                     log_cat,
-                    "Error: Failed to write connection close packet: {}",
+                    "Failed to write connection close packet: {}",
                     written < 0 ? ngtcp2_strerror(static_cast<int>(written)) : "[Error Unknown: closing pkt is 0 bytes?]"s);
 
             delete_connection(conn);
@@ -1062,7 +1065,7 @@ namespace oxen::quic
 
         if (not _manual_routing and !socket)
         {
-            log::warning(log_cat, "Cannot sent to dead socket for path {}", p);
+            log::warning(log_cat, "Cannot send to dead socket for path {}", p);
             if (callback)
                 callback(io_result{EBADF});
             return;

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -63,7 +63,7 @@ namespace oxen::quic
         loop.call_get([&] {
             if (_is_closing || _is_shutdown || _sent_fin)
             {
-                log::warning(log_cat, "Failed to set watermarks; stream is not active!");
+                log::debug(log_cat, "Failed to set watermarks; stream is not active!");
                 return;
             }
 
@@ -189,7 +189,7 @@ namespace oxen::quic
 
             if (!_conn)
             {
-                log::warning(log_cat, "Stream close ignored: the stream's connection is gone");
+                log::debug(log_cat, "Stream close ignored: the stream's connection is gone");
                 return;
             }
 


### PR DESCRIPTION
These being warnings mean they show up in application logs, and really shouldn't as they are just business-as-usual handling of things that can happen on the network.