### PR TITLE
add queued datagram bytes limit

### DIFF
--- a/include/oxen/quic/context.hpp
+++ b/include/oxen/quic/context.hpp
@@ -29,6 +29,7 @@ namespace oxen::quic
         std::chrono::milliseconds idle_timeout{DEFAULT_IDLE_TIMEOUT};
         // datagram support
         bool datagram_support{false};
+        size_t dgram_queue_limit{std::numeric_limits<size_t>::max()};
         // datagram splitting support
         bool split_packet{false};
         // splitting policy

--- a/include/oxen/quic/datagram.hpp
+++ b/include/oxen/quic/datagram.hpp
@@ -283,6 +283,8 @@ namespace oxen::quic
             size_t last_i = std::numeric_limits<size_t>::max();
             SendStatus last_sent = SendStatus::Unsent;
 
+            size_t unsent_bytes{0};
+
             std::deque<storage> buf{};
         };
     }  // namespace dgram

--- a/include/oxen/quic/datagram.hpp
+++ b/include/oxen/quic/datagram.hpp
@@ -330,7 +330,11 @@ namespace oxen::quic
         friend struct dgram::rotating_buffer;
         friend class TestHelper;
 
-        Datagrams(Connection& c, Endpoint& e, dgram_data_callback data_cb = nullptr);
+        Datagrams(
+                Connection& c,
+                Endpoint& e,
+                dgram_data_callback data_cb = nullptr,
+                size_t dgram_queue_limit = std::numeric_limits<size_t>::max());
 
         Datagrams(const Datagrams&) = delete;
         Datagrams(Datagrams&&) = delete;
@@ -338,6 +342,9 @@ namespace oxen::quic
         Datagrams& operator=(Datagrams&&) = delete;
 
         dgram_data_callback dgram_data_cb;
+
+        // Maximum datagram size queued per connection.  Will need tuning.
+        size_t dgram_queue_limit = 2'000'000;
 
         /// Datagram Numbering:
         /// Each datagram ID is comprised of a 16 bit quantity consisting of a 14 bit counter, and

--- a/include/oxen/quic/datagram.hpp
+++ b/include/oxen/quic/datagram.hpp
@@ -344,7 +344,7 @@ namespace oxen::quic
         dgram_data_callback dgram_data_cb;
 
         // Maximum datagram size queued per connection.  Will need tuning.
-        size_t dgram_queue_limit = 2'000'000;
+        size_t dgram_queue_limit = std::numeric_limits<size_t>::max();
 
         /// Datagram Numbering:
         /// Each datagram ID is comprised of a 16 bit quantity consisting of a 14 bit counter, and

--- a/include/oxen/quic/endpoint.hpp
+++ b/include/oxen/quic/endpoint.hpp
@@ -19,6 +19,8 @@
 #include <cstdint>
 #include <exception>
 #include <functional>
+#include <future>
+#include <limits>
 #include <list>
 #include <map>
 #include <memory>
@@ -178,6 +180,7 @@ namespace oxen::quic
         bool _packet_splitting{false};
         Splitting _policy{Splitting::NONE};
         int _rbufsize{4096};
+        size_t _dgram_queue_limit{std::numeric_limits<size_t>::max()};
 
         opt::manual_routing _manual_routing;
         bool _disable_mtu_discovery{false};

--- a/include/oxen/quic/opt.hpp
+++ b/include/oxen/quic/opt.hpp
@@ -133,6 +133,15 @@ namespace oxen::quic
             Splitting mode{Splitting::NONE};
             // Note: this is the size of the entire buffer, divided amongst 4 rows
             int bufsize{4096};
+            size_t dgram_queue_limit{std::numeric_limits<size_t>::max()};
+
+            enable_datagrams& queue_limit(size_t limit)
+            {
+                if (limit == 0)
+                    limit = std::numeric_limits<size_t>::max();
+                dgram_queue_limit = limit;
+                return *this;
+            }
 
             enable_datagrams() = default;
             explicit enable_datagrams(bool e) = delete;

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -1849,7 +1849,10 @@ namespace oxen::quic
 
         if (context->config.datagram_support)
             dgrams = _loop.make_shared<Datagrams>(
-                    *this, _endpoint, context->dgram_data_cb ? context->dgram_data_cb : ep.dgram_recv_cb);
+                    *this,
+                    _endpoint,
+                    context->dgram_data_cb ? context->dgram_data_cb : ep.dgram_recv_cb,
+                    context->config.dgram_queue_limit);
         pseudo_stream = _loop.make_shared<Stream>(*this, _endpoint);
         pseudo_stream->_stream_id = -1;
 

