### PR TITLE
Explicit stream FIN sending and callback + related fixes

### DIFF
--- a/include/oxen/quic/connection.hpp
+++ b/include/oxen/quic/connection.hpp
@@ -507,7 +507,7 @@ namespace oxen::quic
         void stream_closed(int64_t id, uint64_t app_code);
         void close_all_streams();
         void check_pending_streams(uint64_t available);
-        int recv_datagram(std::span<const std::byte> data, bool fin);
+        int recv_datagram(std::span<const std::byte> data);
         int ack_datagram(uint64_t dgram_id);
         int recv_token(const uint8_t* token, size_t tokenlen);
 

--- a/include/oxen/quic/context.hpp
+++ b/include/oxen/quic/context.hpp
@@ -35,8 +35,6 @@ namespace oxen::quic
         Splitting policy{Splitting::NONE};
 
         std::optional<opt::outbound_alpns> out_alpns;
-
-        user_config() = default;
     };
 
     struct IOContext
@@ -47,6 +45,7 @@ namespace oxen::quic
         stream_data_callback stream_data_cb;
         stream_open_callback stream_open_cb;
         stream_close_callback stream_close_cb;
+        opt::stream_fin_callback stream_fin_cb;
         stream_constructor_callback stream_construct_cb;
         dgram_data_callback dgram_data_cb;
         connection_established_callback conn_established_cb;
@@ -76,6 +75,7 @@ namespace oxen::quic
         void handle_ioctx_opt(stream_data_callback func);
         void handle_ioctx_opt(stream_open_callback func);
         void handle_ioctx_opt(stream_close_callback func);
+        void handle_ioctx_opt(opt::stream_fin_callback cb);
         void handle_ioctx_opt(stream_constructor_callback func);
         // Overrides the datagram callback specified at the endpoint level, if given.
         void handle_ioctx_opt(dgram_data_callback func);

--- a/include/oxen/quic/datagram.hpp
+++ b/include/oxen/quic/datagram.hpp
@@ -22,9 +22,6 @@ namespace oxen::quic
     class Endpoint;
     class Datagrams;
 
-    // The pseudo "stream id" we use to indicate the datagram channel:
-    inline constexpr int64_t DATAGRAM_PSEUDO_STREAM_ID = std::numeric_limits<int64_t>::min();
-
     namespace dgram
     {
         struct received
@@ -414,7 +411,7 @@ namespace oxen::quic
         ///
         dgram::rotating_buffer recv_buffer;
 
-        std::optional<dgram::prepared> pending_datagram(bool prefer_small) override;
+        std::optional<dgram::prepared> pending(bool prefer_small);
         void confirm_datagram_sent();
 
         std::optional<std::vector<std::byte>> to_buffer(std::span<const std::byte> data, uint16_t dgid);
@@ -467,17 +464,11 @@ namespace oxen::quic
         void send_impl(std::span<const std::byte> data, std::shared_ptr<void> keep_alive) override;
 
         bool is_closing_impl() const override;
-        bool sent_fin() const override;
-        void set_fin(bool) override;
         size_t unsent_impl() const override;
         bool has_unsent_impl() const override;
-        void wrote(size_t) override;
-        std::vector<ngtcp2_vec> pending() override;
 
       public:
         bool is_stream() const override { return false; }
-        std::shared_ptr<Stream> get_stream() override;
-        int64_t stream_id() const override { return DATAGRAM_PSEUDO_STREAM_ID; }
     };
 
 }  // namespace oxen::quic

--- a/include/oxen/quic/endpoint.hpp
+++ b/include/oxen/quic/endpoint.hpp
@@ -3,6 +3,7 @@
 #include "address.hpp"
 #include "connection.hpp"
 #include "connection_ids.hpp"
+#include "context.hpp"
 #include "crypto.hpp"
 #include "datagram.hpp"
 #include "loop.hpp"
@@ -18,7 +19,6 @@
 #include <cstdint>
 #include <exception>
 #include <functional>
-#include <future>
 #include <list>
 #include <map>
 #include <memory>
