### PR TITLE
Add wakeable event; remove weird/unused rescheduling ticker

### DIFF
--- a/include/oxen/quic/loop.hpp
+++ b/include/oxen/quic/loop.hpp
@@ -52,7 +52,7 @@ namespace oxen::quic
     /// An event loop task that can be fired multiple times, but is triggered manually when needed
     /// to schedule a callback call on the event loop.  Unlike using `call`/`call_soon`, calls to
     /// trigger/wake the event are idempotent: i.e. the event will be called only once regardless of
-    /// how many wakeups there were prior to the call.  Once called, it will not be schedule again
+    /// how many wakeups there were prior to the call.  Once called, it will not be scheduled again
     /// until triggered at least once more.
     ///
     /// Construct via Loop::make_wakeable().

--- a/include/oxen/quic/loop.hpp
+++ b/include/oxen/quic/loop.hpp
@@ -2,7 +2,6 @@
 
 #include "utils.hpp"
 
-#include <atomic>
 #include <future>
 #include <list>
 #include <memory>
@@ -22,39 +21,53 @@ namespace oxen::quic
         friend class Loop;
 
       private:
-        std::atomic<bool> _is_running{false};
         event_ptr ev;
         timeval interval;
         std::function<void()> f;
 
         void init_event(
-                ::event_base* loop,
-                std::chrono::microseconds _t,
-                std::function<void()> task,
-                bool one_off = false,
-                bool start_immediately = true,
-                bool task_rescheduling = false);
+                ::event_base* loop, std::chrono::microseconds _t, std::function<void()> task, bool start_immediately = true);
 
         Ticker() = default;
 
       public:
         ~Ticker();
 
-        bool is_running() const { return _is_running; }
-
-        /** Starts the repeating event on the given interval on Ticker creation
+        /** Starts the repeating event on the given interval on Ticker creation.  Does nothing if
+         *   already active.
             Returns:
                 - true: event successfully started
                 - false: event is already running, or failed to start the event
          */
         bool start();
 
-        /** Stops the repeating event managed by Ticker
+        /** Stops the repeating event managed by Ticker.  Does nothing if not currently active.
             Returns:
                 - true: event successfully stopped
                 - false: event is already stopped, or failed to stop the event
          */
         bool stop();
+    };
+
+    /// An event loop task that can be fired multiple times, but is triggered manually when needed
+    /// to schedule a callback call on the event loop.  Unlike using `call`/`call_soon`, calls to
+    /// trigger/wake the event are idempotent: i.e. the event will be called only once regardless of
+    /// how many wakeups there were prior to the call.  Once called, it will not be schedule again
+    /// until triggered at least once more.
+    ///
+    /// Construct via Loop::make_wakeable().
+    class Wakeable
+    {
+        friend class Loop;
+
+        event_ptr ev;
+        std::function<void()> f;
+
+        Wakeable() = default;
+
+      public:
+        /// Call to schedule f() to be called, if not already scheduled.
+        void wake();
     };
 
     class Loop
@@ -68,26 +81,18 @@ namespace oxen::quic
         std::queue<Job> job_queue;
         std::mutex job_queue_mutex;
 
-        template <std::invocable<> Callable>
-        void add_oneshot_event(std::chrono::microseconds delay, Callable hook)
-        {
-            auto handler = make_shared<Ticker>();
-            auto& h = *handler;
-
-            h.init_event(
-                    get_event_base(),
-                    delay,
-                    [hndlr = std::move(handler), func = std::move(hook)]() mutable {
-                        auto h = std::move(hndlr);
-                        func();
-                    },
-                    true);
-        }
+        void add_oneshot_event(std::chrono::microseconds delay, std::function<void()> hook);
 
       private:
         std::list<std::weak_ptr<Ticker>> tickers;
 
         std::shared_ptr<Ticker> make_ticker();
+
+        // call_later events aren't guaranteed to get properly disposed off if the event loop stops
+        // before it fires, so we stash it in here temporarily and remove it when fired.  During the
+        // Loop destructor, then, if there's anything left that's one that needs to be cleaned up.
+        struct OneShotDelayed;
+        std::list<OneShotDelayed*> delayed_events;
 
       public:
         Loop();
