### PR TITLE
Initialize stream ID to -1; improve max stream data comment

### DIFF
--- a/include/oxen/quic/stream.hpp
+++ b/include/oxen/quic/stream.hpp
@@ -94,8 +94,8 @@ namespace oxen::quic
         ~Stream() override;
 
         bool is_stream() const override { return true; }
-        // Returns the stream ID of this stream, or -1 if an ID has not been assigned yet (i.e. for
-        // a pending stream).
+        // Returns the stream ID of this stream, or a negative value if an ID has not been assigned
+        // yet (i.e. for a pending stream).
         int64_t stream_id() const { return _stream_id; }
 
         const ConnectionID reference_id;
@@ -282,7 +282,7 @@ namespace oxen::quic
         bool _paused{false};
         bool _notify{false};
         bool _had_notify{false};
-        int64_t _stream_id{-1};
+        int64_t _stream_id{-2};
 
         size_t _paused_offset{0};
 

--- a/include/oxen/quic/stream.hpp
+++ b/include/oxen/quic/stream.hpp
@@ -94,6 +94,8 @@ namespace oxen::quic
         ~Stream() override;
 
         bool is_stream() const override { return true; }
+        // Returns the stream ID of this stream, or -1 if an ID has not been assigned yet (i.e. for
+        // a pending stream).
         int64_t stream_id() const { return _stream_id; }
 
         const ConnectionID reference_id;
@@ -280,7 +282,7 @@ namespace oxen::quic
         bool _paused{false};
         bool _notify{false};
         bool _had_notify{false};
-        int64_t _stream_id;
+        int64_t _stream_id{-1};
 
         size_t _paused_offset{0};
 

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -1765,7 +1765,10 @@ namespace oxen::quic
         params.initial_max_data = 15_Mi;
         // Max concurrent streams supported on one connection
         params.initial_max_streams_uni = 0;
-        // Max send buffer for streams (local = streams we initiate, remote = streams initiated to us)
+        // Max amount of data the remote is initially allowed to send on a stream (local = streams
+        // we initiate, remote = streams initiated to us).  Normally, i.e. when the stream is not
+        // paused, we immediately extend the stream window by however many bytes we receive as we
+        // receive stream data.
         params.initial_max_stream_data_bidi_local = 6_Mi;
         params.initial_max_stream_data_bidi_remote = 6_Mi;
         params.initial_max_stream_data_uni = 6_Mi;


### PR DESCRIPTION
Current stream_id is not initialized and so can be random large values depending on the memory it was initialized from.  This fixes it to initialize to -1 until a stream id is assigned so that 1) it has sane values, and 2) you can use it to tell whether a stream is pending.

Also clarifies comments about what stream limit values actually mean.