@@ -35,8 +35,6 @@ struct event_base;
 
 namespace oxen::quic
 {
-    struct IOContext;
-
     class Endpoint : public std::enable_shared_from_this<Endpoint>
     {
       public:

--- a/include/oxen/quic/iochannel.hpp
+++ b/include/oxen/quic/iochannel.hpp
@@ -55,8 +55,6 @@ namespace oxen::quic
         IOChannel& operator=(IOChannel&&) = delete;
 
         virtual bool is_stream() const = 0;
-        virtual std::shared_ptr<Stream> get_stream() = 0;
-        virtual int64_t stream_id() const = 0;
 
         // Returns this channel's connection object.  Will return a nullptr if the Connection no
         // longer exists.
@@ -104,12 +102,6 @@ namespace oxen::quic
         // This is the (single) send implementation that implementing classes must provide; other
         // calls to send are converted into calls to this.
         virtual void send_impl(std::span<const std::byte>, std::shared_ptr<void> keep_alive) = 0;
-
-        virtual std::vector<ngtcp2_vec> pending() = 0;
-        virtual std::optional<dgram::prepared> pending_datagram(bool) = 0;
-        virtual bool sent_fin() const = 0;
-        virtual void set_fin(bool) = 0;
-        virtual void wrote(size_t) = 0;
 
         // Does the actual implementation: these methods may only be called internally, from code
         // already inside the event loop thread.  (The public non-_impl versions of these methods

--- a/include/oxen/quic/stream.hpp
+++ b/include/oxen/quic/stream.hpp
@@ -51,6 +51,14 @@ namespace oxen::quic
         struct stream_notify_t
         {};
         constexpr stream_notify_t stream_notify{};
+
+        // opt::stream_fin allows passing a callback that will be called when the remote has
+        // send a FIN bit (which indicates that it will send no more data).  This callback will be
+        // called after all stream data has been processed.
+        struct stream_fin_callback
+        {
+            std::function<void(Stream&)> cb;
+        };
     }  // namespace opt
 
     class Stream : public IOChannel, public std::enable_shared_from_this<Stream>
@@ -78,6 +86,7 @@ namespace oxen::quic
         void handle_opt(stream_data_callback data_cb);
         void handle_opt(stream_close_callback close_cb);
         void handle_opt(opt::stream_notify_t);
+        void handle_opt(opt::stream_fin_callback fin_cb);
 
         void set_default_callbacks();
 
@@ -85,7 +94,7 @@ namespace oxen::quic
         ~Stream() override;
 
         bool is_stream() const override { return true; }
-        int64_t stream_id() const override { return _stream_id; }
+        int64_t stream_id() const { return _stream_id; }
 
         const ConnectionID reference_id;
 
@@ -164,8 +173,14 @@ namespace oxen::quic
          */
         void resume();
 
-        // Returns true if the stream is usable, i.e. not closing or shutdown.
-        bool available() const;
+        // Returns true if the stream is writeable, i.e. not closing, shutdown and FIN not sent or
+        // scheduled.
+        bool writable() const;
+
+        // Returns true if the stream is potentially readable, i.e. not closed and the other side
+        // has not sent a FIN yet.  A false return value means no more data will arrive on this
+        // stream.
+        bool readable() const;
 
         // Returns true if the stream is ready, that is, has an assigned stream ID and can send data
         // to the other side.  Note that, when a connection is established using 0-RTT, new streams
@@ -176,15 +191,24 @@ namespace oxen::quic
         // available streams.
         bool is_ready() const;
 
-        std::shared_ptr<Stream> get_stream() override;
+        // Queues a FIN bit to be sent on the stream, and stop accepting any new stream data (i.e.
+        // calling send() after this has been called on a stream simply drops the data).  If there
+        // is currently queued data then the FIN bit is sent with the final stream data; if there is
+        // no queued data then this causes an empty stream frame with a FIN bit to be sent.
+        void send_fin();
 
         void close(uint64_t app_err_code = 0);
 
-        void set_stream_data_cb(stream_data_callback cb) { data_callback = std::move(cb); }
-        void set_stream_close_cb(stream_close_callback cb) { close_callback = std::move(cb); }
+        // Replaces the existing stream data callback (if any) with the given one.
+        void set_data_callback(stream_data_callback cb);
+        // Replaces the existing stream close callback (if any) with the given one.
+        void set_close_callback(stream_close_callback cb);
+        // Replaces the existing stream FIN callback (if any) with the given one.
+        void set_fin_callback(std::function<void(Stream&)> cb);
 
         stream_data_callback data_callback;
         stream_close_callback close_callback;
+        std::function<void(Stream&)> fin_callback;
 
       protected:
         virtual void receive(std::span<const std::byte> data)
@@ -211,6 +235,11 @@ namespace oxen::quic
         // only be momentary.  See above.
         virtual void on_unready() {}
 
+        // Called when a stream FIN is received from the other end, indicating that the other end
+        // will send no more data.  Calls the fin_callback, if set.  If overriding, be sure to call
+        // the base class method to properly set the _received_fin bit.
+        virtual void on_fin();
+
         /// Called periodically to check if anything needs to be timed out.  The default does
         /// nothing, but subclasses can override to not do nothing if it's not the case that nothing
         /// ain't not good enough isn't false.
@@ -219,9 +248,6 @@ namespace oxen::quic
         void send_impl(std::span<const std::byte> data, std::shared_ptr<void> keep_alive) override;
 
         stream_buffer user_buffers;
-
-        bool sent_fin() const override { return _sent_fin; }
-        void set_fin(bool v) override { _sent_fin = v; }
 
         bool has_unsent_impl() const override { return not is_empty_impl(); }
         bool is_closing_impl() const override { return _is_closing; }
@@ -232,12 +258,19 @@ namespace oxen::quic
         // Called if 0-RTT early data was rejected; marks all sent data as unsent
         void revert_stream();
 
-        std::vector<ngtcp2_vec> pending() override;
+        // Returns ngtcp2 vector of user buffer pointers of unsent data.  Returned buffers cover at
+        // least `bytes` of unsent data (if available).  The second value of the pair will be true
+        // if there is more stream data queued beyond the returned user buffers, or if the user
+        // buffers cover to the end of currently queued data.  (If there is no `more` *and*
+        // _send_fin is set then we know it is time to give the FIN flag to ngtcp2).  This is
+        // primary used by connection.cpp to obtain the next chunk of data from this stream.
+        std::pair<std::vector<ngtcp2_vec>, bool> pending(size_t bytes);
 
         size_t _unacked_size{0};
         bool _is_closing{false};
-        bool _is_shutdown{false};
+        bool _send_fin{false};
         bool _sent_fin{false};
+        bool _received_fin{false};
         bool _ready{false};
         bool _paused{false};
         bool _notify{false};
@@ -251,7 +284,7 @@ namespace oxen::quic
         std::function<void(Stream&)> _watermark_on_alarm;
         std::function<void(Stream&)> _watermark_on_clear;
 
-        void wrote(size_t bytes) override;
+        void wrote(size_t bytes);
 
         void append_buffer(std::span<const std::byte> buffer, std::shared_ptr<void> keep_alive);
 
@@ -369,8 +402,6 @@ namespace oxen::quic
                 str.send(bsv, std::move(next));
             }
         };