@@ -194,35 +199,22 @@ namespace oxen::quic
 
         /// Sets up a task `f()` to be called on the event loop periodically.
         ///
+        /// `interval` controls the interval on which the task will be called.
+        ///
         /// `start_immediately` controls whether the task is scheduled on the event loop right away
         /// (true, the default), or not (false).  If not started immediately then the task will not
         /// fire until `start()` is called on it.  (Note that this parameter does not mean "call
         /// immediately" -- it simply controls whether the initial timer for the first call is
         /// started or not).
         ///
-        /// `task_rescheduling=false` (the default) schedules a call to the task at the
-        /// given interval.  For example, "call this every 10 seconds."
-        ///
-        /// `task_rescheduling=true` waits until the completion of each task before rescheduling
-        /// another call of the callback `interval` later.  That is, if the task itself  takes a
-        /// long time or other action on the event loop delayed it, that will also delay all later
-        /// invocations.  For example, "call this repeatedly with 10 seconds between calls."
-        ///
-        /// `task_rescheduling=true` is equivalent to using a one-shot `call_later` that reschedules
-        /// itself with another `call_later` at the end of each invocation.
-        ///
         /// The ticker will remain active as long the loop remains active and the returned Ticker
         /// object is kept alive.
         template <std::invocable<> Callable>
         [[nodiscard]] std::shared_ptr<Ticker> call_every(
-                std::chrono::microseconds interval,
-                Callable&& f,
-                bool start_immediately = true,
-                bool task_rescheduling = false)
+                std::chrono::microseconds interval, Callable&& f, bool start_immediately = true)
         {
             auto h = make_ticker();
-            h->init_event(
-                    get_event_base(), interval, std::forward<Callable>(f), false, start_immediately, task_rescheduling);
+            h->init_event(get_event_base(), interval, std::forward<Callable>(f), start_immediately);
             return h;
         }
 
@@ -247,6 +239,12 @@ namespace oxen::quic
                 });
             }
         }
+
+        /// Creates a Wakeable event tied to this event loop that can be manually triggered when
+        /// desired to schedule an invocation of the callback.  Unlike call_soon, this is idempotent
+        /// (i.e. multiple wakeups before it actually runs does not schedule multiple calls).  Note
+        /// that this call only constructs the event, but does not initially schedule it.
+        std::shared_ptr<Wakeable> make_wakeable(std::function<void()> hook);
 
         static void activate(::event& evt);
 

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -193,8 +193,8 @@ namespace oxen::quic
             }
         }
 
-        for (auto* ods : delayed_events)
-            delete ods;
+        for (auto* osd : delayed_events)
+            delete osd;
         delayed_events.clear();
 
         event_base_loopbreak(ev_loop.get());

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -33,76 +33,47 @@ namespace oxen::quic
         });
     }
 
