### PR TITLE
0RTT API improvements and default tweaks

### DIFF
--- a/include/oxen/quic/gnutls_crypto.hpp
+++ b/include/oxen/quic/gnutls_crypto.hpp
@@ -438,6 +438,9 @@ namespace oxen::quic
             negative durations will use gnutls's default (6h).  The maximum validity period allowed
             by GNUTLS is one week (604800 seconds).
 
+          - max_early_data -- the maximum early data size for inbound connections.  If omitted or 0
+            then this uses the default (currently 32kiB).
+
           - anti_replay_add -- this optional callback allows for manual storage and retrieval of
             anti-replay data.  It is passed three values: a key, a value, and the earliest time at
             which the key may be expired.  If given a nullptr or empty func then default internal
@@ -481,6 +484,7 @@ namespace oxen::quic
         void enable_inbound_0rtt(
                 std::chrono::milliseconds anti_replay_window = 0s,
                 std::chrono::seconds ticket_validity = 0s,
+                size_t max_early_data = 0,
                 anti_replay_add_cb anti_replay_add = nullptr,
                 std::span<const unsigned char> master_key = {});
 
@@ -568,6 +572,7 @@ namespace oxen::quic
         int session_ticket_expiration = 0;
         gnutls_anti_replay_t anti_replay = nullptr;
         anti_replay_add_cb anti_replay_add;
+        size_t max_early_data = 32_ki;
         store_callback session_store;
         extract_callback session_extract;
 

--- a/include/oxen/quic/gnutls_crypto.hpp
+++ b/include/oxen/quic/gnutls_crypto.hpp
@@ -358,8 +358,8 @@ namespace oxen::quic
         gnutls_datum_t* datum() { return &_data; }
     };
 
-    using store_callback = std::function<void(
-            RemoteAddress remote, std::vector<unsigned char> data, std::chrono::system_clock::time_point expiry)>;
+    using store_callback =
+            std::function<void(RemoteAddress remote, std::vector<unsigned char> data, std::chrono::sys_seconds expiry)>;
     using extract_callback = std::function<std::optional<std::vector<unsigned char>>(const RemoteAddress& remote)>;
 
     class GNUTLSCreds : public TLSCreds
@@ -373,9 +373,7 @@ namespace oxen::quic
         static std::shared_ptr<GNUTLSCreds> make_from_ed_seckey(std::string_view sk);
 
         using anti_replay_add_cb = std::function<bool(
-                std::span<const unsigned char> key,
-                std::span<const unsigned char> value,
-                std::chrono::system_clock::time_point expiry)>;
+                std::span<const unsigned char> key, std::span<const unsigned char> value, std::chrono::sys_seconds expiry)>;
 
         ~GNUTLSCreds();
 

--- a/include/oxen/quic/gnutls_crypto.hpp
+++ b/include/oxen/quic/gnutls_crypto.hpp
@@ -552,7 +552,8 @@ namespace oxen::quic
           available; the `store` function will still be given session tickets even if 0-RTT was not
           used for the connection.
          */
-        void enable_outbound_0rtt(store_callback store = {}, extract_callback extract = {});
+        void enable_outbound_0rtt(store_callback store, extract_callback extract);
+        void enable_outbound_0rtt();
 
         /// Returns true if outbound 0-RTT callbacks have been configured.
         bool outbound_0rtt() const override { return static_cast<bool>(session_extract); }

--- a/src/gnutls_crypto.cpp
+++ b/src/gnutls_crypto.cpp
@@ -311,11 +311,17 @@ namespace oxen::quic
     void GNUTLSCreds::enable_inbound_0rtt(
             std::chrono::milliseconds anti_replay_window,
             std::chrono::seconds ticket_validity,
+            size_t max_early,
             anti_replay_add_cb anti_replay_add_,
             std::span<const unsigned char> master_key)
     {
         if (inbound_0rtt())
             throw std::logic_error{"Inbound 0-RTT is already enabled for this GNUTLSCreds instance"};
+
+        if (max_early == 0)
+            max_early_data = 32_ki;
+        else
+            max_early_data = max_early;
 
         session_ticket_key.sensitive = true;
         session_ticket_key.reset();
@@ -699,7 +705,7 @@ namespace oxen::quic
                     gnutls_db_set_cache_expiration(session, creds.session_ticket_expiration);
 
                 gnutls_anti_replay_enable(session, creds.anti_replay);
-                gnutls_record_set_max_early_data_size(session, 1048576);
+                gnutls_record_set_max_early_data_size(session, creds.max_early_data);
                 if (auto rv = gnutls_session_ticket_enable_server(session, creds.session_ticket_key); rv != 0)
                     log::error(
                             log_cat,

--- a/src/gnutls_crypto.cpp
+++ b/src/gnutls_crypto.cpp
@@ -441,6 +441,10 @@ namespace oxen::quic
         session_extract = std::move(extract);
         log::debug(log_cat, "0-RTT support enabled for outbound connections");
     }
+    void GNUTLSCreds::enable_outbound_0rtt()
+    {
+        enable_outbound_0rtt(nullptr, nullptr);
+    }
 
     void GNUTLSCreds::store_session_ticket(Connection& conn, RemoteAddress addr, std::span<const unsigned char> ticket_data)
     {

--- a/src/gnutls_crypto.cpp
+++ b/src/gnutls_crypto.cpp
@@ -267,7 +267,7 @@ namespace oxen::quic
             accepted = creds.anti_replay_add(
                     std::span<const unsigned char>{key->data, key->size},
                     std::span<const unsigned char>{data->data, data->size},
-                    std::chrono::system_clock::from_time_t(exp_time));
+                    std::chrono::time_point_cast<std::chrono::seconds>(std::chrono::system_clock::from_time_t(exp_time)));
             log::debug(log_cat, "anti-replay storage {} incoming key", accepted ? "accepted" : "REJECTED");
         }
         catch (const std::exception& e)
@@ -458,7 +458,8 @@ namespace oxen::quic
 
         gnutls_datum_t gticket_data{
                 const_cast<unsigned char*>(ticket_data.data()), static_cast<unsigned int>(ticket_data.size())};
-        auto expiry = std::chrono::system_clock::from_time_t(gnutls_db_check_entry_expire_time(&gticket_data));
+        auto expiry = std::chrono::time_point_cast<std::chrono::seconds>(
+                std::chrono::system_clock::from_time_t(gnutls_db_check_entry_expire_time(&gticket_data)));
         if (expiry.time_since_epoch() == 0s)
         {
             log::error(log_cat, "Unable to store session ticket: failed to extract expiry time from TLS session ticket");


### PR DESCRIPTION
- Make the 0RTT callbacks take a sys_seconds instead of full time_point: we only get time_t's out of gnutls, and so it seems pointless to pretend to have more precision than that.  (Plus sys_seconds is convertible to a full time_point so you can still pass a lambda taking that if you like).
- The early_data size was huge and not configurable.  This makes it configurable, and makes it less huge (32kiB instead of 1MiB).