-
-        std::optional<dgram::prepared> pending_datagram(bool) override;
 
       public:
         /// Sends data in chunks: `next_chunk` is some callable (e.g. lambda) that will be called

--- a/include/oxen/quic/stream.hpp
+++ b/include/oxen/quic/stream.hpp
@@ -206,15 +206,11 @@ namespace oxen::quic
         // Replaces the existing stream FIN callback (if any) with the given one.
         void set_fin_callback(std::function<void(Stream&)> cb);
 
-        stream_data_callback data_callback;
-        stream_close_callback close_callback;
-        std::function<void(Stream&)> fin_callback;
-
       protected:
         virtual void receive(std::span<const std::byte> data)
         {
-            if (data_callback)
-                data_callback(*this, data);
+            if (_data_callback)
+                _data_callback(*this, data);
         }
 
         virtual void closed(uint64_t app_code);
@@ -278,6 +274,10 @@ namespace oxen::quic
         int64_t _stream_id;
 
         size_t _paused_offset{0};
+
+        stream_data_callback _data_callback;
+        stream_close_callback _close_callback;
+        std::function<void(Stream&)> _fin_callback;
 
         std::optional<std::pair<size_t, size_t>> _watermarking;  // {alarm threshold, all-clear threshold}
         bool _watermark_alarm{false};

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -77,11 +77,10 @@ namespace oxen::quic
         }
 
         static int on_recv_datagram(
-                ngtcp2_conn* /* conn */, uint32_t flags, const uint8_t* data, size_t datalen, void* user_data)
+                ngtcp2_conn* /* conn */, uint32_t /*flags*/, const uint8_t* data, size_t datalen, void* user_data)
         {
             log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
-            return static_cast<Connection*>(user_data)->recv_datagram(
-                    {reinterpret_cast<const std::byte*>(data), datalen}, flags & NGTCP2_STREAM_DATA_FLAG_FIN);
+            return static_cast<Connection*>(user_data)->recv_datagram({reinterpret_cast<const std::byte*>(data), datalen});
         }
 
         static int on_recv_token(ngtcp2_conn* /* conn */, const uint8_t* token, size_t tokenlen, void* user_data)
@@ -820,7 +819,8 @@ namespace oxen::quic
         if (!stream && default_stream)
             stream = default_stream(*this, _endpoint);
         if (!stream)
-            stream = _loop.make_shared<Stream>(*this, _endpoint, context->stream_data_cb, context->stream_close_cb);
+            stream = _loop.make_shared<Stream>(
+                    *this, _endpoint, context->stream_data_cb, context->stream_close_cb, context->stream_fin_cb);
 
         return stream;
     }
@@ -1103,27 +1103,33 @@ namespace oxen::quic
             ngtcp2_ssize nwrite = 0;
             ngtcp2_ssize ndatalen;
             uint32_t flags = 0;
-            int64_t stream_id = -10;
+            int64_t stream_id;
 
             auto* source = channels.front();
             channels.pop_front();  // Pop it off; if this stream should be checked again, append just
                                    // before streams_end_it.
 
+            const bool is_stream = source->is_stream();
+
             // this block will execute all "real" streams plus the "pseudo stream" of ID -1 to finish
             // off any packets that need to be sent
