### PR TITLE
No-credential connections and 0-RTT fixes

### DIFF
--- a/include/oxen/quic/connection.hpp
+++ b/include/oxen/quic/connection.hpp
@@ -310,8 +310,9 @@ namespace oxen::quic
         Endpoint& endpoint() { return _endpoint; }
         const Endpoint& endpoint() const { return _endpoint; }
 
-        // Returns the connection's negotiated ALPN.  Only available after connection handshake;
-        // before that this will return an empty string.
+        // Returns the connection's negotiated ALPN.  Only available after the connection is
+        // established (typically once handshaked, but can be earlier for an incoming 0-RTT
+        // connection).  Before that this will return an empty string.
         std::string_view selected_alpn() const;
 
         size_t get_max_datagram_piece() const;
@@ -444,6 +445,13 @@ namespace oxen::quic
         bool closing = false;
         bool handshaked = false;
         bool handshake_confirmed = false;
+
+        // There are multiple points at which we can call the conn_established_cb: in a normal 1-RTT
+        // connection, it happens after handshake completes, but with 0-RTT it can happen when early
+        // stream or datagram data is received *before* handshake completes.  check_established() is
+        // called from the various locations, and invokes the callback the first time it is called.
+        void check_established();
+        bool establish_hook_called = false;
 
         // Invokes the stream_construct_cb, if present; if not present, or if it returns nullptr,
         // then the given `make_stream` gets invoked to create a default stream.

--- a/include/oxen/quic/connection.hpp
+++ b/include/oxen/quic/connection.hpp
@@ -106,6 +106,10 @@ namespace oxen::quic
         TLSSession* get_session() const { return tls_session.get(); }
         TLSCreds* get_creds() const { return tls_creds.get(); }
 
+        // Returns the remote pubkey, if known (and empty otherwise).  For a client this is known
+        // from construction; for a server, this is known only after handshake completes, but even
+        // then might not be known if a client pubkey is not required for incoming connections (see
+        // GNUTLSCreds).
         std::span<const unsigned char> remote_key() const;
 
         Direction direction() const { return dir; }
@@ -297,6 +301,12 @@ namespace oxen::quic
         bool is_inbound() const { return not is_outbound(); }
         std::string direction_str() { return is_inbound() ? "SERVER"s : "CLIENT"s; }
 
+        // Returns true if handshaking has finished on this connection.
+        bool is_handshaked() const { return handshaked; }
+        // Returns true if handshaking is finished on this connection and confirmed on the server.
+        // (For incoming connections, this will always be the same as is_handshaked()).
+        bool is_handshake_confirmed() const { return handshake_confirmed; }
+
         Endpoint& endpoint() { return _endpoint; }
         const Endpoint& endpoint() const { return _endpoint; }
 
@@ -305,9 +315,6 @@ namespace oxen::quic
         size_t get_max_datagram_piece() const;
 
         std::optional<size_t> max_datagram_size_changed();
-
-        // True if the connection has been accepted and the remote pubkey successfully verified.
-        bool is_validated() const { return _is_validated; }
 
         const ConnectionID& reference_id() const { return _ref_id; }
 
@@ -318,12 +325,7 @@ namespace oxen::quic
       private:
         void packet_io_ready();
         void halt_events();
-        void set_closing() { closing = true; }
-        void set_draining() { draining = true; }
         stream_data_callback get_default_data_callback() const;
-
-        // This mutator is called from the gnutls code after cert verification (if it is successful)
-        void set_validated();
 
         connection_established_callback conn_established_cb;
         connection_closed_callback conn_closed_cb;
@@ -339,6 +341,7 @@ namespace oxen::quic
         const std::unordered_set<hashed_reset_token>& associated_reset_tokens() const { return _associated_resets; }
 
         int client_handshake_completed();
+        void client_handshake_confirmed();
 
         int server_handshake_completed();
 
@@ -402,8 +405,6 @@ namespace oxen::quic
         mutable std::atomic<bool> _max_dgram_size_changed{true};
 
         std::atomic<bool> _close_quietly{false};
-        std::atomic<bool> _is_validated{false};
-
         std::vector<unsigned char> remote_pubkey{};
 
         void revert_early_channels();
@@ -439,6 +440,8 @@ namespace oxen::quic
 
         bool draining = false;
         bool closing = false;
+        bool handshaked = false;
+        bool handshake_confirmed = false;
 
         // Invokes the stream_construct_cb, if present; if not present, or if it returns nullptr,
         // then the given `make_stream` gets invoked to create a default stream.

--- a/include/oxen/quic/connection.hpp
+++ b/include/oxen/quic/connection.hpp
@@ -310,6 +310,8 @@ namespace oxen::quic
         Endpoint& endpoint() { return _endpoint; }
         const Endpoint& endpoint() const { return _endpoint; }
 
+        // Returns the connection's negotiated ALPN.  Only available after connection handshake;
+        // before that this will return an empty string.
         std::string_view selected_alpn() const;
 
         size_t get_max_datagram_piece() const;

--- a/include/oxen/quic/crypto.hpp
+++ b/include/oxen/quic/crypto.hpp
@@ -81,6 +81,10 @@ namespace oxen::quic
         // Returns true if client-side 0-RTT is enabled
         virtual bool outbound_0rtt() const = 0;
 
+        // Returns true if this credential has actual credentials set.  Unauthenticating credential
+        // objects are only usable for outbound connections.
+        virtual bool has_credentials() const = 0;
+
         virtual ~TLSCreds() = default;
     };
 
@@ -90,8 +94,8 @@ namespace oxen::quic
         ngtcp2_crypto_conn_ref conn_ref;
         virtual void* get_session() = 0;
         virtual bool get_early_data_accepted() const = 0;
-        virtual std::string_view selected_alpn() const = 0;
-        virtual std::span<const unsigned char> remote_key() const = 0;
+        virtual std::string_view selected_alpn() = 0;
+        virtual std::span<const unsigned char> remote_key() = 0;
 
         // If this session loaded 0-rtt data, this will return the encoded transport data to be
         // loaded into the ngtcp2 connection to enable 0-RTT.  Note that the value is transferred to

--- a/include/oxen/quic/endpoint.hpp
+++ b/include/oxen/quic/endpoint.hpp
@@ -54,7 +54,9 @@ namespace oxen::quic
         template <typename... Opt>
         void listen(Opt&&... opts)
         {
-            check_for_tls_creds<Opt...>();
+            static_assert(
+                    (0 + ... + std::is_convertible_v<std::remove_cvref_t<Opt>, std::shared_ptr<TLSCreds>>) == 1,
+                    "listen() requires exactly one std::shared_ptr<TLSCreds> argument");
 
             loop.call_get([&opts..., this]() {
                 if (inbound_ctx)
@@ -70,7 +72,9 @@ namespace oxen::quic
         template <typename... Opt>
         std::shared_ptr<Connection> connect(RemoteAddress remote, Opt&&... opts)
         {
-            check_for_tls_creds<Opt...>();
+            static_assert(
+                    (0 + ... + std::is_convertible_v<std::remove_cvref_t<Opt>, std::shared_ptr<TLSCreds>>) <= 1,
+                    "connect() requires at most one std::shared_ptr<TLSCreds> argument");
 
             if (not _manual_routing and !remote.is_addressable())
                 throw std::invalid_argument("Address must be addressable to connect");
@@ -370,14 +374,6 @@ namespace oxen::quic
         //     else.
         std::pair<Connection*, bool> accept_initial_connection(const Packet& pkt);
         Connection* check_stateless_reset(const Packet& pkt);
-
-        template <typename... Opt>
-        static constexpr void check_for_tls_creds()
-        {
-            static_assert(
-                    (0 + ... + std::is_convertible_v<std::remove_cvref_t<Opt>, std::shared_ptr<TLSCreds>>) == 1,
-                    "Endpoint listen/connect require exactly one std::shared_ptr<TLSCreds> argument");
-        }
     };
 
 }  // namespace oxen::quic

--- a/include/oxen/quic/gnutls_crypto.hpp
+++ b/include/oxen/quic/gnutls_crypto.hpp
@@ -133,23 +133,7 @@ namespace oxen::quic
         }
     };
 
