### PR TITLE
Fix opt::stream_notify not working with rejected 0RTT early data

### DIFF
--- a/include/oxen/quic/address.hpp
+++ b/include/oxen/quic/address.hpp
@@ -62,7 +62,7 @@ namespace oxen::quic
       protected:
         void _copy_internals(const Address& obj)
         {
-            std::memmove(&_sock_addr, &obj._sock_addr, sizeof(_sock_addr));
+            std::memcpy(&_sock_addr, &obj._sock_addr, sizeof(_sock_addr));
             _addr.addrlen = obj._addr.addrlen;
             dual_stack = obj.dual_stack;
         }
@@ -106,7 +106,8 @@ namespace oxen::quic
         Address(const Address& obj) { _copy_internals(obj); }
         Address& operator=(const Address& obj)
         {
-            _copy_internals(obj);
+            if (&obj != this)
+                _copy_internals(obj);
             return *this;
         }
 

--- a/include/oxen/quic/stream.hpp
+++ b/include/oxen/quic/stream.hpp
@@ -241,6 +241,7 @@ namespace oxen::quic
         bool _ready{false};
         bool _paused{false};
         bool _notify{false};
+        bool _had_notify{false};
         int64_t _stream_id;
 
         size_t _paused_offset{0};

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -385,7 +385,8 @@ namespace oxen::quic
         {
             conn.close_all_streams();
 
-            if (conn.is_inbound() && !conn.is_handshake_confirmed()) {
+            if (conn.is_inbound() && !conn.is_handshake_confirmed())
+            {
                 // For inbound connections we fire the connection-established callback immediately
                 // after setting handshaked to true, so if we *haven't* done that yet, don't call
                 // the close callback because other the first time the application would learn of

--- a/src/gnutls_crypto.cpp
+++ b/src/gnutls_crypto.cpp
@@ -888,7 +888,6 @@ namespace oxen::quic
             return;
         }
 
-
         if (cert_list_size != 1)
             log::debug(
                     log_cat,

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -30,6 +30,7 @@ namespace oxen::quic
     void Stream::handle_opt(opt::stream_notify_t)
     {
         _notify = true;
+        _had_notify = true;
     }
     Stream::Stream(Connection& conn, Endpoint& ep, base_ctor) : IOChannel{conn, ep}, reference_id{conn.reference_id()}
     {
@@ -318,6 +319,8 @@ namespace oxen::quic
         assert(loop.inside());
         log::trace(log_cat, "Stream (ID:{}) reverting after early data rejected...", _stream_id);
         _unacked_size = 0;
+        if (_had_notify)
+            _notify = true;
         log::debug(log_cat, "Stream (ID:{}) has {}B in buffer, 0B unacked...", _stream_id, size());
     }
 

--- a/tests/014-0rtt.cpp
+++ b/tests/014-0rtt.cpp
@@ -486,4 +486,118 @@ namespace oxen::quic::test
         REQUIRE(!bad_foo.load());
     }
 
+    TEST_CASE("014 - Send empty initial 0RTT stream data", "[014][0rtt][streams][empty]")
+    {
+        // This is the same test as the opt::stream_notify test in 004-streams.cpp, except here
+        // applied to a 0-RTT stream: when creating a new stream the stream is not opened on the
+        // remote until stream data arrives.  QUIC explicitly allows a 0-length stream frame to be
+        // used to serve as a stream open notification when no data is available.
+        //
+        // This tests that same test but with:
+        // - early data
+        // - rejected early data
+
+        if (disable_0rtt)
+            SKIP("0-RTT tests not enabled for this test iteration!");
+
+        Loop loop;
+
+        std::shared_ptr<GNUTLSCreds> client_tls, server_tls;
+        std::tie(client_tls, server_tls) = defaults::tls_creds_from_ed_keys();
+        server_tls->require_client_keys(nullptr);
+        server_tls->enable_inbound_0rtt();
+        client_tls->enable_outbound_0rtt();
+
+        Address server_local{LOCALHOST, 0};
+        Address client_local{LOCALHOST, 0};
+
+        std::promise<ConnectionID> s_est_prom;
+        auto server_endpoint = Endpoint::endpoint(loop, server_local, opt::inbound_alpn("foo"));
+
+        std::shared_ptr<Stream> incoming_stream;
+
+        std::shared_ptr<quic::Stream> s_str;
+        server_endpoint->listen(server_tls, [&s_est_prom, &incoming_stream](Connection& c) {
+            incoming_stream = c.queue_incoming_stream();
+            s_est_prom.set_value(c.reference_id());
+        });
+
+        auto client_endpoint = Endpoint::endpoint(loop, client_local);
+        std::promise<void> c_est_prom;
+        auto conn = client_endpoint->connect(
+                RemoteAddress{defaults::SERVER_PUBKEY, server_endpoint->local()},
+                client_tls,
+                opt::outbound_alpn("foo"),
+                [&c_est_prom](Connection&) { c_est_prom.set_value(); });
+        conn->open_stream(opt::stream_notify);
+
+        auto s_est_fut = s_est_prom.get_future();
+        require_future(s_est_fut);
+
+        REQUIRE(incoming_stream->is_ready());
+        REQUIRE(incoming_stream->stream_id() == 0);
+
+        auto c_est_fut = c_est_prom.get_future();
+        require_future(c_est_fut);
+
+        // At this point we just made a 1-RTT connection on a 0-RTT enabled server, so this is
+        // likely no different than what the 004 test accomplishes (except with 0rtt flipped on but
+        // not actually used yet):
+
+        incoming_stream.reset();
+
+        // TLS tickets can arrive just after the handshake confirmed packet, so add a tiny
+        // extra wait to allow for them to arrive.
+        std::this_thread::sleep_for(5ms);
+
+        // Now we close and reopen the connection, as it should now have 0-RTT data.
+        conn->close_connection();
+        conn.reset();
+
+        std::this_thread::sleep_for(5ms);
+
+        SECTION("With 0-RTT early data accepted")
+        {
+            // Do nothing
+        }
+        SECTION("With 0-RTT early data rejected")
+        {
+            // Restart the server with a new creds object so that there will be a new 0RTT key and
+            // early data will be rejected
+            auto addr = server_endpoint->local();
+            server_endpoint.reset();
+
+            std::tie(std::ignore, server_tls) = defaults::tls_creds_from_ed_keys();
+            server_tls->require_client_keys(nullptr);
+            server_tls->enable_inbound_0rtt();
+
+            server_endpoint = Endpoint::endpoint(loop, addr, opt::inbound_alpn("foo"));
+            server_endpoint->listen(server_tls, [&s_est_prom, &incoming_stream](Connection& c) {
+                incoming_stream = c.queue_incoming_stream();
+                s_est_prom.set_value(c.reference_id());
+            });
+        }
+
+        s_est_prom = {};
+        s_est_fut = s_est_prom.get_future();
+        c_est_prom = {};
+        c_est_fut = c_est_prom.get_future();
+
+        loop.call_get([&] {
+            conn = client_endpoint->connect(
+                    RemoteAddress{defaults::SERVER_PUBKEY, server_endpoint->local()},
+                    client_tls,
+                    opt::outbound_alpn("foo"),
+                    [&c_est_prom](Connection&) { c_est_prom.set_value(); });
+
+            std::promise<size_t> received;
+            auto cstream = conn->open_stream(opt::stream_notify);
+        });
+
+        require_future(s_est_fut);
+        require_future(c_est_fut);
+        REQUIRE(incoming_stream->is_ready());
+        REQUIRE(incoming_stream->stream_id() == 0);
+    }
+
 }  //  namespace oxen::quic::test


### PR DESCRIPTION
If early data gets rejected but we had already sent the early 0-byte stream notify opener then we wouldn't try sending another stream notify because the `_notify` flag was false.

This fixes it by adding a second `_had_notify` property so that we can flip _notify back to on if the stream data gets reset by early data rejection, so that the empty notify frame then still gets properly sent as a 1RTT stream frame.