-            if (source->is_stream())
+            if (is_stream)
             {
-                std::vector<ngtcp2_vec> bufs = source->pending();
+                auto* s = static_cast<Stream*>(source);
+                auto [bufs, more] = s->pending(MAX_PMTUD_UDP_PAYLOAD);
 
-                stream_id = source->stream_id();
+                stream_id = s->stream_id();
 
+                flags = NGTCP2_WRITE_STREAM_FLAG_MORE;
+
+                bool sending_fin = false;
                 if (stream_id != -1)
                 {
-                    if (source->is_closing() && !source->sent_fin() && source->unsent() == 0)
+                    if (s->_send_fin && !more)
                     {
                         log::trace(log_cat, "Sending FIN");
                         flags |= NGTCP2_WRITE_STREAM_FLAG_FIN;
-                        source->set_fin(true);
+                        sending_fin = true;
                     }
                     else if (bufs.empty())
                     {
@@ -1139,11 +1145,23 @@ namespace oxen::quic
                         buf_pos,
                         MAX_PMTUD_UDP_PAYLOAD,
                         &ndatalen,
-                        flags |= NGTCP2_WRITE_STREAM_FLAG_MORE,
+                        flags,
                         stream_id,
                         bufs.data(),
                         bufs.size(),
                         ts);
+
+                if (sending_fin && ndatalen >= 0)
+                {
+                    // If we're trying to send the FIN bit and ngtcp2 accepted data from us then
+                    // whether we *actually* send the FIN bit depends on whether ngtcp2 actually
+                    // consumed all the data we offered:
+                    size_t total = 0;
+                    for (auto& b : bufs)
+                        total += b.len;
+                    if (static_cast<size_t>(ndatalen) == total)
+                        s->_sent_fin = true;
+                }
 
                 log::trace(log_cat, "add_stream_data for stream {} returned [{},{}]", stream_id, nwrite, ndatalen);
             }
@@ -1157,9 +1175,10 @@ namespace oxen::quic
 
                 datagram_waiting = true;  // This will remain true only if we have datagrams pending
                                           // but accept none of them into the packet.
+                flags = NGTCP2_WRITE_DATAGRAM_FLAG_MORE;
                 for (;;)
                 {
-                    auto dgram = dgrams->pending_datagram(partially_filled);
+                    auto dgram = dgrams->pending(partially_filled);
                     if (!dgram)
                     {
                         datagram_waiting = false;
@@ -1174,7 +1193,7 @@ namespace oxen::quic
                             buf_pos,
                             MAX_PMTUD_UDP_PAYLOAD,
                             &accepted,
-                            flags |= NGTCP2_WRITE_DATAGRAM_FLAG_MORE,
+                            flags,
                             dgram->id,
                             dgram->data(),
                             dgram->size(),
@@ -1198,7 +1217,7 @@ namespace oxen::quic
             // congested
             if (nwrite == 0)
             {
-                bool congested = source->is_stream() && stream_id != -1;
+                bool congested = is_stream && stream_id != -1;
                 log::trace(
                         log_cat,
                         "Done writing: {}",
@@ -1227,12 +1246,12 @@ namespace oxen::quic
                 {
                     partially_filled = true;
 
-                    if (source->is_stream())
+                    if (is_stream)
                     {
                         log::trace(log_cat, "Consumed {} bytes from stream {} and have space left", ndatalen, stream_id);
                         assert(ndatalen >= 0);
                         if (stream_id != -1)
-                            source->wrote(ndatalen);
+                            static_cast<Stream*>(source)->wrote(ndatalen);
                     }
                     else
                     {
@@ -1250,10 +1269,10 @@ namespace oxen::quic
 
             partially_filled = false;
 
-            if (stream_id > -1 && ndatalen >= 0)
+            if (is_stream && stream_id != -1 && ndatalen >= 0)
             {
                 log::trace(log_cat, "consumed {} bytes from stream {}", ndatalen, stream_id);
-                source->wrote(ndatalen);
+                static_cast<Stream*>(source)->wrote(ndatalen);
             }
 
             // success
@@ -1392,7 +1411,7 @@ namespace oxen::quic
     void Connection::stream_execute_close(Stream& stream, uint64_t app_code)
     {
         const bool was_closing = stream._is_closing;
-        stream._is_closing = stream._is_shutdown = true;
+        stream._is_closing = true;
 
         stream.disable_watermarks();
 
@@ -1483,9 +1502,14 @@ namespace oxen::quic
         if (data.size() == 0)
         {
             log::debug(
-                    log_cat,
-                    "Stream (ID: {}) received empty fin frame, bypassing user-supplied data callback",
-                    str->_stream_id);
+                    log_cat, "Stream (ID: {}) received empty frame, bypassing user-supplied data callback", str->_stream_id);
+
+            if (fin)
+            {
+                log::info(log_cat, "Stream ID: {} sent FIN bit (in empty stream frame)", str->_stream_id);
+                str->on_fin();
+            }
+
             return 0;
         }
 
@@ -1533,8 +1557,8 @@ namespace oxen::quic
 
         if (fin)
         {
-            log::info(log_cat, "Stream {} closed by remote", str->_stream_id);
-            // no clean up, close_cb called after this
+            log::info(log_cat, "Stream {} sent FIN bit", str->_stream_id);
+            str->on_fin();
         }
         else
         {
@@ -1555,7 +1579,7 @@ namespace oxen::quic
         return 0;
     }
 
-    int Connection::recv_datagram(std::span<const std::byte> data, bool fin)
+    int Connection::recv_datagram(std::span<const std::byte> data)
     {
         log::trace(log_cat, "Connection (CID: {}) received datagram: {}", _source_cid, buffer_printer{data});
 
@@ -1631,12 +1655,6 @@ namespace oxen::quic
                 _endpoint.close_connection(*this, io_error{DATAGRAM_ERROR_EXCEPTION});
                 return NGTCP2_ERR_CALLBACK_FAILURE;
             }
-        }
-
-        if (fin)
-        {
-            log::debug(log_cat, "Connection (CID: {}) received FIN from remote", _source_cid);
-            // TODO: no clean up, as close cb is called after? Or just for streams
         }
 
         return 0;

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -1,6 +1,7 @@
 #include "context.hpp"
 
 #include "internal.hpp"
+#include "stream.hpp"
 
 #include <fmt/ranges.h>
 
@@ -69,6 +70,12 @@ namespace oxen::quic
     {
         log::trace(log_cat, "IO context stored stream open callback");
         stream_close_cb = std::move(func);
+    }
+
+    void IOContext::handle_ioctx_opt(opt::stream_fin_callback cb)
+    {
+        log::trace(log_cat, "IO context stored stream fin callback, {}", !!cb.cb);
+        stream_fin_cb = std::move(cb);
     }
 
     void IOContext::handle_ioctx_opt(stream_constructor_callback func)

--- a/src/datagram.cpp
+++ b/src/datagram.cpp
@@ -19,25 +19,10 @@ namespace oxen::quic
         log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
     }
 
-    std::shared_ptr<Stream> Datagrams::get_stream()
-    {
-        log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
-        return nullptr;
-    }
-
     bool Datagrams::is_closing_impl() const
     {
         log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
         return false;
-    }
-    bool Datagrams::sent_fin() const
-    {
-        log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
-        return false;
-    }
-    void Datagrams::set_fin(bool)
-    {
-        log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
     }
     size_t Datagrams::unsent_impl() const
     {
@@ -48,16 +33,6 @@ namespace oxen::quic
     {
         return not is_empty_impl();
     }
-    void Datagrams::wrote(size_t)
-    {
-        log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
-    }
-    std::vector<ngtcp2_vec> Datagrams::pending()
-    {
-        log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
-        return {};
-    }
-
     void Datagrams::early_data_begin()
     {
         _send_buffer.early_data_begin();
@@ -108,7 +83,7 @@ namespace oxen::quic
         });
     }
 
-    std::optional<dgram::prepared> Datagrams::pending_datagram(bool prefer_small)
+    std::optional<dgram::prepared> Datagrams::pending(bool prefer_small)
     {
         log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
         return _send_buffer.fetch(_conn->get_max_datagram_piece(), prefer_small);

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -21,11 +21,11 @@ namespace oxen::quic
 {
     void Stream::handle_opt(stream_data_callback data_cb)
     {
-        data_callback = std::move(data_cb);
+        _data_callback = std::move(data_cb);
     }
     void Stream::handle_opt(stream_close_callback close_cb)
     {
-        close_callback = std::move(close_cb);
+        _close_callback = std::move(close_cb);
     }
     void Stream::handle_opt(opt::stream_notify_t)
     {
@@ -35,7 +35,7 @@ namespace oxen::quic
     void Stream::handle_opt(opt::stream_fin_callback fcb)
     {
         log::trace(log_cat, "{} fin callback", fcb.cb ? "Setting" : "Not setting (callback is nullptr)");
-        fin_callback = std::move(fcb.cb);
+        _fin_callback = std::move(fcb.cb);
     }
     Stream::Stream(Connection& conn, Endpoint& ep, base_ctor) : IOChannel{conn, ep}, reference_id{conn.reference_id()}
     {
@@ -43,11 +43,11 @@ namespace oxen::quic
     }
     void Stream::set_default_callbacks()
     {
-        if (!data_callback)
-            data_callback = _conn->get_default_data_callback();
+        if (!_data_callback)
+            _data_callback = _conn->get_default_data_callback();
 
-        if (!close_callback)
-            close_callback = [](Stream&, uint64_t error_code) {
+        if (!_close_callback)
+            _close_callback = [](Stream&, uint64_t error_code) {
                 log::debug(log_cat, "Default stream close callback called ({})", quic_strerror(error_code));
             };
 
@@ -169,8 +169,8 @@ namespace oxen::quic
     void Stream::on_fin()
     {
         _received_fin = true;
-        if (fin_callback)
-            fin_callback(*this);
+        if (_fin_callback)
+            _fin_callback(*this);
     }
 
     void Stream::send_fin()
@@ -202,7 +202,7 @@ namespace oxen::quic
                     ngtcp2_conn_shutdown_stream(*_conn, 0, _stream_id, app_err_code);
                 }
             }
-            data_callback = nullptr;
+            _data_callback = nullptr;
 
             if (!_conn)
             {
@@ -216,24 +216,24 @@ namespace oxen::quic
 
     void Stream::set_data_callback(stream_data_callback cb)
     {
-        loop.call_get([&] { data_callback = std::move(cb); });
+        loop.call_get([&] { _data_callback = std::move(cb); });
     }
     void Stream::set_close_callback(stream_close_callback cb)
     {
-        loop.call_get([&] { close_callback = std::move(cb); });
+        loop.call_get([&] { _close_callback = std::move(cb); });
     }
     void Stream::set_fin_callback(std::function<void(Stream&)> cb)
     {
-        loop.call_get([&] { fin_callback = std::move(cb); });
+        loop.call_get([&] { _fin_callback = std::move(cb); });
     }
 
     void Stream::closed(uint64_t app_code)
     {
-        if (close_callback)
+        if (_close_callback)
         {
             try
             {
-                close_callback(*this, app_code);
+                _close_callback(*this, app_code);
             }
             catch (const std::exception& e)
             {

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -32,6 +32,11 @@ namespace oxen::quic
         _notify = true;
         _had_notify = true;
     }
+    void Stream::handle_opt(opt::stream_fin_callback fcb)
+    {
+        log::trace(log_cat, "{} fin callback", fcb.cb ? "Setting" : "Not setting (callback is nullptr)");
+        fin_callback = std::move(fcb.cb);
+    }
     Stream::Stream(Connection& conn, Endpoint& ep, base_ctor) : IOChannel{conn, ep}, reference_id{conn.reference_id()}
     {
         log::trace(log_cat, "Creating Stream object...");
@@ -62,7 +67,7 @@ namespace oxen::quic
                     "Invalid enable_watermarks() call: alarm watermark ({}) must be > clear watermark ({})"_format(
                             alarm, clear)};
         loop.call_get([&] {
-            if (_is_closing || _is_shutdown || _sent_fin)
+            if (_is_closing || _send_fin)
             {
                 log::debug(log_cat, "Failed to set watermarks; stream is not active!");
                 return;
@@ -138,9 +143,13 @@ namespace oxen::quic
         return loop.call_get([this]() { return _paused; });
     }
 
-    bool Stream::available() const
+    bool Stream::writable() const
     {
-        return loop.call_get([this] { return !(_is_closing || _is_shutdown || _sent_fin); });
+        return loop.call_get([this] { return !(_is_closing || _send_fin || _sent_fin); });
+    }
+    bool Stream::readable() const
+    {
+        return loop.call_get([this] { return !(_is_closing || _received_fin); });
     }
 
     bool Stream::is_ready() const
@@ -157,9 +166,19 @@ namespace oxen::quic
         });
     }
 
-    std::shared_ptr<Stream> Stream::get_stream()
+    void Stream::on_fin()
     {
-        return shared_from_this();
+        _received_fin = true;
+        if (fin_callback)
+            fin_callback(*this);
+    }
+
+    void Stream::send_fin()
+    {
+        loop.call([this] {
+            _send_fin = true;
+            _conn->packet_io_ready();
+        });
     }
 
     void Stream::close(uint64_t app_err_code)
@@ -172,21 +191,18 @@ namespace oxen::quic
         loop.call([this, app_err_code]() {
             log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
 
-            if (_is_shutdown)
-                log::trace(log_cat, "Stream is already shutting down");
-            else if (_is_closing)
+            if (_is_closing)
                 log::trace(log_cat, "Stream is already closing");
             else
             {
-                _is_closing = _is_shutdown = true;
+                _send_fin = _is_closing = true;
                 if (_conn)
                 {
                     log::info(log_cat, "Closing stream (ID: {}) with: {}", _stream_id, quic_strerror(app_err_code));
                     ngtcp2_conn_shutdown_stream(*_conn, 0, _stream_id, app_err_code);
                 }
             }
-            if (_is_shutdown)
-                data_callback = nullptr;
+            data_callback = nullptr;
 
             if (!_conn)
             {
@@ -196,6 +212,19 @@ namespace oxen::quic
 
             _conn->packet_io_ready();
         });
+    }
+
+    void Stream::set_data_callback(stream_data_callback cb)
+    {
+        loop.call_get([&] { data_callback = std::move(cb); });
+    }
+    void Stream::set_close_callback(stream_close_callback cb)
+    {
+        loop.call_get([&] { close_callback = std::move(cb); });
+    }
+    void Stream::set_fin_callback(std::function<void(Stream&)> cb)
+    {
+        loop.call_get([&] { fin_callback = std::move(cb); });
     }
 
     void Stream::closed(uint64_t app_code)
@@ -213,7 +242,7 @@ namespace oxen::quic
         }
 
         _conn = nullptr;
-        _is_closing = _is_shutdown = true;
+        _send_fin = _is_closing = true;
     }
 
     void Stream::check_watermark()
@@ -324,11 +353,12 @@ namespace oxen::quic
         log::debug(log_cat, "Stream (ID:{}) has {}B in buffer, 0B unacked...", _stream_id, size());
     }
 
-    std::vector<ngtcp2_vec> Stream::pending()
+    std::pair<std::vector<ngtcp2_vec>, bool> Stream::pending(size_t bytes)
     {
         log::trace(log_cat, "{} called", __PRETTY_FUNCTION__);
 
-        std::vector<ngtcp2_vec> nbufs{};
+        std::pair<std::vector<ngtcp2_vec>, bool> ret;
+        auto& [nbufs, more] = ret;
 
         log::trace(log_cat, "unsent: {}", unsent());
 
@@ -340,22 +370,25 @@ namespace oxen::quic
                 // and we haven't done so yet, so return an empty buffer.
                 nbufs.emplace_back(nullptr, 0);
             }
-            return nbufs;
+            more = false;
+            return ret;
         }
 
         auto [it, offset] = get_buffer_it(user_buffers, _unacked_size);
-        nbufs.reserve(std::distance(it, user_buffers.end()));
         auto& temp = nbufs.emplace_back();
         temp.base = const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(it->first.data() + offset));
         temp.len = it->first.size() - offset;
-        while (++it != user_buffers.end())
+        size_t total = temp.len;
+        for (++it; it != user_buffers.end() && total < bytes; ++it)
         {
             auto& temp = nbufs.emplace_back();
             temp.base = const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(it->first.data()));
             temp.len = it->first.size();
+            total += temp.len;
         }
 
-        return nbufs;
+        more = it != user_buffers.end();
+        return ret;
     }
 
     void Stream::send_impl(std::span<const std::byte> data, std::shared_ptr<void> keep_alive)
@@ -390,9 +423,9 @@ namespace oxen::quic
             }
             // else send() was already inside the event loop and thus `this` is still valid
 
-            if (_is_closing || _is_shutdown || _sent_fin)
+            if (_is_closing || _send_fin || _sent_fin)
             {
-                log::debug(log_cat, "Stream {} is closing/shutting down, dropping send data", _stream_id);
+                log::debug(log_cat, "Stream {} is already finalized, dropping send data", _stream_id);
                 return;
             }
             else if (!_conn || _conn->is_closing() || _conn->is_draining())
@@ -432,12 +465,6 @@ namespace oxen::quic
     void _chunk_sender_trace(const char* file, int lineno, std::string_view message, size_t val)
     {
         log::trace(log_cat, "{}:{} -- {}{}", file, lineno, message, val);
-    }
-
-    std::optional<dgram::prepared> Stream::pending_datagram(bool)
-    {
-        log::warning(log_cat, "{} called, but this is a stream object!", __PRETTY_FUNCTION__);
-        return std::nullopt;
     }
 
 }  // namespace oxen::quic

