### PR TITLE
Rewrite and expose size + data accumulation

### DIFF
--- a/include/oxen/quic/btstream.hpp
+++ b/include/oxen/quic/btstream.hpp
@@ -34,9 +34,9 @@ namespace oxen::quic
     // request sizes
     inline constexpr long long MAX_REQ_LEN = 10_M;
 
-    // maximum length of the bencoded request length string, including the `:`.  This must be large
-    // enough to hold `MAX_REQ_LEN` followed by a `:`.
-    inline constexpr size_t MAX_REQ_LEN_ENCODED = 9;  // "10000000:"
+    // maximum length of the bencoded request length string that we parse, including the `:`.  This
+    // must be at least as large as needed to hold `MAX_REQ_LEN` followed by a `:`.
+    inline constexpr size_t MAX_REQ_LEN_ENCODED = 10;  // "999999999:"
 
     class BTRequestStream;
 
@@ -180,6 +180,38 @@ namespace oxen::quic
         }
     };
 
+    /// Accumulates digits from a `123:DATA`.  If req completes the size prefix this removes the
+    /// parsed size from the (possibly) concatenated partial + req.  If req is insufficient (for
+    /// example, if it only contains "12") then the input is appended to partial to be reused in the
+    /// next call to `request_accumulator`, and nullopt is returned.  In either case, req is
+    /// prefix-shortened by the consumed digits and colon (and will be empty when nullopt is
+    /// returned, i.e. all data accumulated).
+    ///
+    /// If req does not contain a valid numeric prefix then this throws a std::invalid_argument (req
+    /// will not modified).
+    ///
+    /// This function is designed to be able to be called multiple times: the incoming stream data
+    /// could be sliced at any arbitrary point, and so calling it multiple times accumulates
+    /// additional digits until it has accumulated a full `N:` prefix.
+    ///
+    /// This function currently allows a maximum 9-digit prefix length (i.e. 999999999:).
+    ///
+    /// This method is used internally by BTRequestStream to process requests and responses, but is
+    /// also provided for external use for custom streams with similar parsing requirements.
+    std::optional<size_t> prefix_accumulator(std::string& partial, std::span<const std::byte>& req);
+
+    /// Accumulates data from a stream until reaching the given size.  This is typically used
+    /// immediately after `prefix_accumulator` to accumulate the amount of data indicated by the
+    /// prefix.  If the incoming data does not complete the size, it is appended to `buf` for a
+    /// repeated call to continue to accumulate (or complete).
+    ///
+    /// `req` is reduced by the size of accumulated data (which might, for instance, be the
+    /// beginning of the next request).
+    ///
+    /// Returns true if `buf` has been filled to the requested size, false if more data is needed.
+    /// In both cases, `req` is prefix-reduced by the size of the accumulated data.
+    bool data_accumulator(std::vector<std::byte>& buf, std::span<const std::byte>& req, size_t size);
+
     class BTRequestStream : public Stream
     {
         friend class TestHelper;
@@ -298,8 +330,6 @@ namespace oxen::quic
         std::string encode_response(int64_t rid, std::span<const std::byte> body, bool error);
 
         sent_request* add_sent_request(std::shared_ptr<sent_request> req);
-
-        size_t parse_length(std::string_view req);
 
         size_t num_pending_impl() const { return user_buffers.size(); }
 

--- a/src/btstream.cpp
+++ b/src/btstream.cpp
@@ -203,6 +203,51 @@ namespace oxen::quic
         }
     }
 