-    /** Static casting to `decltype(timeval::tv_{sec,usec})` makes sure that;
-        - on linux
-            .tv_sec is type __time_t
-            .tv_usec is type __suseconds_t
-        - on OSX    (https://developer.apple.com/documentation/kernel/timeval)
-            .tv_sec is type __darwin_time_t
-                - this is an annoying typedef of `time_t`
-            .tv_usec is type __darwin_suseconds_t
-                - this is an equally annoying typedef for `suseconds_t`
-        Alas, yet again another mac idiosyncrasy...
-     */
     static timeval loop_time_to_timeval(std::chrono::microseconds t)
     {
-        return timeval{
-                .tv_sec = static_cast<decltype(timeval::tv_sec)>(t / 1s),
-                .tv_usec = static_cast<decltype(timeval::tv_usec)>((t % 1s) / 1us)};
+#ifdef _WIN32
+        using suseconds_t = long;
+#endif
+        return timeval{.tv_sec = static_cast<time_t>(t / 1s), .tv_usec = static_cast<suseconds_t>((t % 1s) / 1us)};
     }
 
     bool Ticker::start()
     {
-        if (_is_running)
-            return false;
-
         if (event_add(ev.get(), &interval) != 0)
         {
             log::warning(log_cat, "EventHandler failed to start repeating event!");
             return false;
         }
 
-        _is_running = true;
-
         return true;
     }
 
     bool Ticker::stop()
     {
-        if (not _is_running)
-            return false;
-
         if (event_del(ev.get()) != 0)
         {
             log::warning(log_cat, "EventHandler failed to pause repeating event!");
             return false;
         }
 
-        _is_running = false;
-
         return true;
     }
 
     void Ticker::init_event(
-            ::event_base* loop,
-            std::chrono::microseconds _t,
-            std::function<void()> task,
-            bool one_off,
-            bool start_immediately,
-            bool task_rescheduling)
+            ::event_base* loop, std::chrono::microseconds t, std::function<void()> task, bool start_immediately)
     {
-        f = (one_off or not task_rescheduling) ? std::move(task) : [this, func = std::move(task)] {
-            func();
-            event_del(ev.get());
-            event_add(ev.get(), &interval);
-        };
+        f = std::move(task);
 
-        interval = loop_time_to_timeval(_t);
+        interval = loop_time_to_timeval(t);
 
         ev.reset(event_new(
                 loop,
                 -1,
-                task_rescheduling ? 0 : EV_PERSIST,
+                EV_PERSIST,
                 [](evutil_socket_t, short, void* s) {
                     try
                     {
@@ -122,9 +93,8 @@ namespace oxen::quic
                 },
                 this));
 
-        if (one_off or start_immediately)
-            if (not start())
-                log::warning(log_cat, "Failed to immediately start one-off event!");
+        if (start_immediately and not start())
+            log::warning(log_cat, "Failed to immediately start one-off event!");
     }
 
     Ticker::~Ticker()
@@ -202,6 +172,14 @@ namespace oxen::quic
         log::info(log_cat, "libevent loop is started");
     }
 
+    struct Loop::OneShotDelayed
+    {
+        Loop& loop;
+        std::function<void()> f;
+
+        OneShotDelayed(Loop& loop, std::function<void()> f) : loop{loop}, f{std::move(f)} {}
+    };
+
     Loop::~Loop()
     {
         log::debug(log_cat, "Shutting down loop...");
@@ -214,6 +192,10 @@ namespace oxen::quic
                 tick->stop();
             }
         }
+
+        for (auto* ods : delayed_events)
+            delete ods;
+        delayed_events.clear();
 
         event_base_loopbreak(ev_loop.get());
         loop_thread.join();
@@ -233,8 +215,32 @@ namespace oxen::quic
         return t;
     }
 
+    std::shared_ptr<Wakeable> Loop::make_wakeable(std::function<void()> callback)
+    {
+        auto w = make_shared<Wakeable>();
+        w->f = std::move(callback);
+        w->ev.reset(event_new(
+                ev_loop.get(),
+                -1,
+                0,
+                [](evutil_socket_t, short, void* w) {
+                    auto* wakeable = static_cast<Wakeable*>(w);
+                    if (wakeable->f)
+                        wakeable->f();
+                },
+                w.get()));
+        return w;
+    }
+
+    void Wakeable::wake()
+    {
+        event_active(ev.get(), 0, 0);
+    }
+
     void Loop::setup_job_waker()
     {
+        // Almost identical to the generic make_wakeable, except that we avoid the std::function and
+        // its implicit virtual function call.
         job_waker.reset(event_new(
                 ev_loop.get(),
                 -1,
@@ -245,6 +251,29 @@ namespace oxen::quic
                 },
                 this));
         assert(job_waker);