--- a/tests/004-streams.cpp
+++ b/tests/004-streams.cpp
@@ -1,3 +1,4 @@
+#include "oxen/quic/stream.hpp"
 #include "unit_test.hpp"
 
 namespace oxen::quic::test
@@ -1082,10 +1083,10 @@ namespace oxen::quic::test
 
         auto s1 = conn->open_stream();
         CHECK(s1->is_closing());
-        CHECK_FALSE(s1->available());
+        CHECK_FALSE(s1->writable());
         auto s2 = conn->queue_incoming_stream();
         CHECK(s2->is_closing());
-        CHECK_FALSE(s2->available());
+        CHECK_FALSE(s2->writable());
         CHECK(conn->num_streams_active() == 0);
         CHECK(conn->num_streams_pending() == 0);
     }
@@ -1134,6 +1135,127 @@ namespace oxen::quic::test
         require_future(fut_cstream);
         auto cstream_id = fut_cstream.get();
         CHECK(cstream_id == 1);
+    }
+
+    TEST_CASE("004 - Stream FIN", "[004][streams][fin]")
+    {
+        auto [client_tls, server_tls] = defaults::tls_creds_from_ed_keys();
+
+        quic::Loop loop;
+
+        std::promise<std::shared_ptr<Connection>> server_conn;
+        auto s_conn_fut = server_conn.get_future();
+        std::shared_ptr<Stream> sserver, sclient;
+
+        std::promise<int64_t> got_sstream, got_cstream;
+        auto fut_sstream = got_sstream.get_future(), fut_cstream = got_cstream.get_future();
+        auto server_endpoint = Endpoint::endpoint(
+                loop, Address{}, [&server_conn](Connection& c) { server_conn.set_value(c.shared_from_this()); });
+
+        std::unordered_map<int64_t, std::string> received;
+
+        std::promise<void> s0_fin, s1_fin, c0_fin, c1_fin;
+        server_endpoint->listen(
+                server_tls,
+                [&](Stream& s) -> uint64_t {
+                    s.set_data_callback([&](Stream& s, std::span<const std::byte> data) {
+                        received[s.stream_id()] += std::string_view{reinterpret_cast<const char*>(data.data()), data.size()};
+                    });
+                    got_sstream.set_value(s.stream_id());
+                    return 0;
+                },
+                opt::stream_fin_callback{[&](Stream&) { s0_fin.set_value(); }});
+
+        RemoteAddress client_remote{defaults::SERVER_PUBKEY, LOCALHOST, server_endpoint->local().port()};
+
+        auto client_endpoint = Endpoint::endpoint(loop, Address{});
+        auto conn = client_endpoint->connect(client_remote, client_tls, [&](Stream& s) -> uint64_t {
+            s.set_data_callback([&](Stream& s, std::span<const std::byte> data) {
+                received[s.stream_id()] += std::string_view{reinterpret_cast<const char*>(data.data()), data.size()};
+            });
+            s.set_fin_cb([&](Stream&) { c1_fin.set_value(); });
+            got_cstream.set_value(s.stream_id());
+            return 0;
+        });
+
+        auto c_str = conn->open_stream(opt::stream_fin_callback{[&](Stream&) { c0_fin.set_value(); }});
+        c_str->send("a");
+
+        require_future(s_conn_fut);
+        require_future(fut_sstream);
+
+        auto sstream_id = fut_sstream.get();
+        CHECK(sstream_id == 0);
+
+        auto s_str = s_conn_fut.get()->open_stream();
+        s_str->set_fin_cb([&](Stream&) { s1_fin.set_value(); });
+        s_str->send("z");
+
+        require_future(fut_cstream);
+        auto cstream_id = fut_cstream.get();
+        CHECK(cstream_id == 1);
+
+        auto s0_fin_fut = s0_fin.get_future();
+        auto s1_fin_fut = s1_fin.get_future();
+        auto c0_fin_fut = c0_fin.get_future();
+        auto c1_fin_fut = c1_fin.get_future();
+
+        std::string payload;
+
+        bool client_to_server;
+        SECTION("Client to server, small data")
+        {
+            client_to_server = true;
+            payload.resize(100, '#');
+        }
+        SECTION("Client to server, big data")
+        {
+            client_to_server = true;
+            payload.resize(10000, '#');
+        }
+        SECTION("Client to server, no data")
+        {
+            client_to_server = true;
+        }
+        SECTION("Server to client, small data")
+        {
+            client_to_server = false;
+            payload.resize(100, '#');
+        }
+        SECTION("Server to client, big data")
+        {
+            client_to_server = false;
+            payload.resize(10000, '#');
+        }
+        SECTION("Server to client, no data")
+        {
+            client_to_server = false;
+        }
+
+        auto& sender_str = client_to_server ? c_str : s_str;
+
+        if (payload.empty())
+            sender_str->send_fin();
+        else
+            loop.call([&] {
+                sender_str->send(payload, nullptr);
+                sender_str->send_fin();
+            });
+
+        auto& fin_fut = client_to_server ? s0_fin_fut : c1_fin_fut;
+        require_future(fin_fut);
+
+        CHECK(received.size() == 2);
+        REQUIRE(received.contains(0));
+        REQUIRE(received.contains(1));
+
+        auto& buf = received[client_to_server ? 0 : 1];
+        CHECK(buf.size() == 1 + payload.size());
+        CHECK(buf.starts_with(client_to_server ? "a" : "z"));
+        CHECK(buf.ends_with(payload));
+
+        auto& other = received[client_to_server ? 1 : 0];
+        CHECK(other == (client_to_server ? "z" : "a"));
     }
 
 }  // namespace oxen::quic::test