-    struct gtls_key final : std::array<unsigned char, GNUTLS_KEY_SIZE>
-    {
-        gtls_key() = default;
-        gtls_key(const unsigned char* data, size_t size) { write(data, size); }
-        explicit gtls_key(std::string_view data) : gtls_key{reinterpret_cast<const unsigned char*>(data.data()), data.size()}
-        {}
-        explicit gtls_key(std::span<const unsigned char> data) : gtls_key{data.data(), data.size()} {}
-
-        //  Writes to the internal buffer holding the gnutls key
-        void write(const unsigned char* buf, size_t size)
-        {
-            if (size != GNUTLS_KEY_SIZE)
-                throw std::invalid_argument{"GNUTLS key must be 32 bytes!"};
-
-            std::memcpy(data(), buf, size);
-        }
-    };
+    using gtls_key = std::array<unsigned char, GNUTLS_KEY_SIZE>;
 
     // key: remote key to verify, alpn: negotiated alpn's
     using key_verify_callback = std::function<bool(std::span<const unsigned char> key, std::string_view alpn)>;
@@ -367,10 +351,17 @@ namespace oxen::quic
         friend class GNUTLSSession;
 
         GNUTLSCreds(std::string_view ed_seed, std::string_view ed_pubkey);
+        GNUTLSCreds();
 
       public:
+        // Construct a credentials object from a Ed25519 seed and pubkey.  (The seed may optionally
+        // be a combined seed+pk libsodium 64-byte value; only the first 32 bytes are used).
         static std::shared_ptr<GNUTLSCreds> make_from_ed_keys(std::string_view seed, std::string_view pubkey);
+        // Construct a credentials object from a Ed25519 combined seed/pubkey value.
         static std::shared_ptr<GNUTLSCreds> make_from_ed_seckey(std::string_view sk);
+        // Constructs a no-credentials object.  This object may *only* be used for client
+        // connections, and will fail if the server is configured to require a client certificate.
+        static std::shared_ptr<GNUTLSCreds> make_unauthenticated();
 
         using anti_replay_add_cb = std::function<bool(
                 std::span<const unsigned char> key,
@@ -555,14 +546,19 @@ namespace oxen::quic
         /// Returns true if outbound 0-RTT callbacks have been configured.
         bool outbound_0rtt() const override { return static_cast<bool>(session_extract); }
 
+        bool has_credentials() const override { return has_creds; }
+
       private:
         gnutls_pcert_st pcrt;
         gnutls_privkey_t pkey;
-        const bool using_raw_pk{false};
+        const bool using_raw_pk{true};  // Currently always true, but might get changed in the future
+        bool has_creds{false};
 
         gnutls_certificate_credentials_t cred;
 
-        key_verify_callback key_verify;
+        key_verify_callback client_key_verify;
+        bool ccert_required = false;
+        bool ccert_requested = false;
 
         gnutls_priority_t priority_cache;
 
@@ -588,7 +584,42 @@ namespace oxen::quic
 
         void load_keys(x509_loader& seed, x509_loader& pk);
 
-        void set_key_verify_callback(key_verify_callback cb) { key_verify = std::move(cb); }
+        /// Called to require an incoming connection to provide a certificate, to be verified by the
+        /// given callback which returns true to allow the connection, false to reject it.  Clients
+        /// without a certificate will be unable to establish a connection.
+        ///
+        /// This callback will *not* be invoked for 0-RTT connections (which are considered to be
+        /// resumptions of an existing connection, rather than a whole new one, and so do not verify
+        /// keys again).
+        ///
+        /// If `cb` is unset, a certificate will still be required, but any valid pubkey will be
+        /// allowed.
+        ///
+        /// This call does nothing when using the Creds object for an outgoing connection.
+        void require_client_keys(key_verify_callback cb);
+
+        /// Called to request a certificate from an incoming connection.  If the client does not
+        /// provide one, the verify callback will be called with an empty `key` argument to allow
+        /// the callback to decide whether to allow the no-pubkey connection (for example, based on
+        /// the negotiated ALPN passed to the verify function).  If a client key is available, it is
+        /// passed (as it would be with require_client_keys()).
+        ///
+        /// An omitted callback will allow all connections, but unlike `disable_client_keys()` it
+        /// still requests the pubkeys and so the pubkeys of clients will still be available when
+        /// provided by the client via `remote_key()`.
+        ///
+        /// As with `require_client_keys`, accepted 0-RTT re-established connections bypass this
+        /// call.
+        ///
+        /// This call only has an effect on incoming connections.
+        void request_client_keys(key_verify_callback cb);
+
+        /// Call to disable requiring or requesting of client certificates.  All incoming
+        /// connections will be accepted regardless of pubkey, client certs will not be requested,
+        /// and `remote_key()` will be empty for all incoming connections.
+        ///
+        /// This is the default is none of request/require/disable_client_keys is called.
+        void disable_client_keys();
     };
 
     class GNUTLSSession : public TLSSession
@@ -603,10 +634,13 @@ namespace oxen::quic
 
         std::string _selected_alpn{};
         std::optional<gtls_key> _expected_remote_key;
-        gtls_key _remote_key{};
+        std::optional<gtls_key> _remote_key;
         std::optional<std::vector<unsigned char>> _0rtt_tp_data;
 
-        void set_selected_alpn();
+        bool _loaded_remote_key = false;
+        bool _loaded_alpn = false;
+        void load_selected_alpn();
+        void load_remote_key();
 
       public:
         GNUTLSSession(
@@ -631,9 +665,9 @@ namespace oxen::quic
             return gnutls_session_get_flags(session) & GNUTLS_SFLAGS_EARLY_DATA;
         }
 
-        std::span<const unsigned char> remote_key() const override { return _remote_key; }
+        std::span<const unsigned char> remote_key() override;
 
-        std::string_view selected_alpn() const override { return _selected_alpn; }
+        std::string_view selected_alpn() override;
 
         bool validate_remote_key();
 
@@ -643,13 +677,3 @@ namespace oxen::quic
     };
 
 }  // namespace oxen::quic
-
-// gtls_key hasher
-template <>
-struct std::hash<oxen::quic::gtls_key>
-{
-    size_t operator()(const oxen::quic::gtls_key& key) const
-    {
-        return std::hash<std::string_view>{}(std::string_view{reinterpret_cast<const char*>(key.data()), key.size()});
-    }
-};

--- a/include/oxen/quic/gnutls_crypto.hpp
+++ b/include/oxen/quic/gnutls_crypto.hpp
@@ -359,8 +359,9 @@ namespace oxen::quic
         static std::shared_ptr<GNUTLSCreds> make_from_ed_keys(std::string_view seed, std::string_view pubkey);
         // Construct a credentials object from a Ed25519 combined seed/pubkey value.
         static std::shared_ptr<GNUTLSCreds> make_from_ed_seckey(std::string_view sk);