+    }
+
+    void Loop::add_oneshot_event(std::chrono::microseconds delay, std::function<void()> hook)
+    {
+        auto* handler = new OneShotDelayed{*this, std::move(hook)};
+        delayed_events.push_back(handler);
+        auto& h = *handler;
+        const auto delay_tv = loop_time_to_timeval(delay);
+        event_base_once(
+                get_event_base(),
+                -1,
+                EV_TIMEOUT,
+                [](evutil_socket_t, short, void* e) mutable {
+                    auto* h = static_cast<OneShotDelayed*>(e);
+                    if (h->f)
+                        h->f();
+                    auto& de = h->loop.delayed_events;
+                    if (auto it = std::find(de.begin(), de.end(), h); it != de.end())
+                        de.erase(it);
+                    delete h;
+                },
+                &h,
+                &delay_tv);
     }
 
     void Loop::process_job_queue()

--- a/tests/013-eventhandler.cpp
+++ b/tests/013-eventhandler.cpp
@@ -21,13 +21,7 @@ namespace oxen::quic::test
 
         std::shared_ptr<Ticker> handler;
 
-        stream_data_callback server_data_cb = [&](Stream&, std::span<const std::byte>) {
-            recv_counter += 1;
-            if (recv_counter == NUM_ITERATIONS)
-            {
-                handler->stop();
-            }
-        };
+        stream_data_callback server_data_cb = [&recv_counter](Stream&, std::span<const std::byte>) { recv_counter++; };
 
         auto [client_tls, server_tls] = defaults::tls_creds_from_ed_keys();
 
@@ -55,22 +49,69 @@ namespace oxen::quic::test
 
         handler->start();
 
-        REQUIRE(handler->is_running());
-        test_net.loop()->call_later(DELAY, [&]() { prom_a.set_value(); });
+        test_net.loop()->call_later(DELAY, [&prom_a] { prom_a.set_value(); });
 
         require_future(fut_a, 5s);
         REQUIRE(recv_counter == send_counter);
-        REQUIRE_FALSE(handler->is_running());
 
         recv_counter = 0;
         send_counter = 0;
 
         REQUIRE(handler->start());
 
-        test_net.loop()->call_later(DELAY, [&]() { prom_b.set_value(); });
+        test_net.loop()->call_later(DELAY, [&prom_b] { prom_b.set_value(); });
 
         require_future(fut_b, 5s);
         REQUIRE(recv_counter == send_counter);
-        REQUIRE_FALSE(handler->is_running());
     }
+
+    TEST_CASE("013 - Wakeable event handler", "[013][wakeable]")
+    {
+        Loop loop;
+
+        std::promise<void> prom;
+        std::atomic<int> i = 0;
+
+        auto w = loop.make_wakeable([&i, &prom] {
+            ++i;
+            prom.set_value();
+        });
+
+        w->wake();
+        auto fut = prom.get_future();
+
+        require_future(fut, 1s);
+        REQUIRE(i == 1);
+
+        std::promise<void> prom2, prom5;
+        w = loop.make_wakeable([&i, &prom2, &prom5] {
+            auto v = ++i;
+            if (v == 2)
+                prom2.set_value();
+            else if (v == 5)
+                prom5.set_value();
+        });
+
+        loop.call_get([&w] {
+            for (int i = 0; i < 100; i++)
+                w->wake();
+        });
+
+        auto fut2 = prom2.get_future();
+        require_future(fut2, 1s);
+        REQUIRE(i == 2);
+
+        loop.call_get([&w] {
+            for (int i = 0; i < 100; i++)
+                w->wake();
+        });
+        std::this_thread::sleep_for(25ms);
+        w->wake();
+        std::this_thread::sleep_for(25ms);
+        w->wake();
+        auto fut5 = prom5.get_future();
+        require_future(fut5, 1s);
+        REQUIRE(i == 5);
+    }
+
 }  //  namespace oxen::quic::test


### PR DESCRIPTION
Adds quic::Wakeable/loop.make_wakeable() that lets you create an idempotent triggerable event so that you can fire at it many times without worrying about triggering it multiple times.

Also removes the "task_rescheduling" option from Trigger because it isn't used anywhere and was fairly useless.

Also removes Trigger's _is_running bool, because `start()` and `stop()` are underlying calls to libevent that are already idempotent and don't need an atomic bool around them.