--- a/tests/004-streams.cpp
+++ b/tests/004-streams.cpp
@@ -1173,7 +1173,7 @@ namespace oxen::quic::test
             s.set_data_callback([&](Stream& s, std::span<const std::byte> data) {
                 received[s.stream_id()] += std::string_view{reinterpret_cast<const char*>(data.data()), data.size()};
             });
-            s.set_fin_cb([&](Stream&) { c1_fin.set_value(); });
+            s.set_fin_callback([&](Stream&) { c1_fin.set_value(); });
             got_cstream.set_value(s.stream_id());
             return 0;
         });
@@ -1188,7 +1188,7 @@ namespace oxen::quic::test
         CHECK(sstream_id == 0);
 
         auto s_str = s_conn_fut.get()->open_stream();
-        s_str->set_fin_cb([&](Stream&) { s1_fin.set_value(); });
+        s_str->set_fin_callback([&](Stream&) { s1_fin.set_value(); });
         s_str->send("z");
 
         require_future(fut_cstream);

--- a/tests/006-server-send.cpp
+++ b/tests/006-server-send.cpp
@@ -17,20 +17,20 @@ namespace oxen::quic::test
         std::future<void> server_future = server_promise.get_future(), client_future = client_promise.get_future(),
                           stream_future = stream_promise.get_future();
 