-        // Constructs a no-credentials object.  This object may *only* be used for client
-        // connections, and will fail if the server is configured to require a client certificate.
+        // Constructs a no-credentials object.  This object may *only* be used for outbound
+        // connections, and connections using it will fail if the server is configured to require a
+        // client certificate.
         static std::shared_ptr<GNUTLSCreds> make_unauthenticated();
 
         using anti_replay_add_cb = std::function<bool(

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -1625,7 +1625,7 @@ namespace oxen::quic
 
     std::string_view Connection::selected_alpn() const
     {
-        return _loop.call_get([this]() { return get_session()->selected_alpn(); });
+        return _loop.call_get([this]() { return handshaked ? get_session()->selected_alpn() : ""sv; });
     }
 
     uint64_t Connection::get_streams_available_impl() const

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -3,6 +3,7 @@
 #include "context.hpp"
 #include "datagram.hpp"
 #include "endpoint.hpp"
+#include "gnutls_crypto.hpp"
 #include "internal.hpp"
 #include "iochannel.hpp"
 #include "result.hpp"
@@ -201,6 +202,8 @@ namespace oxen::quic
             // server should never call this, as it "confirms" on handshake completed
             assert(conn->is_outbound());
             log::trace(log_cat, "HANDSHAKE CONFIRMED on CLIENT connection");
+
+            conn->client_handshake_confirmed();
 
             if (conn->conn_established_cb)
                 conn->conn_established_cb(*conn);
@@ -494,6 +497,8 @@ namespace oxen::quic
 
     int Connection::client_handshake_completed()
     {
+        handshaked = true;
+
         if (tls_creds->outbound_0rtt())
         {
             const bool accepted = tls_session->get_early_data_accepted();
@@ -518,9 +523,18 @@ namespace oxen::quic
 
         return 0;
     }
+    void Connection::client_handshake_confirmed()
+    {
+        handshake_confirmed = true;
+    }
 
     int Connection::server_handshake_completed()
     {
+        handshaked = true;
+        handshake_confirmed = true;
+        auto key = get_session()->remote_key();
+        remote_pubkey.assign(key.begin(), key.end());  // Can be empty if client key not required
+
         if (tls_creds->inbound_0rtt())
         {
             log::debug(log_cat, "Server handshake completed and we support 0-RTT, sending TLS tickets");
@@ -566,17 +580,6 @@ namespace oxen::quic
         log::debug(log_cat, "Server successfully submitted regular token on handshake completion...");
 
         return 0;
-    }
-
-    void Connection::set_validated()
-    {
-        _is_validated = true;
-
-        if (is_inbound())
-        {
-            auto key = get_session()->remote_key();
-            remote_pubkey.assign(key.begin(), key.end());
-        }
     }
 
     void Connection::set_remote_addr(const ngtcp2_addr& new_remote)
@@ -1787,6 +1790,16 @@ namespace oxen::quic
             _packet_splitting{context->config.split_packet},
             tls_creds{context->tls_creds}
     {
+        if (is_outbound())
+        {
+            if (!tls_creds)
+                tls_creds = GNUTLSCreds::make_unauthenticated();
+        }
+        else
+        {
+            assert(tls_creds && tls_creds->has_credentials());
+        }
+
         // If a connection_{established/closed}_callback was passed to IOContext via `Endpoint::{listen,connect}(...)`...
         //  - If this is an outbound, steal the callback to be used once. Outbound connections
         //    generate a new IOContext for each call to `::connect(...)`

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -156,7 +156,7 @@ namespace oxen::quic
             if (rv == 0)
             {
                 // We store the client initial DCID as that will be used by 0-RTT packets that
-                // arrive before the handshake completes.  However, since we didn't get the safely
+                // arrive before the handshake completes.  However, since we didn't get to safely
                 // choose this, we only set if it not already used (so that a possible collision
                 // between the temporary dcid and some scid we generated properly yields to the
                 // latter).
@@ -184,10 +184,7 @@ namespace oxen::quic
             {
                 rv = conn->server_handshake_completed();
 
-                if (conn->conn_established_cb)
-                    conn->conn_established_cb(*conn);
-                else
-                    conn->endpoint().connection_established(*conn);
+                conn->check_established();
             }
             else
                 rv = conn->client_handshake_completed();
@@ -205,10 +202,7 @@ namespace oxen::quic
 
             conn->client_handshake_confirmed();
 
-            if (conn->conn_established_cb)
-                conn->conn_established_cb(*conn);
-            else
-                conn->endpoint().connection_established(*conn);
+            conn->check_established();
 
             return 0;
         }
@@ -495,6 +489,19 @@ namespace oxen::quic
         return 0;
     }
 
+    void Connection::check_established()
+    {
+        if (establish_hook_called)
+            return;
+        establish_hook_called = true;
+        auto key = get_session()->remote_key();
+        remote_pubkey.assign(key.begin(), key.end());  // Can be empty if client key not required
+        if (conn_established_cb)
+            conn_established_cb(*this);
+        else
+            endpoint().connection_established(*this);
+    }
+
     int Connection::client_handshake_completed()
     {
         handshaked = true;
@@ -532,8 +539,6 @@ namespace oxen::quic
     {
         handshaked = true;
         handshake_confirmed = true;
-        auto key = get_session()->remote_key();
-        remote_pubkey.assign(key.begin(), key.end());  // Can be empty if client key not required
 
         if (tls_creds->inbound_0rtt())
         {
@@ -1340,6 +1345,12 @@ namespace oxen::quic
 
     int Connection::stream_opened(int64_t id)
     {
+        if (!establish_hook_called)
+        {
+            log::debug(log_cat, "Early stream opened before handshake completed; firing established cb");
+            check_established();
+        }
+
         log::trace(log_cat, "New stream ID:{}", id);
 
         if (auto itr = _stream_queue.find(id); itr != _stream_queue.end())
@@ -1548,6 +1559,12 @@ namespace oxen::quic
     {
         log::trace(log_cat, "Connection (CID: {}) received datagram: {}", _source_cid, buffer_printer{data});
 
+        if (!establish_hook_called)
+        {
+            log::debug(log_cat, "Early datagram received before handshake completed; firing established cb");
+            check_established();
+        }
+
         assert(dgrams);  // This callback shouldn't have been set up if we don't have datagrams
 
         std::optional<std::vector<std::byte>> maybe_data;
@@ -1627,7 +1644,8 @@ namespace oxen::quic
 
     std::string_view Connection::selected_alpn() const
     {
-        return _loop.call_get([this]() { return handshaked ? get_session()->selected_alpn() : ""sv; });
+        return _loop.call_get(
+                [this]() { return (handshaked or establish_hook_called) ? get_session()->selected_alpn() : ""sv; });
     }
 
     uint64_t Connection::get_streams_available_impl() const

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -1354,6 +1354,8 @@ namespace oxen::quic
             assert(ins);
             return 0;
         }
+        else if (id == next_incoming_stream_id)
+            next_incoming_stream_id += 4;
 
         auto stream = construct_stream(nullptr, id);
 

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -10,8 +10,10 @@ namespace oxen::quic
 {
     void IOContext::_init()
     {
-        if (tls_creds == nullptr)
-            throw std::runtime_error{"Session IOContext requires some form of TLS credentials to operate"};
+        if (dir == Direction::INBOUND && (!tls_creds || !tls_creds->has_credentials()))
+            throw std::logic_error{"listen() requires full TLS credentials"};
+        // For outbound we allow no creds; connect will create a default, non-credential object if
+        // we give it a outbound null creds.
 
         log::debug(log_cat, "{} IO context created successfully", (dir == Direction::OUTBOUND) ? "Outbound"s : "Inbound"s);
     }

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -272,7 +272,7 @@ namespace oxen::quic
             return;
 
         conn.halt_events();
-        conn.set_draining();
+        conn.draining = true;
 
         const auto* err = ngtcp2_conn_get_ccerr(conn);
 
@@ -415,7 +415,7 @@ namespace oxen::quic
             return;
 
         // mark connection as closing so that if we re-enter we won't try closing a second time
-        conn.set_closing();
+        conn.closing = true;
         conn.halt_events();
 
         if (ec.ngtcp2_code() == NGTCP2_ERR_IDLE_CLOSE)
@@ -494,7 +494,7 @@ namespace oxen::quic
         const auto& rid = conn.reference_id();
 
         conn.halt_events();
-        conn.set_closing();
+        conn.closing = true;
 
         log::debug(log_cat, "Deleting associated CIDs for connection {}", rid);
 

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -385,6 +385,14 @@ namespace oxen::quic
         {
             conn.close_all_streams();
 
+            if (conn.is_inbound() && !conn.is_handshake_confirmed()) {
+                // For inbound connections we fire the connection-established callback immediately
+                // after setting handshaked to true, so if we *haven't* done that yet, don't call
+                // the close callback because other the first time the application would learn of
+                // the connection is by a close callback firing on a connection it has never seen
+                // before (other than, perhaps, a key verification callback).
+                return;
+            }
             // prioritize connection level callback over endpoint level
             if (conn.conn_closed_cb)
             {

--- a/src/gnutls_crypto.cpp
+++ b/src/gnutls_crypto.cpp
@@ -856,6 +856,16 @@ namespace oxen::quic
 
         auto cert_type = gnutls_certificate_type_get2(session, GNUTLS_CTYPE_PEERS);
 
+        uint32_t cert_list_size = 0;
+        const gnutls_datum_t* cert_list = gnutls_certificate_get_peers(session, &cert_list_size);
+
+        // The peer did not return a certificate
+        if (cert_list_size == 0)
+        {
+            log::debug(log_cat, "Quic {} called {}, but peer's cert list is empty.", local_name, __PRETTY_FUNCTION__);
+            return;
+        }
+
         // this function is only for raw pubkey mode, and should not be called otherwise
         if (cert_type != GNUTLS_CRT_RAWPK)
         {
@@ -867,15 +877,6 @@ namespace oxen::quic
             return;
         }
 
-        uint32_t cert_list_size = 0;
-        const gnutls_datum_t* cert_list = gnutls_certificate_get_peers(session, &cert_list_size);
-
-        // The peer did not return a certificate
-        if (cert_list_size == 0)
-        {
-            log::debug(log_cat, "Quic {} called {}, but peers cert list is empty.", local_name, __PRETTY_FUNCTION__);
-            return;
-        }
 
         if (cert_list_size != 1)
             log::debug(

--- a/src/gnutls_crypto.cpp
+++ b/src/gnutls_crypto.cpp
@@ -115,12 +115,7 @@ namespace oxen::quic
         return "<< UNKNOWN >>";
     }
 
-    void conn_set_validated(Connection& c)
-    {
-        c.set_validated();
-    }
-
-    // Return value: 0 is pass, negative is fail
+    // Return value: 0 is pass, non-zero to terminate.
     extern "C" int cert_verify_callback_gnutls(gnutls_session_t session)
     {
         log::debug(log_cat, "{} called", __PRETTY_FUNCTION__);
@@ -128,23 +123,17 @@ namespace oxen::quic
 
         GNUTLSSession& tls_session = GNUTLSSession::from(conn);
 
-        auto local_name = (conn.is_outbound()) ? "CLIENT" : "SERVER";
-
-        //  true: Peer provided a valid cert; connection is accepted and marked validated
-        //  false: Peer either provided an invalid cert or no cert; connection is rejected
         bool success = tls_session.validate_remote_key();
-        if (success)
-            conn_set_validated(conn);
-
-        auto err = "Quic {} was {}able to validate peer certificate; {} connection!"_format(
-                local_name, success ? "" : "un", success ? "accepting" : "rejecting");
 
         if (success)
-            log::debug(log_cat, "{}", err);
+            log::debug(log_cat, "{} certificate validated successfully", conn.is_outbound() ? "Server" : "Client");
         else
-            log::error(log_cat, "{}", err);
+            log::error(
+                    log_cat,
+                    "{} certificate validation failed; rejecting connection",
+                    conn.is_outbound() ? "Server" : "Client");
 
-        return !success;
+        return success ? 0 : 1;
     }
 
     void GNUTLSCreds::load_keys(x509_loader& s, x509_loader& pk)
@@ -162,7 +151,33 @@ namespace oxen::quic
             log::warning(log_cat, "Privkey import failed!");
     }
 
-    GNUTLSCreds::GNUTLSCreds(std::string_view ed_seed, std::string_view ed_pubkey) : using_raw_pk{true}
+    static constexpr auto* PRIORITY =
+            "NORMAL:+ECDHE-PSK:+PSK:+ECDHE-ECDSA:+AES-128-CCM-8:+CTYPE-CLI-ALL:+CTYPE-SRV-ALL:+SHA256";
+
+    GNUTLSCreds::GNUTLSCreds()
+    {
+        log::trace(log_cat, "Initializing GNUTLSCreds from Ed25519 keypair");
+        if (auto rv = gnutls_certificate_allocate_credentials(&cred); rv < 0)
+        {
+            log::warning(log_cat, "gnutls_certificate_allocate_credentials failed: {}", gnutls_strerror(rv));
+            throw std::runtime_error("gnutls credential allocation failed");
+        }
+
+        const char* err{nullptr};
+        if (auto rv = gnutls_priority_init(&priority_cache, PRIORITY, &err); rv < 0)
+        {
+            if (rv == GNUTLS_E_INVALID_REQUEST)
+                log::warning(log_cat, "gnutls_priority_init error: {}", err);
+            else
+                log::warning(log_cat, "gnutls_priority_init error: {}", gnutls_strerror(rv));
+
+            throw std::runtime_error("gnutls key exchange algorithm priority setup failed");
+        }
+
+        gnutls_certificate_set_verify_function(cred, cert_verify_callback_gnutls);
+    }
+
+    GNUTLSCreds::GNUTLSCreds(std::string_view ed_seed, std::string_view ed_pubkey) : GNUTLSCreds{}
     {
         log::trace(log_cat, "Initializing GNUTLSCreds from Ed25519 keypair");
 
@@ -181,40 +196,13 @@ namespace oxen::quic
 
         // LOAD KEYS HERE
         load_keys(seed, pubkey);
-
-        if (auto rv = gnutls_certificate_allocate_credentials(&cred); rv < 0)
-        {
-            log::warning(log_cat, "gnutls_certificate_allocate_credentials failed: {}", gnutls_strerror(rv));
-            throw std::runtime_error("gnutls credential allocation failed");
-        }
-
-        [[maybe_unused]] constexpr auto usage_flags = GNUTLS_KEY_DIGITAL_SIGNATURE | GNUTLS_KEY_NON_REPUDIATION |
-                                                      GNUTLS_KEY_KEY_ENCIPHERMENT | GNUTLS_KEY_DATA_ENCIPHERMENT |
-                                                      GNUTLS_KEY_KEY_AGREEMENT | GNUTLS_KEY_KEY_CERT_SIGN;
+        has_creds = true;
 
         if (auto rv = gnutls_certificate_set_key(cred, NULL, 0, &pcrt, 1, pkey); rv < 0)
         {
             log::warning(log_cat, "gnutls import of raw Ed keys failed: {}", gnutls_strerror(rv));
             throw std::runtime_error("gnutls import of raw Ed keys failed");
         }
-
-        // clang format keeps changing this arbitrarily, so disable for this line
-        // clang-format off
-        constexpr auto* priority = "NORMAL:+ECDHE-PSK:+PSK:+ECDHE-ECDSA:+AES-128-CCM-8:+CTYPE-CLI-ALL:+CTYPE-SRV-ALL:+SHA256";
-        // clang-format on
-
-        const char* err{nullptr};
-        if (auto rv = gnutls_priority_init(&priority_cache, priority, &err); rv < 0)
-        {
-            if (rv == GNUTLS_E_INVALID_REQUEST)
-                log::warning(log_cat, "gnutls_priority_init error: {}", err);
-            else
-                log::warning(log_cat, "gnutls_priority_init error: {}", gnutls_strerror(rv));
-
-            throw std::runtime_error("gnutls key exchange algorithm priority setup failed");
-        }
-
-        gnutls_certificate_set_verify_function(cred, cert_verify_callback_gnutls);
     }
 
     GNUTLSCreds::~GNUTLSCreds()
@@ -228,7 +216,7 @@ namespace oxen::quic
     std::shared_ptr<GNUTLSCreds> GNUTLSCreds::make_from_ed_keys(std::string_view seed, std::string_view pubkey)
     {
         // would use make_shared, but I want GNUTLSCreds' constructor to be private
-        std::shared_ptr<GNUTLSCreds> p{new GNUTLSCreds(seed, pubkey)};
+        std::shared_ptr<GNUTLSCreds> p{new GNUTLSCreds{seed, pubkey}};
         return p;
     }
 
@@ -240,8 +228,33 @@ namespace oxen::quic
         auto pk = sk.substr(GNUTLS_KEY_SIZE);
         sk = sk.substr(0, GNUTLS_KEY_SIZE);
 
-        std::shared_ptr<GNUTLSCreds> p{new GNUTLSCreds(sk, pk)};
+        std::shared_ptr<GNUTLSCreds> p{new GNUTLSCreds{sk, pk}};
         return p;
+    }
+
+    std::shared_ptr<GNUTLSCreds> GNUTLSCreds::make_unauthenticated()
+    {
+        return std::shared_ptr<GNUTLSCreds>(new GNUTLSCreds{});
+    }
+
+    void GNUTLSCreds::require_client_keys(key_verify_callback cb)
+    {
+        client_key_verify = std::move(cb);
+        ccert_required = true;
+        ccert_requested = false;
+    }
+
+    void GNUTLSCreds::request_client_keys(key_verify_callback cb)
+    {
+        client_key_verify = std::move(cb);
+        ccert_required = false;
+        ccert_requested = true;
+    }
+
+    void GNUTLSCreds::disable_client_keys()
+    {
+        client_key_verify = nullptr;
+        ccert_required = ccert_requested = false;
     }
 
     std::unique_ptr<TLSSession> GNUTLSCreds::make_session(
@@ -252,7 +265,11 @@ namespace oxen::quic
     {
         std::optional<gtls_key> exp_key;
         if (expected_key)
-            exp_key.emplace(*expected_key);
+        {
+            if (expected_key->size() != GNUTLS_KEY_SIZE)
+                throw std::invalid_argument{"Invalid GNUTLS expected pubkey"};
+            std::memcpy(exp_key.emplace().data(), expected_key->data(), expected_key->size());
+        }
         return std::make_unique<GNUTLSSession>(*this, ctx, c, alpns, std::move(exp_key));
     }
 
@@ -713,8 +730,9 @@ namespace oxen::quic
                 throw std::runtime_error("ngtcp2_crypto_gnutls_configure_client_session failed");
             }
 
-            // server always requests cert from client
-            gnutls_certificate_server_set_request(session, GNUTLS_CERT_REQUIRE);
+            if (creds.ccert_required || creds.ccert_requested)
+                gnutls_certificate_server_set_request(
+                        session, creds.ccert_required ? GNUTLS_CERT_REQUIRE : GNUTLS_CERT_REQUEST);
         }
         else
         {
@@ -807,47 +825,27 @@ namespace oxen::quic
             log::error(log_cat, "gnutls_session_ticket_send failed: {}", gnutls_strerror(rv));
     }
 
-    void GNUTLSSession::set_selected_alpn()
+    void GNUTLSSession::load_selected_alpn()
     {
         gnutls_datum_t _alpn{};
-
         if (auto rv = gnutls_alpn_get_selected_protocol(session, &_alpn); rv < 0)
         {
-            auto err = "{} called, but ALPN negotiation incomplete."_format(__PRETTY_FUNCTION__);
+            auto err = "ALPN negotiation incomplete";
             log::error(log_cat, "{}", err);
-            throw std::logic_error(err);
+            throw std::logic_error{err};
         }
-
-        _selected_alpn.resize(_alpn.size);
-        std::memmove(_selected_alpn.data(), _alpn.data, _alpn.size);
+        _selected_alpn = {reinterpret_cast<const char*>(_alpn.data), _alpn.size};
+        _loaded_alpn = true;
     }
 
-    //  In our new cert verification scheme, the logic proceeds as follows.
-    //
-    //  - Upon every connection, the local endpoint will request certificates from ALL peers
-    //  - IF: the local endpoint provided a key_verify callback
-    //      - IF: the peer provides a certificate:
-    //          - If the certificate is accepted, then the connection is allowed and the
-    //            connection is marked as "validated"
-    //          - If the certificate is rejected, then the connection is refused
-    //        ELSE:
-    //          - The connection is refused
-    //    ELSE: the remote pubkey is compared against the pubkey in the address upon connection
-    //      - If the pubkey matches, then the connection is allowed and the connection is
-    //        marked as "validated"
-    //      - If the pubkeys don't match, then the connection is refused
-    //
-    //  Return values:
-    //       true: The connection is accepted and marked "validated"
-    //       false: The connection is refused
-    //
-    bool GNUTLSSession::validate_remote_key()
+    void GNUTLSSession::load_remote_key()
     {
         log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
+        _loaded_remote_key = true;
+
         assert(creds.using_raw_pk);
 
         const auto local_name = _is_client ? "CLIENT"sv : "SERVER"sv;
-        bool success = false;
 
         log::debug(
                 log_cat,
@@ -861,12 +859,12 @@ namespace oxen::quic
         // this function is only for raw pubkey mode, and should not be called otherwise
         if (cert_type != GNUTLS_CRT_RAWPK)
         {
-            log::error(
+            log::warning(
                     log_cat,
                     "{} called, but remote cert type is not raw pubkey (type: {}).",
                     __PRETTY_FUNCTION__,
                     translate_cert_type(cert_type));
-            return success;
+            return;
         }
 
         uint32_t cert_list_size = 0;
@@ -876,16 +874,14 @@ namespace oxen::quic
         if (cert_list_size == 0)
         {
             log::debug(log_cat, "Quic {} called {}, but peers cert list is empty.", local_name, __PRETTY_FUNCTION__);
-            return success;
+            return;
         }
 
         if (cert_list_size != 1)
-        {
             log::debug(
                     log_cat,
                     "Quic {} received peers cert list with more than one entry; choosing first item and proceeding...",
                     local_name);
-        }
 
         const auto* cert_data = cert_list[0].data + CERT_HEADER_SIZE;
         auto cert_size = cert_list[0].size - CERT_HEADER_SIZE;
@@ -898,42 +894,77 @@ namespace oxen::quic
                 buffer_printer{std::span{cert_data, cert_size}});
 
         // pubkey comes as 12 bytes header + 32 bytes key
-        _remote_key.write(cert_data, cert_size);
+        if (cert_size != GNUTLS_KEY_SIZE)
+        {
+            log::warning(log_cat, "Rejecting remote key: invalid key size {} != expected {}", cert_size, GNUTLS_KEY_SIZE);
+            return;
+        }
 
-        set_selected_alpn();
+        std::memcpy(_remote_key.emplace().data(), cert_data, cert_size);
+    }
+
+    std::span<const unsigned char> GNUTLSSession::remote_key()
+    {
+        if (!_loaded_remote_key)
+            load_remote_key();
+        if (_remote_key)
+            return *_remote_key;
+        return {};
+    }
+
+    std::string_view GNUTLSSession::selected_alpn()
+    {
+        if (!_loaded_alpn)
+            load_selected_alpn();
+        return _selected_alpn;
+    }
+
+    // Called to verify a remote key during connection establishing *if* a remote key is provided:
+    // - server must always provide a key
+    // - clients must provide a key if require_client_keys() was called on the server, and may
+    //   provide one if request_client_keys() was called on the server, and otherwise don't provide
+    //   one.
+    //
+    // 0-RTT connections (which are resumption of an earlier connection) do not call this at all.
+    //
+    //  Return values:
+    //       true: The connection is accepted and marked "validated"
+    //       false: The connection is refused
+    //
+    bool GNUTLSSession::validate_remote_key()
+    {
+        load_remote_key();
+        load_selected_alpn();
 
         if (_is_client)
         {
             // Client does validation through a remote pubkey provided when calling endpoint::connect
-            success = _remote_key == _expected_remote_key;
-
-            log::debug(
-                    log_cat,
-                    "Quic {} {}successfully validated remote key! {} connection",
-                    local_name,
-                    success ? "" : "un",
-                    success ? "accepting" : "rejecting");
-
+            bool success = !_expected_remote_key || *_remote_key == _expected_remote_key;
+            if (success)
+                log::debug(log_cat, "Client successfully validated server pubkey; accepting connection");
+            else
+                log::warning(
+                        log_cat,
+                        "Mismatch during server pubkey verification: expected {}, got {}",
+                        oxenc::to_hex(_expected_remote_key->begin(), _expected_remote_key->end()),
+                        oxenc::to_hex(_remote_key->begin(), _remote_key->end()));
             return success;
         }
-        else
+
+        // Server does validation through optional callback
+        if (!_remote_key && creds.ccert_required)
         {
-            // Server does validation through callback
-            log::debug(
-                    log_cat,
-                    "Quic {}: {} key verify callback{}",
-                    local_name,
-                    creds.key_verify ? "calling" : "did not provide",
-                    creds.key_verify ? "" : "; accepting connection");
-
-            // Key verify cb will return true on success, false on fail. Since this is only called if a client has
-            // provided a certificate and is only called by the server, we can assume the following returns:
-            //      true: the certificate was verified, and the connection is marked as validated
-            //      false: the certificate was not verified, and the connection is rejected
-            success = (creds.key_verify) ? creds.key_verify(_remote_key, selected_alpn()) : true;
-
-            return success;
+            log::debug(log_cat, "Rejecting incoming connection: required client key not provided");
+            return false;
         }
+        if (!creds.client_key_verify)
+        {
+            log::debug(log_cat, "Accepting incoming connection with pubkey (without key verification callback)");
+            return true;
+        }
+        bool success = creds.client_key_verify(remote_key(), selected_alpn());
+        log::debug(log_cat, "Key verify callback {} incoming connection", success ? "accepted" : "rejected");
+        return success;
     }
 
 }  //  namespace oxen::quic

--- a/tests/001-handshake.cpp
+++ b/tests/001-handshake.cpp
@@ -396,18 +396,60 @@ namespace oxen::quic::test
             CHECK(true);
         }
 
-        SECTION("No TLS creds in connect/listen")
+        SECTION("Wrong number of TLS creds to connect/listen")
         {
-            // If uncommented, any of these lines should not compile! connect() and listen()
-            // each require exactly one TLSCreds shared pointer to be provided.
+            // If uncommented, any of these lines should not compile! listen() requires exactly one
+            // TLSCreds shared pointer argument, and connect() requires at most one.
 
-            // server_endpoint->connect(client_remote);                          // no tls
-            // server_endpoint->connect(client_tls, client_remote, client_tls);  // multiple tls
+            // server_endpoint->connect(client_remote, server_tls, server_tls);  // multiple tls
             // server_endpoint->listen(client_remote);                           // no tls
             // server_endpoint->listen(server_tls, client_remote, server_tls);   // multiple tls
 
             CHECK(true);
         }
+    }
+
+    TEST_CASE("001 - Handshaking: No client pubkey", "[001][client][unauthenticated][pubkeys]")
+    {
+        auto server_established = callback_waiter{[](Connection&) {}};
+        auto client_established = callback_waiter{[](Connection&) {}};
+
+        Loop loop;
+
+        auto server_tls = GNUTLSCreds::make_from_ed_keys(defaults::SERVER_SEED, defaults::SERVER_PUBKEY);
+
+        Address server_local{};
+        Address client_local{};
+
+        auto server_endpoint = Endpoint::endpoint(loop, server_local, server_established);
+        server_endpoint->listen(server_tls);
+
+        auto client_endpoint = Endpoint::endpoint(loop, client_local);
+
+        RemoteAddress server_raddr{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
+
+        std::shared_ptr<Connection> conn;
+        SECTION("Explicit unauthenticated TLS")
+        {
+            conn = client_endpoint->connect(server_raddr, GNUTLSCreds::make_unauthenticated(), client_established);
+        }
+        SECTION("Omitted TLS argument for unauthenticated default")
+        {
+            conn = client_endpoint->connect(server_raddr, client_established);
+        }
+
+        CHECK(client_established.wait());
+        CHECK(server_established.wait());
+        CHECK(conn->is_handshaked());
+        CHECK(conn->is_handshake_confirmed());
+        CHECK(oxenc::to_hex(view(conn->remote_key())) == oxenc::to_hex(defaults::SERVER_PUBKEY));
+
+        auto server_conns = server_endpoint->get_all_conns(Direction::INBOUND);
+        REQUIRE(server_conns.size() == 1);
+        auto& sconn = server_conns.front();
+        CHECK(sconn->is_handshaked());
+        CHECK(sconn->is_handshake_confirmed());
+        CHECK(sconn->remote_key().empty());
     }
 
     TEST_CASE("001 - Handshaking: Pubkey successes", "[001][client][correct][pubkeys]")
@@ -436,11 +478,11 @@ namespace oxen::quic::test
             // This will return false until the connection has had time to establish and validate. Depending
             // on the architecture running the test, the connection may be already established and validated
             // by the time this line es executed
-            CHECK_NOFAIL(client_ci->is_validated());
+            CHECK_NOFAIL(client_ci->is_handshaked());
 
             CHECK(client_established.wait());
             CHECK(server_established.wait());
-            CHECK(client_ci->is_validated());
+            CHECK(client_ci->is_handshaked());
         }
 
         SECTION("Immediate network shutdown after calling connect")
@@ -460,7 +502,7 @@ namespace oxen::quic::test
 
         auto [client_tls, server_tls] = defaults::tls_creds_from_ed_keys();
 
-        server_tls->set_key_verify_callback(
+        server_tls->require_client_keys(
                 [](std::span<const unsigned char> key, std::string_view) { return view(key) == defaults::CLIENT_PUBKEY; });
 
         Address server_local{};
@@ -480,10 +522,21 @@ namespace oxen::quic::test
         auto server_cis = server_endpoint->get_all_conns(Direction::INBOUND);
         REQUIRE(!server_cis.empty());
         auto& server_ci = server_cis.front();
-        CHECK(client_ci->is_validated());
-        CHECK(server_ci->is_validated());
+        CHECK(client_ci->is_handshaked());
+        CHECK(server_ci->is_handshaked());
 
         CHECK(view(server_ci->remote_key()) == defaults::CLIENT_PUBKEY);
+    }
+
+    TEST_CASE("001 - Handshaking: Server creds required", "[001][server][creds]")
+    {
+        auto creds = GNUTLSCreds::make_unauthenticated();
+
+        Loop loop;
+        Address server_local{};
+        auto server_endpoint = Endpoint::endpoint(loop, server_local);
+
+        CHECK_THROWS_AS(server_endpoint->listen(creds), std::logic_error);
     }
 
     TEST_CASE("001 - Handshaking: Types - IPv6", "[001][ipv6]")
@@ -535,7 +588,7 @@ namespace oxen::quic::test
 
         CHECK(client_established.wait());
         CHECK(server_established.wait());
-        CHECK(client_ci->is_validated());
+        CHECK(client_ci->is_handshaked());
     }
 
     TEST_CASE("001 - multi-listen failure", "[001][dumb][listen][protection]")
@@ -670,12 +723,12 @@ namespace oxen::quic::test
             return defer_to_incoming;
         };
 
-        server_tls->set_key_verify_callback([&](std::span<const unsigned char> key, std::string_view) {
+        server_tls->require_client_keys([&](std::span<const unsigned char> key, std::string_view) {
             std::lock_guard lock{ci_mutex};
             return defer_hook(view(key), S_PUBKEY, C_PUBKEY, server_ci);
         });
 
-        client_tls->set_key_verify_callback([&](std::span<const unsigned char> key, std::string_view) {
+        client_tls->require_client_keys([&](std::span<const unsigned char> key, std::string_view) {
             std::lock_guard lock{ci_mutex};
             return defer_hook(view(key), C_PUBKEY, S_PUBKEY, client_ci);
         });
@@ -830,7 +883,7 @@ namespace oxen::quic::test
         // need anything else from the server), so the handshake established timeout just doesn't
         // fire on the client and, no matter how long we block the server, the only timeout that
         // will happen is the idle timeout.
-        server_tls->set_key_verify_callback([](const ustring_view&, const ustring_view&) {
+        server_tls->require_client_keys([](const ustring_view&, const ustring_view&) {
             // This stalls the entire network object; this is a really terrible thing to do outside
             // of test code, but will let us simulate a slow handshake.
             log::critical(test_cat, "key verify sleeping...");

--- a/tests/004-streams.cpp
+++ b/tests/004-streams.cpp
@@ -863,7 +863,7 @@ namespace oxen::quic::test
             REQUIRE(msg.body() == TEST_BODY);
         }};
 
-        server_tls->set_key_verify_callback([&](std::span<const unsigned char>, std::string_view) {
+        server_tls->require_client_keys([&](std::span<const unsigned char>, std::string_view) {
             // In order to test the queueing ability of streams, we need to attempt to send things
             // from the client side PRIOR to connection completion. Using the TLS verification callback
             // is the improper and hacky way to do this, but will function fine for the purposes of this

--- a/tests/014-0rtt.cpp
+++ b/tests/014-0rtt.cpp
@@ -241,4 +241,139 @@ namespace oxen::quic::test
         CHECK(stream_time < expected_rtt * SIMULATED_RTT + RTT_BUFFER);
     }
 
+    TEST_CASE("014 - 0-RTT with key verification", "[014][0rtt][key-verify]")
+    {
+        if (disable_0rtt)
+            SKIP("0-RTT tests not enabled for this test iteration!");
+
+        Loop loop;
+
+        std::atomic<bool> bad_foo = false;
+        std::shared_ptr<GNUTLSCreds> client_tls, server_tls;
+        std::promise<std::vector<unsigned char>> key_prom;
+        bool expect_pubkey = true, expect_key_prom = true;
+        SECTION("With client keys required")
+        {
+            std::tie(client_tls, server_tls) = defaults::tls_creds_from_ed_keys();
+            server_tls->require_client_keys([&key_prom, &bad_foo](std::span<const unsigned char> key, std::string_view alpn) {
+                key_prom.set_value(std::vector<unsigned char>{key.begin(), key.end()});
+                if (alpn != "foo42")
+                    bad_foo = true;
+                return true;
+            });
+        }
+        SECTION("With optional client keys provided")
+        {
+            std::tie(client_tls, server_tls) = defaults::tls_creds_from_ed_keys();
+            server_tls->request_client_keys([&key_prom, &bad_foo](std::span<const unsigned char> key, std::string_view alpn) {
+                key_prom.set_value(std::vector<unsigned char>{key.begin(), key.end()});
+                if (alpn != "foo42")
+                    bad_foo = true;
+                return true;
+            });
+        }
+        SECTION("With optional client keys omitted")
+        {
+            server_tls = GNUTLSCreds::make_from_ed_keys(defaults::SERVER_SEED, defaults::SERVER_PUBKEY);
+            server_tls->request_client_keys([&key_prom, &bad_foo](std::span<const unsigned char> key, std::string_view alpn) {
+                key_prom.set_value(std::vector<unsigned char>{key.begin(), key.end()});
+                if (alpn != "foo42")
+                    bad_foo = true;
+                return true;
+            });
+            client_tls = GNUTLSCreds::make_unauthenticated();
+            expect_pubkey = false;
+        }
+        SECTION("Without client keys requested")
+        {
+            server_tls = GNUTLSCreds::make_from_ed_keys(defaults::SERVER_SEED, defaults::SERVER_PUBKEY);
+            client_tls = GNUTLSCreds::make_unauthenticated();
+            expect_pubkey = false;
+            expect_key_prom = false;
+        }
+
+        server_tls->enable_inbound_0rtt();
+        client_tls->enable_outbound_0rtt();
+
+        Address server_local{LOCALHOST, 0};
+        Address client_local{LOCALHOST, 0};
+
+        std::promise<ConnectionID> s_est_prom;
+        auto server_endpoint = Endpoint::endpoint(loop, server_local, opt::inbound_alpns{"foo41", "foo42", "foo43"});
+
+        server_endpoint->listen(server_tls, [&s_est_prom](Connection& c) { s_est_prom.set_value(c.reference_id()); });
+
+        auto client_endpoint = Endpoint::endpoint(loop, client_local);
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, server_endpoint->local()};
+        std::promise<void> c_est_prom;
+        auto conn =
+                client_endpoint->connect(client_remote, client_tls, opt::outbound_alpn("foo42"), [&c_est_prom](Connection&) {
+                    c_est_prom.set_value();
+                });
+
+        require_future(c_est_prom.get_future());
+        auto s_connid_fut = s_est_prom.get_future();
+        require_future(s_connid_fut);
+        auto key_fut = key_prom.get_future();
+        // The key verify callback should only get called if the client actually has a key to
+        // provide:
+        if (expect_key_prom)
+            require_future(key_fut);
+        else
+            CHECK(key_fut.wait_for(0s) == std::future_status::timeout);
+
+        REQUIRE(conn->selected_alpn() == "foo42");
+        REQUIRE(oxenc::to_hex(conn->remote_key()) == oxenc::to_hex(defaults::SERVER_PUBKEY));
+
+        auto sconn = server_endpoint->get_conn(s_connid_fut.get());
+        REQUIRE(sconn->selected_alpn() == "foo42");
+        if (expect_key_prom)
+        {
+            if (expect_pubkey)
+                REQUIRE(oxenc::to_hex(view(key_fut.get())) == oxenc::to_hex(defaults::CLIENT_PUBKEY));
+            else
+                REQUIRE(oxenc::to_hex(view(key_fut.get())) == "");
+        }
+        if (expect_pubkey)
+            REQUIRE(oxenc::to_hex(sconn->remote_key()) == oxenc::to_hex(defaults::CLIENT_PUBKEY));
+        else
+            REQUIRE(oxenc::to_hex(sconn->remote_key()) == "");
+
+        // TLS tickets can arrive just after the handshake confirmed packet, so add a tiny
+        // extra wait to allow for them to arrive.
+        std::this_thread::sleep_for(5ms);
+
+        // Now we close and reopen the connection, as it should now have 0-RTT data.
+        conn->close_connection();
+        conn.reset();
+
+        std::this_thread::sleep_for(5ms);
+
+        s_est_prom = {};
+        c_est_prom = {};
+        key_prom = {};
+        conn = client_endpoint->connect(client_remote, client_tls, opt::outbound_alpn("foo42"), [&c_est_prom](Connection&) {
+            c_est_prom.set_value();
+        });
+
+        require_future(c_est_prom.get_future());
+
+        s_connid_fut = s_est_prom.get_future();
+        require_future(s_connid_fut);
+        // The key verify callback does *not* get called for 0-RTT:
+        CHECK(key_prom.get_future().wait_for(0s) == std::future_status::timeout);
+
+        REQUIRE(conn->selected_alpn() == "foo42");
+        REQUIRE(oxenc::to_hex(conn->remote_key()) == oxenc::to_hex(defaults::SERVER_PUBKEY));
+
+        sconn = server_endpoint->get_conn(s_connid_fut.get());
+        REQUIRE(sconn->selected_alpn() == "foo42");
+        if (expect_pubkey)
+            REQUIRE(oxenc::to_hex(sconn->remote_key()) == oxenc::to_hex(defaults::CLIENT_PUBKEY));
+        else
+            REQUIRE(oxenc::to_hex(sconn->remote_key()) == "");
+
+        REQUIRE(!bad_foo.load());
+    }
+
 }  //  namespace oxen::quic::test

--- a/tests/014-0rtt.cpp
+++ b/tests/014-0rtt.cpp
@@ -241,6 +241,113 @@ namespace oxen::quic::test
         CHECK(stream_time < expected_rtt * SIMULATED_RTT + RTT_BUFFER);
     }
 
+    TEST_CASE("014 - 0-RTT early data conn established callback", "[014][0rtt][conn-established]")
+    {
+        // This test makes sure that the connection established connection gets called for early
+        // stream data *before* the stream construction happens.
+
+        if (disable_0rtt)
+            SKIP("0-RTT tests not enabled for this test iteration!");
+
+        Loop loop;
+
+        auto [client_tls, server_tls] = defaults::tls_creds_from_ed_keys();
+
+        server_tls->enable_inbound_0rtt();
+        client_tls->enable_outbound_0rtt();
+
+        server_tls->require_client_keys(nullptr);
+
+        Address server_local{LOCALHOST, 0};
+        Address client_local{LOCALHOST, 0};
+
+        std::promise<ConnectionID> s_est_prom;
+        std::optional<bool> s_est_first;
+        std::promise<void> s_str_prom;
+        std::string estcb_alpn, estcb_remote_pk;
+
+        auto server_endpoint = Endpoint::endpoint(loop, server_local, opt::inbound_alpns{"foo41", "foo42", "foo43"});
+        server_endpoint->listen(
+                server_tls,
+                [&s_est_prom, &s_est_first, &estcb_alpn, &estcb_remote_pk](Connection& c) {
+                    if (!s_est_first)
+                        s_est_first = true;
+                    estcb_alpn = c.selected_alpn();
+                    estcb_remote_pk = oxenc::to_hex(view(c.remote_key()));
+                    s_est_prom.set_value(c.reference_id());
+                },
+                [&s_est_first, &s_str_prom](Stream&) {
+                    if (!s_est_first)
+                        s_est_first = false;
+                    s_str_prom.set_value();
+                    return 0;
+                }
+
+        );
+
+        auto client_endpoint = Endpoint::endpoint(loop, client_local);
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, server_endpoint->local()};
+        std::promise<void> c_est_prom;
+        auto conn =
+                client_endpoint->connect(client_remote, client_tls, opt::outbound_alpn("foo42"), [&c_est_prom](Connection&) {
+                    c_est_prom.set_value();
+                });
+
+        require_future(c_est_prom.get_future());
+        auto s_connid_fut = s_est_prom.get_future();
+        require_future(s_connid_fut);
+
+        CHECK(conn->selected_alpn() == "foo42");
+        CHECK(oxenc::to_hex(conn->remote_key()) == oxenc::to_hex(defaults::SERVER_PUBKEY));
+
+        auto sconn = server_endpoint->get_conn(s_connid_fut.get());
+        CHECK(sconn->selected_alpn() == "foo42");
+        CHECK(oxenc::to_hex(sconn->remote_key()) == oxenc::to_hex(defaults::CLIENT_PUBKEY));
+        CHECK(estcb_alpn == "foo42");
+        CHECK(estcb_remote_pk == oxenc::to_hex(defaults::CLIENT_PUBKEY));
+
+        // TLS tickets can arrive just after the handshake confirmed packet, so add a tiny
+        // extra wait to allow for them to arrive.
+        std::this_thread::sleep_for(5ms);
+
+        // Now we close and reopen the connection, as it should now have 0-RTT data.
+        conn->close_connection();
+        conn.reset();
+
+        std::this_thread::sleep_for(5ms);
+
+        s_est_prom = {};
+        c_est_prom = {};
+        s_est_first.reset();
+        estcb_alpn = "";
+        estcb_remote_pk = "";
+
+        conn = client_endpoint->connect(client_remote, client_tls, opt::outbound_alpn("foo42"), [&c_est_prom](Connection&) {
+            c_est_prom.set_value();
+        });
+
+        auto str = conn->open_stream();
+        str->send("hello");
+
+        require_future(c_est_prom.get_future());
+        s_connid_fut = s_est_prom.get_future();
+        require_future(s_connid_fut);
+
+        CHECK(conn->selected_alpn() == "foo42");
+        CHECK(oxenc::to_hex(conn->remote_key()) == oxenc::to_hex(defaults::SERVER_PUBKEY));
+
+        sconn = server_endpoint->get_conn(s_connid_fut.get());
+        CHECK(sconn->selected_alpn() == "foo42");
+        CHECK(oxenc::to_hex(sconn->remote_key()) == oxenc::to_hex(defaults::CLIENT_PUBKEY));
+        require_future(s_str_prom.get_future());
+
+        CHECK(s_est_first.has_value());
+        // The server's conn establish should get fired before the stream:
+        CHECK(*s_est_first);
+        CHECK(estcb_alpn == "foo42");
+        CHECK(estcb_remote_pk == oxenc::to_hex(defaults::CLIENT_PUBKEY));
+    }
+
     TEST_CASE("014 - 0-RTT with key verification", "[014][0rtt][key-verify]")
     {
         if (disable_0rtt)
@@ -255,32 +362,35 @@ namespace oxen::quic::test
         SECTION("With client keys required")
         {
             std::tie(client_tls, server_tls) = defaults::tls_creds_from_ed_keys();
-            server_tls->require_client_keys([&key_prom, &bad_foo](std::span<const unsigned char> key, std::string_view alpn) {
-                key_prom.set_value(std::vector<unsigned char>{key.begin(), key.end()});
-                if (alpn != "foo42")
-                    bad_foo = true;
-                return true;
-            });
+            server_tls->require_client_keys(
+                    [&key_prom, &bad_foo](std::span<const unsigned char> key, std::string_view alpn) {
+                        key_prom.set_value(std::vector<unsigned char>{key.begin(), key.end()});
+                        if (alpn != "foo42")
+                            bad_foo = true;
+                        return true;
+                    });
         }
         SECTION("With optional client keys provided")
         {
             std::tie(client_tls, server_tls) = defaults::tls_creds_from_ed_keys();
-            server_tls->request_client_keys([&key_prom, &bad_foo](std::span<const unsigned char> key, std::string_view alpn) {
-                key_prom.set_value(std::vector<unsigned char>{key.begin(), key.end()});
-                if (alpn != "foo42")
-                    bad_foo = true;
-                return true;
-            });
+            server_tls->request_client_keys(
+                    [&key_prom, &bad_foo](std::span<const unsigned char> key, std::string_view alpn) {
+                        key_prom.set_value(std::vector<unsigned char>{key.begin(), key.end()});
+                        if (alpn != "foo42")
+                            bad_foo = true;
+                        return true;
+                    });
         }
         SECTION("With optional client keys omitted")
         {
             server_tls = GNUTLSCreds::make_from_ed_keys(defaults::SERVER_SEED, defaults::SERVER_PUBKEY);
-            server_tls->request_client_keys([&key_prom, &bad_foo](std::span<const unsigned char> key, std::string_view alpn) {
-                key_prom.set_value(std::vector<unsigned char>{key.begin(), key.end()});
-                if (alpn != "foo42")
-                    bad_foo = true;
-                return true;
-            });
+            server_tls->request_client_keys(
+                    [&key_prom, &bad_foo](std::span<const unsigned char> key, std::string_view alpn) {
+                        key_prom.set_value(std::vector<unsigned char>{key.begin(), key.end()});
+                        if (alpn != "foo42")
+                            bad_foo = true;
+                        return true;
+                    });
             client_tls = GNUTLSCreds::make_unauthenticated();
             expect_pubkey = false;
         }


### PR DESCRIPTION
This commit adds the ability for a client to connect to a server without providing a key, and allows listening servers to choose whether client keys are required, requested, or omitted.  Required means a client must provide a key, and it must pass the key verification function; requested means the server will request a key and the client may provide one: the key verification function is called with an empty key if the client does not provide one (so that it can still use the ALPN to reject the connection, for example, if certain ALPNs require keys and others don't).  Omitted means the server won't request one at all.

For omitted client pubkeys (either not requested, or requested and not provided but still allowed), the connection's `remote_key()` will return an empty span.

Client connections can now use GNUTLSCreds::make_unauthenticated to make a connection without a pubkey.  They can also omit the TLSCreds from the connect() call entirely, but that won't allow doing things like enable 0rtt.  This connection with such a missing pubkey will fail if the server requires pubkeys, but otherwise is allowed.

This deliberately renames `set_key_verify_callback` to `require_client_keys` (thus breaking code) as calling code needs to decide whether it wants requires or requests behaviour.

This also fixes closely related issues with 0-RTT: under 0-RTT resumption, key verification callbacks were never called, and so the remote_key was never set on the connection object.  This is actually intentional: a valid 0-RTT ticket already contains the connection data, and so the initial connection that produced the ticket already passed verification.  This commit contains fixes to this so that they get properly reflected in the Connection object, and documents this for the key verification functions.

Other changes:

- remove pointless `gtls_key` struct and make it back into a simple typedef, like it used to be.  The indirection added nothing.

- replace Connection `is_validated()` with `is_handshaked()` and `is_handshake_confirmed()`.  Validated isn't used anywhere outside of libquic's test suite, and doesn't really work with 0-RTT connections that don't re-validate.

- remove `set_draining()` and `set_closing()` -- they were pointless private methods that simply set the variable of the same name to false.  But anything with private access can already just set those to false itself.

- Fixed wrong comment above cert_verify_callback_gnutls about what a failure return value looks like.  The function was already returning 1 rather than a negative (which is actually okay), but this intent is now clearer in the comment and the code.

- Removed unused `usage_flags`.  It was already tagged `[[maybe_unused]]` but was actually unused and didn't seem to have any purpose.