--- a/src/datagram.cpp
+++ b/src/datagram.cpp
@@ -239,6 +239,10 @@ namespace oxen::quic
             {
                 // Early data accepted, so now we can discard all the sent packets (which will be
                 // everything up, but not including, `early_data_head`).
+                [[maybe_unused]] size_t old_unsent = unsent_bytes;
+                for (auto pkt_itr = buf.begin(); pkt_itr < buf.begin() + *early_data_head; pkt_itr++)
+                    unsent_bytes -= pkt_itr->size();
+                assert(unsent_bytes <= old_unsent);  // in case I'm dumb and the loop above is one too many
                 buf.erase(buf.begin(), buf.begin() + *early_data_head);
             }
             early_data_head.reset();
@@ -246,6 +250,7 @@ namespace oxen::quic
 
         void queue::emplace(std::span<const std::byte> payload, uint16_t base_dgid, std::shared_ptr<void> keepalive)
         {
+            unsent_bytes += payload.size();
             buf.emplace_back(payload, base_dgid, std::move(keepalive));
         }
 
@@ -409,7 +414,10 @@ namespace oxen::quic
                 if (early_data_head)
                     ++*early_data_head;
                 else
+                {
+                    unsent_bytes -= buf.front().size();
                     buf.pop_front();
+                }
             }
 
             last_i = std::numeric_limits<size_t>::max();
@@ -417,10 +425,7 @@ namespace oxen::quic
 
         size_t queue::pending_bytes() const
         {
-            size_t bytes = 0;
-            for (auto it = buf.begin() + early_data_head.value_or(0); it != buf.end(); ++it)
-                bytes += it->unsent_size();
-            return bytes;
+            return unsent_bytes;
         }
 
         storage::storage(std::span<const std::byte> payload, uint16_t base_dgid, std::shared_ptr<void> keepalive) :

--- a/src/datagram.cpp
+++ b/src/datagram.cpp
@@ -9,13 +9,15 @@
 namespace oxen::quic
 {
 
-    Datagrams::Datagrams(Connection& c, Endpoint& e, dgram_data_callback data_cb) :
+    Datagrams::Datagrams(Connection& c, Endpoint& e, dgram_data_callback data_cb, size_t dgram_queue_limit_) :
             IOChannel{c, e},
             dgram_data_cb{std::move(data_cb)},
             rbufsize{endpoint.datagram_bufsize()},
             recv_buffer{*this},
             _packet_splitting(_conn->packet_splitting_enabled())
     {
+        if (dgram_queue_limit_)
+            dgram_queue_limit = dgram_queue_limit_;
         log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
     }
 
@@ -64,6 +66,12 @@ namespace oxen::quic
             if (!_conn)
             {
                 log::debug(log_cat, "Unable to send datagram: connection has gone away");
+                return;
+            }
+
+            if (unsent_impl() > dgram_queue_limit)
+            {
+                log::trace(log_cat, "Dropping datagram, queue over limit.");
                 return;
             }
 

--- a/src/datagram.cpp
+++ b/src/datagram.cpp
@@ -5,6 +5,7 @@
 #include "internal.hpp"
 
 #include <numeric>
+#include <ranges>
 
 namespace oxen::quic
 {
@@ -71,7 +72,7 @@ namespace oxen::quic
 
             if (unsent_impl() > dgram_queue_limit)
             {
-                log::trace(log_cat, "Dropping datagram, queue over limit.");
+                log::info(log_cat, "Dropping datagram, queue over limit.");
                 return;
             }
 
@@ -240,8 +241,8 @@ namespace oxen::quic
                 // Early data accepted, so now we can discard all the sent packets (which will be
                 // everything up, but not including, `early_data_head`).
                 [[maybe_unused]] size_t old_unsent = unsent_bytes;
-                for (auto pkt_itr = buf.begin(); pkt_itr < buf.begin() + *early_data_head; pkt_itr++)
-                    unsent_bytes -= pkt_itr->size();
+                for (auto& pkt : buf | std::views::take(*early_data_head))
+                    unsent_bytes -= pkt.size();
                 assert(unsent_bytes <= old_unsent);  // in case I'm dumb and the loop above is one too many
                 buf.erase(buf.begin(), buf.begin() + *early_data_head);
             }

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -41,6 +41,7 @@ namespace oxen::quic
         _packet_splitting = dc.split_packets;
         _policy = dc.mode;
         _rbufsize = dc.bufsize;
+        _dgram_queue_limit = dc.dgram_queue_limit;
 
         log::trace(
                 log_cat,
@@ -211,6 +212,7 @@ namespace oxen::quic
     void Endpoint::_assign_context_globals(IOContext& ctx) const
     {
         ctx.config.datagram_support = _datagrams;
+        ctx.config.dgram_queue_limit = _dgram_queue_limit;
         ctx.config.split_packet = _packet_splitting;
         ctx.config.policy = _policy;
     }


### PR DESCRIPTION
The datagram channel backing up is not only a memory usage issue, but also will cause congestion control algorithms for a connection over top of this (e.g. a quic connection over lokinet, which in turn means the datagrams go over multiple other quic connections) to throttle angrily.  Ideally this will help to mitigate that latter issue, but it will probably need tuning.