-        stream_open_callback server_io_open_cb = [&](IOChannel& s) {
+        stream_open_callback server_io_open_cb = [&](Stream& s) {
             log::debug(test_cat, "Calling server stream open callback... stream opened...");
-            server_stream = s.get_stream();
+            server_stream = s.shared_from_this();
             stream_promise.set_value();
             return 0;
         };
 
-        stream_data_callback server_io_data_cb = [&](IOChannel&, std::span<const std::byte>) {
+        stream_data_callback server_io_data_cb = [&](Stream&, std::span<const std::byte>) {
             log::debug(test_cat, "Calling server stream data callback... data received... incrementing counter...");
             data_check += 1;
             server_promise.set_value();
         };
 
-        stream_data_callback client_io_data_cb = [&](IOChannel&, std::span<const std::byte>) {
+        stream_data_callback client_io_data_cb = [&](Stream&, std::span<const std::byte>) {
             log::debug(test_cat, "Calling client stream data callback... data received... incrementing counter...");
             data_check += 1;
             client_promise.set_value();
@@ -84,7 +84,7 @@ namespace oxen::quic::test
 
         stream_open_callback server_io_open_cb = [&](Stream& s) {
             log::debug(test_cat, "Calling server stream open callback... stream opened...");
-            server_extracted_stream = s.get_stream();
+            server_extracted_stream = s.shared_from_this();
             try
             {
                 server_promises.at(si).set_value();
@@ -99,7 +99,7 @@ namespace oxen::quic::test
 
         stream_open_callback client_io_open_cb = [&](Stream& s) {
             log::debug(test_cat, "Calling client stream open callback... stream opened...");
-            client_extracted_stream = s.get_stream();
+            client_extracted_stream = s.shared_from_this();
             try
             {
                 client_promises.at(ci).set_value();


### PR DESCRIPTION
This adds support for expliciting sending a FIN on a stream to signal to
the other side that you are done writing to the stream without closing
the connection by calling `send_fin()` on the stream.

This also adds a opt::stream_fin_callback to allow setting a handler
that will be invoked after all stream data has been processed and the
FIN stream been received, i.e. called at the end of all incoming stream
data.

Along the way, this encountered a bunch of weirdness, fixed here:
- removed pointless explicit default `user_config` constructor
- removed pointless "pseudo stream id" for datagrams
- removed a bunch of pointless stream-only and datagram-only methods
  from IOChannel; those are now simply stream or datagram methods (and
  we already know we can static cast to those based on whether the
  generic pointer is a stream or not).  The list of pointless
  stream-only methods: `stream_id`, `get_stream`, `pending`, `sent_fin`,
  `set_fin`, `wrote` and datagram-only `pending_datagram`. For all of
  these, either datagram or stream has a "do nothing" method, rather
  than simply not having a method at all.  Now they simply don't have a
  method at all that they don't have any use for.
- datagram does not have a FIN flag, and trying to detect the stream FIN
  flag on datagrams is not right.  (Thankfully the stream FIN flag was
  2, and ngtcp2 doesn't appear to set that bit in the flags, currently).
- fix endpoint.hpp not including the "context.hpp" include that it
  actually requires to be able to construct an Endpoint.
- `available()` is replaced with `writable()` and `readable()` to be
  able to query each direction separately (which check for whether FIN
  is sent/queued/received).
- Avoid nasty (and pointless) bit-mutation-inside-a-parameter
- Removed `_is_shutdown` because it was always set to exactly the same
  value as `_is_closing`, and always checked alongside `_is_closing`, so
  served no purpose.