+    std::optional<size_t> prefix_accumulator(std::string& partial, std::span<const std::byte>& req)
+    {
+        std::optional<size_t> s;
+        auto it = req.begin();
+        for (; it != req.end(); ++it)
+        {
+            if (*it >= std::byte{'0'} && *it <= std::byte{'9'})
+            {
+                partial += static_cast<char>(*it);
+                if (partial.size() > MAX_REQ_LEN_ENCODED)
+                    throw std::invalid_argument{"invalid encoded data length"};
+            }
+            else if (*it == std::byte{':'})
+            {
+                if (partial.size() > 1 && partial.front() == '0')
+                    throw std::invalid_argument{"bt-encoded string size cannot begin with 0"};
+                [[maybe_unused]] auto [ptr, ec] =
+                        std::from_chars(partial.data(), partial.data() + partial.size(), s.emplace());
+                // These should be guaranteed by the parsing above
+                assert(ec == std::errc{});
+                assert(ptr == partial.data() + partial.size());
+                partial.clear();
+                ++it;
+                break;
+            }
+            else
+                throw std::invalid_argument{"invalid input: expected bt-encoded data block"};
+        }
+
+        req = {it, req.end()};
+        return s;
+    }
+
+    bool data_accumulator(std::vector<std::byte>& buf, std::span<const std::byte>& req, size_t size)
+    {
+        assert(buf.size() < size);
+        auto old_size = buf.size();
+        auto new_size = std::min(old_size + req.size(), size);
+        buf.resize(new_size);
+        std::memcpy(buf.data() + old_size, req.data(), new_size - old_size);
+        req = req.subspan(new_size - old_size);
+
+        return buf.size() == size;
+    }
+
     void BTRequestStream::process_incoming(std::span<const std::byte> req)
     {
         log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
@@ -211,80 +256,33 @@ namespace oxen::quic
         {
             if (current_len == 0)
             {
-                std::string_view sreq{reinterpret_cast<const char*>(req.data()), req.size()};
-                size_t consumed;
-                size_t prev_len = size_buf.size();
-                if (prev_len)
+                if (auto s = prefix_accumulator(size_buf, req))
                 {
-                    // We have some leftover digits in size_buf, so copy some more from the incoming
-                    // data to make size_buf up to MAX_REQ_LEN_ENCODED long:
-                    if (prev_len < MAX_REQ_LEN_ENCODED)
-                        size_buf += sreq.substr(0, MAX_REQ_LEN_ENCODED - prev_len);
-
-                    // Now see if we can parse a `N:` value out of it.
-                    consumed = parse_length(size_buf);
-                    // 0 means the : wasn't found *but* that the input value is still less than the
-                    // max, so we've already appended it and can just wait for more data to append.
-                    // (This case is rare; it would mean we only got a very small number of stream
-                    // bytes).
-                    if (consumed == 0)
-                        return;
-
-                    // Otherwise we successfully parsed the size, have updated current_len, and
-                    // don't need the size buffer anymore:
-                    size_buf.clear();
-                }
-                else
-                {
-                    // With no initial buffer we can just parse off the beginning of the input
-                    // value, to save copying it to buf in most cases.
-                    consumed = parse_length(sreq.substr(0, MAX_REQ_LEN_ENCODED));
-                    if (consumed == 0)
+                    current_len = *s;
+                    if (current_len == 0)
                     {
-                        // The input didn't contain a number, but wasn't long enough to definitively
-                        // be a number, so we copy what we have and then wait for more stream data
-                        // to arrive with the rest of the number.
-                        size_buf.resize(req.size());
-                        std::memcpy(size_buf.data(), req.data(), req.size());
+                        log::debug(log_cat, "Ignoring 0-length btstream body");
                         return;
                     }
+                    if (current_len > MAX_REQ_LEN)
+                        throw std::invalid_argument{"Request exceeds maximum size!"};
                 }
-                // If we get here, then we consumed `consumed` in total and parsed it into
-                // current_len, but that includes a possible `prev_len` characters we already had.
-                // So remove whatever arrived in this current call from the from of req; the
-                // remainder is the beginning of the incoming `current_len` request data bytes.
-                assert(consumed > prev_len);
-                req = req.subspan(consumed - prev_len);
+                else
+                    return;
+
+                assert(current_len > 0);  // We shouldn't get out of the above without knowing this
+                buf.reserve(current_len);
             }
 
-            assert(current_len > 0);  // We shouldn't get out of the above without knowing this
-
-            if (auto r_size = req.size() + buf.size(); r_size >= current_len)
+            if (data_accumulator(buf, req, current_len))
             {
-                // We have enough data for a complete request, so copy whatever we need to
-                // complete the current request into buf and process it, leaving behind the
-                // potential start of the next request:
-                if (buf.size() < current_len)
-                {
-                    size_t need = current_len - buf.size();
-                    buf.insert(buf.end(), req.begin(), req.begin() + need);
-                    req = req.subspan(need);
-                }
-
                 handle_input(message{*this, std::move(buf)});
                 buf.clear();
 
                 // Back to the top to try processing another request that might have arrived in
                 // the same stream buffer
                 current_len = 0;
-                continue;
             }
-
-            // Otherwise we don't have enough data on hand for a complete request, so move what we
-            // got to the buffer to be processed when the next incoming chunk of data arrives.
-            buf.reserve(current_len);
-            buf.insert(buf.end(), req.begin(), req.end());
-            return;
         }
     }
 
@@ -334,47 +332,6 @@ namespace oxen::quic
             return nullptr;
         }
         return sent_reqs.emplace_back(std::move(req)).get();
-    }
-
-    /** Returns:
-            0: length was incomplete
-            >0: number of characters (including colon) parsed from front of req
-
-        Error:
-            throws on invalid value
-    */
-    size_t BTRequestStream::parse_length(std::string_view req)
-    {
-        auto pos = req.find_first_of(':');
-
-        // request is incomplete with no readable request length
-        if (pos == std::string_view::npos)
-        {
-            if (req.size() >= MAX_REQ_LEN_ENCODED)
-                // we didn't find a valid length, but do have enough consumed for the maximum valid
-                // length, so something is clearly wrong with this input.
-                throw std::invalid_argument{"Invalid incoming request; invalid encoding or request too large"};
-
-            return 0;
-        }
-
-        auto [ptr, ec] = std::from_chars(req.data(), req.data() + pos, current_len);
-
-        const char* bad = nullptr;
-        if (ec != std::errc() || ptr != req.data() + pos)
-            bad = "Invalid incoming request encoding!";
-        else if (current_len == 0)
-            bad = "Invalid empty bt request!";
-        else if (current_len > MAX_REQ_LEN)
-            bad = "Request exceeds maximum size!";
-
-        if (bad)
-        {
-            close(BTREQ_ERROR_EXCEPTION);
-            throw std::invalid_argument{bad};
-        }
-
-        return pos + 1;
     }
 
     size_t BTRequestStream::num_pending() const


### PR DESCRIPTION
This is useful for custom streams that have a similar need to decode a prefix-length block of data but aren't actually a BTRequestStream.

This also rewrites the accumulation to be simpler.

Finally this allows (and ignores) an empty BTRequestStream data (e.g. `0:`).  This was a fatal BTRequestStream error before, but could be useful, for instance as a no-op to keep a connection alive without a quic-level keep-alive.